### PR TITLE
Add document viewer CLI with search and tests

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,66 @@
+import json
+import argparse
+from typing import List, Dict
+
+Document = Dict[str, str]
+
+
+def load_documents(path: str) -> List[Document]:
+    """Load documents from a JSON file.
+
+    The file should contain a list of objects with ``title``, ``citation`` and
+    ``content`` fields.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def filter_documents(
+    docs: List[Document],
+    citation: str | None = None,
+    title: str | None = None,
+    keyword: str | None = None,
+) -> List[Document]:
+    """Return documents matching the given filter."""
+    if citation:
+        return [d for d in docs if d.get("citation") == citation]
+    if title:
+        return [d for d in docs if d.get("title") == title]
+    if keyword:
+        kw = keyword.lower()
+        return [
+            d
+            for d in docs
+            if kw in d.get("title", "").lower()
+            or kw in d.get("content", "").lower()
+        ]
+    return docs
+
+
+def render_document(doc: Document) -> str:
+    """Format a document for terminal display."""
+    title = doc.get("title", "Untitled")
+    citation = doc.get("citation", "")
+    content = doc.get("content", "")
+    return f"{title} ({citation})\n{content}\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="View stored documents")
+    parser.add_argument("path", help="Path to JSON document file")
+    parser.add_argument("--citation", help="Select document by citation")
+    parser.add_argument("--title", help="Select document by title")
+    parser.add_argument("--search", help="Keyword to filter documents")
+    args = parser.parse_args()
+
+    docs = load_documents(args.path)
+    results = filter_documents(docs, args.citation, args.title, args.search)
+    if not results:
+        print("No documents found.")
+        return
+    for doc in results:
+        print(render_document(doc))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,48 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def make_sample_data(tmp_path: Path) -> Path:
+    data = [
+        {
+            "citation": "123 U.S. 456",
+            "title": "Example v. Sample",
+            "content": "This case discusses examples and samples.",
+        },
+        {
+            "citation": "789 U.S. 101",
+            "title": "Another v. Case",
+            "content": "Another case with different facts.",
+        },
+    ]
+    path = tmp_path / "data.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def run_cli(path: Path, *args: str) -> str:
+    cmd = ["python", "-m", "src.cli", str(path), *args]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return completed.stdout
+
+
+def test_search(tmp_path: Path):
+    data_path = make_sample_data(tmp_path)
+    out = run_cli(data_path, "--search", "examples")
+    assert "Example v. Sample" in out
+    assert "Another v. Case" not in out
+
+
+def test_select_by_citation(tmp_path: Path):
+    data_path = make_sample_data(tmp_path)
+    out = run_cli(data_path, "--citation", "789 U.S. 101")
+    assert "Another v. Case" in out
+    assert "Example v. Sample" not in out
+
+
+def test_select_by_title(tmp_path: Path):
+    data_path = make_sample_data(tmp_path)
+    out = run_cli(data_path, "--title", "Example v. Sample")
+    assert "123 U.S. 456" in out
+    assert "Another v. Case" not in out


### PR DESCRIPTION
## Summary
- add CLI utility to load JSON documents and render them in the terminal
- support filtering by citation, title, or keyword
- add tests demonstrating search and selection behavior

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d360f7948322826aa6e098b047a5