### PR TITLE
Add ontology tagging utilities and provision model

### DIFF
--- a/data/ontology/cco.json
+++ b/data/ontology/cco.json
@@ -1,0 +1,6 @@
+{
+  "customs": {
+    "trade_usage": ["trade", "usage"],
+    "business_practice": ["business", "practice"]
+  }
+}

--- a/data/ontology/lpo.json
+++ b/data/ontology/lpo.json
@@ -1,0 +1,7 @@
+{
+  "principles": {
+    "rule_of_law": ["law", "legal"],
+    "fairness": ["fair", "justice"],
+    "environmental_protection": ["environment", "pollution"]
+  }
+}

--- a/docs/ontology.md
+++ b/docs/ontology.md
@@ -1,0 +1,36 @@
+# Ontology Tagging
+
+The project includes a lightweight tagging utility that assigns legal
+principles and commercial customs to provisions extracted from documents.
+
+## Ontology Definitions
+
+Two simple ontologies are bundled as JSON files under `data/ontology`:
+
+- **lpo.json** – Legal Principles Ontology (LPO)
+- **cco.json** – Commercial Customs Ontology (CCO)
+
+Each ontology maps tag names to a list of keywords used for rule-based
+matching.
+
+## Tagging Provisions
+
+The function `ontology.tagger.tag_text` creates a :class:`~models.provision.Provision`
+from raw text and populates `principles` and `customs` lists based on the
+ontology keyword matches.  Existing `Provision` instances can be tagged with
+`ontology.tagger.tag_provision`.
+
+```python
+from ontology.tagger import tag_text
+
+prov = tag_text("Fair business practices protect the environment.")
+print(prov.principles)  # ['fairness', 'environmental_protection']
+print(prov.customs)     # ['business_practice']
+```
+
+## Ingestion Pipeline Integration
+
+During ingestion, `src.ingestion.parser.emit_document` applies the tagger to
+produce `Document` objects whose `provisions` field contains the tagged
+content.  Each document currently generates a single provision from its body
+text, but the approach can be extended to finer-grained parsing.

--- a/src/ingestion/parser.py
+++ b/src/ingestion/parser.py
@@ -2,14 +2,21 @@
 
 from typing import Any, Dict
 
-from models.document import Document
+from ..models.document import Document
+from ..ontology.tagger import tag_text
 
 
 def emit_document(record: Dict[str, Any]) -> Document:
-    """Convert a raw record dictionary into a :class:`Document` instance."""
-    return Document.from_dict(record)
+    """Convert a raw record dictionary into a tagged :class:`Document` instance."""
+    doc = Document.from_dict(record)
+    if not doc.provisions:
+        doc.provisions = [tag_text(doc.body)]
+    return doc
 
 
 def emit_document_from_json(data: str) -> Document:
-    """Convert a JSON string into a :class:`Document` instance."""
-    return Document.from_json(data)
+    """Convert a JSON string into a tagged :class:`Document` instance."""
+    doc = Document.from_json(data)
+    if not doc.provisions:
+        doc.provisions = [tag_text(doc.body)]
+    return doc

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,6 @@
+"""Model classes used throughout the project."""
+
+from .document import Document, DocumentMetadata
+from .provision import Provision
+
+__all__ = ["Document", "DocumentMetadata", "Provision"]

--- a/src/models/document.py
+++ b/src/models/document.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from datetime import date, datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 import json
+
+from .provision import Provision
 
 
 @dataclass
@@ -46,14 +48,20 @@ class DocumentMetadata:
 
 @dataclass
 class Document:
-    """Representation of a legal document including metadata and body text."""
+    """Representation of a legal document including metadata, body text,
+    and any extracted provisions."""
 
     metadata: DocumentMetadata
     body: str
+    provisions: List[Provision] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize the document to a dictionary."""
-        return {"metadata": self.metadata.to_dict(), "body": self.body}
+        return {
+            "metadata": self.metadata.to_dict(),
+            "body": self.body,
+            "provisions": [p.to_dict() for p in self.provisions],
+        }
 
     def to_json(self) -> str:
         """Serialize the document to a JSON string."""
@@ -63,7 +71,8 @@ class Document:
     def from_dict(cls, data: Dict[str, Any]) -> "Document":
         """Deserialize a document from a dictionary."""
         metadata = DocumentMetadata.from_dict(data["metadata"])
-        return cls(metadata=metadata, body=data["body"])
+        provisions = [Provision.from_dict(p) for p in data.get("provisions", [])]
+        return cls(metadata=metadata, body=data["body"], provisions=provisions)
 
     @classmethod
     def from_json(cls, data: str) -> "Document":

--- a/src/models/provision.py
+++ b/src/models/provision.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class Provision:
+    """A discrete provision within a legal document."""
+
+    text: str
+    principles: List[str] = field(default_factory=list)
+    customs: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the provision to a dictionary."""
+        return {
+            "text": self.text,
+            "principles": list(self.principles),
+            "customs": list(self.customs),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Provision":
+        """Deserialize a provision from a dictionary."""
+        return cls(
+            text=data["text"],
+            principles=list(data.get("principles", [])),
+            customs=list(data.get("customs", [])),
+        )

--- a/src/ontology/tagger.py
+++ b/src/ontology/tagger.py
@@ -1,0 +1,55 @@
+"""Utilities for tagging provisions with ontology-based labels."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from ..models.provision import Provision
+
+# Directory where ontology JSON files are stored.
+ONTOLOGY_DIR = Path(__file__).resolve().parents[2] / "data" / "ontology"
+
+
+def _load_ontology(filename: str) -> Dict[str, Dict[str, List[str]]]:
+    """Load an ontology definition from a JSON file.
+
+    The JSON file is expected to map tag names to a list of keywords.  The
+    function returns the parsed dictionary or an empty mapping if the file is
+    missing.
+    """
+    path = ONTOLOGY_DIR / filename
+    if not path.exists():
+        return {}
+    with path.open() as f:
+        return json.load(f)
+
+
+# Load ontologies at module import time.  These serve as simple rule bases
+# for the tagging process.  A real implementation could replace this with an
+# ML model or more sophisticated pipeline.
+LPO = _load_ontology("lpo.json").get("principles", {})
+CCO = _load_ontology("cco.json").get("customs", {})
+
+
+def _match_terms(text: str, mapping: Dict[str, List[str]]) -> List[str]:
+    """Return tags whose associated keywords appear in the text."""
+    lower = text.lower()
+    return [tag for tag, kws in mapping.items() if any(kw.lower() in lower for kw in kws)]
+
+
+def tag_provision(provision: Provision) -> Provision:
+    """Assign principle and custom tags to a provision.
+
+    The function mutates the provided :class:`Provision` instance and also
+    returns it for convenience.
+    """
+    provision.principles = _match_terms(provision.text, LPO)
+    provision.customs = _match_terms(provision.text, CCO)
+    return provision
+
+
+def tag_text(text: str) -> Provision:
+    """Create and tag a provision directly from raw text."""
+    return tag_provision(Provision(text=text))


### PR DESCRIPTION
## Summary
- implement rule-based ontology tagger for provisions
- extend documents with provisions and integrate tagging into ingestion
- document ontology usage and add sample LPO/CCO definitions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898da456e2c8322a262dd826a9c6b87