### PR TITLE
Add consent gate policy checks

### DIFF
--- a/src/ingestion/consent_gate.py
+++ b/src/ingestion/consent_gate.py
@@ -1,0 +1,33 @@
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+SENSITIVE_FLAGS = {"sacred", "restricted", "no_store", "no_share"}
+
+
+class ConsentError(Exception):
+    """Raised when cultural policy checks fail."""
+
+
+def check_consent(record: Dict[str, Any]) -> None:
+    """Evaluate cultural flags and consent before persisting a record.
+
+    If the record contains any cultural flags deemed sensitive, consent must be
+    explicitly granted via the ``consent`` field. A consent receipt is logged
+    on success, otherwise a :class:`ConsentError` is raised to block persistence
+    or transmission.
+    """
+
+    flags = set(record.get("cultural_flags", []))
+    if flags & SENSITIVE_FLAGS:
+        if not record.get("consent"):
+            logger.warning(
+                "Blocked record %s due to missing consent", record.get("metadata", {}).get("citation")
+            )
+            raise ConsentError("Consent required for records with cultural flags")
+        logger.info(
+            "Consent receipt for record %s: %s",
+            record.get("metadata", {}).get("citation"),
+            record.get("consent_receipt", "consent granted"),
+        )

--- a/src/ingestion/parser.py
+++ b/src/ingestion/parser.py
@@ -1,15 +1,31 @@
 """Utility functions for ingesting raw records into :class:`Document` objects."""
 
+import json
 from typing import Any, Dict
 
 from models.document import Document
+from .consent_gate import check_consent
 
 
 def emit_document(record: Dict[str, Any]) -> Document:
-    """Convert a raw record dictionary into a :class:`Document` instance."""
+    """Convert a raw record dictionary into a :class:`Document` instance.
+
+    The record is evaluated by the consent gate before being converted to a
+    :class:`Document`. If policy checks fail, a :class:`ConsentError` is
+    raised to block unauthorized persistence or transmission.
+    """
+
+    check_consent(record)
     return Document.from_dict(record)
 
 
 def emit_document_from_json(data: str) -> Document:
-    """Convert a JSON string into a :class:`Document` instance."""
-    return Document.from_json(data)
+    """Convert a JSON string into a :class:`Document` instance.
+
+    The JSON payload is decoded and passed through the consent gate before the
+    resulting record is converted to a :class:`Document`.
+    """
+
+    record = json.loads(data)
+    check_consent(record)
+    return Document.from_dict(record)

--- a/tests/ingestion/test_consent_gate.py
+++ b/tests/ingestion/test_consent_gate.py
@@ -1,0 +1,49 @@
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+from src.ingestion.parser import emit_document, emit_document_from_json
+from src.ingestion.consent_gate import ConsentError
+
+
+def sample_record(consent: bool = False):
+    record = {
+        "metadata": {
+            "jurisdiction": "US",
+            "citation": "123",
+            "date": "2020-01-01",
+        },
+        "body": "example body",
+        "cultural_flags": ["restricted"],
+    }
+    if consent:
+        record.update({"consent": True, "consent_receipt": "rcpt-001"})
+    return record
+
+
+def test_block_without_consent():
+    record = sample_record(consent=False)
+    with pytest.raises(ConsentError):
+        emit_document(record)
+
+
+def test_log_and_allow_with_consent(caplog):
+    record = sample_record(consent=True)
+    with caplog.at_level(logging.INFO):
+        doc = emit_document(record)
+    assert doc.body == "example body"
+    assert "Consent receipt" in caplog.text
+
+
+def test_from_json_enforces_policy():
+    record = sample_record(consent=False)
+    data = json.dumps(record)
+    with pytest.raises(ConsentError):
+        emit_document_from_json(data)


### PR DESCRIPTION
## Summary
- check ingestion records for cultural flags via consent gate
- log consent receipts and block unauthorized persistence
- add integration tests for consent gating

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898da6c5da88322ab1af00a90a6fba0