### PR TITLE
Add initial legal corpus and schema support

### DIFF
--- a/data/corpus/commonwealth_constitution.json
+++ b/data/corpus/commonwealth_constitution.json
@@ -1,0 +1,12 @@
+{
+  "metadata": {
+    "jurisdiction": "Commonwealth of Australia",
+    "citation": "Australian Constitution",
+    "date": "1901-01-01",
+    "court": null,
+    "lpo_tags": ["constitutional"],
+    "cco_tags": ["governance"],
+    "cultural_flags": ["foundational"]
+  },
+  "body": "Preamble: Whereas the people of New South Wales, Victoria, South Australia, Queensland, and Tasmania, humbly relying on the blessing of Almighty God, have agreed to unite in one indissoluble Federal Commonwealth under the Crown of the United Kingdom of Great Britain and Ireland, and under the Constitution hereby established.\nSection 1: The legislative power of the Commonwealth shall be vested in a Federal Parliament, which shall consist of the Queen, a Senate, and a House of Representatives."
+}

--- a/data/corpus/epbc_act.json
+++ b/data/corpus/epbc_act.json
@@ -1,0 +1,12 @@
+{
+  "metadata": {
+    "jurisdiction": "Commonwealth of Australia",
+    "citation": "Environment Protection and Biodiversity Conservation Act 1999 (Cth)",
+    "date": "1999-07-16",
+    "court": null,
+    "lpo_tags": ["environment"],
+    "cco_tags": ["biodiversity"],
+    "cultural_flags": ["environment"]
+  },
+  "body": "Section 3: The objects of this Act are: (a) to provide for the protection of the environment, especially those aspects of the environment that are matters of national environmental significance; (b) to promote ecologically sustainable development; and (c) to conserve biodiversity."
+}

--- a/data/corpus/native_title_act_core.json
+++ b/data/corpus/native_title_act_core.json
@@ -1,0 +1,12 @@
+{
+  "metadata": {
+    "jurisdiction": "Commonwealth of Australia",
+    "citation": "Native Title Act 1993 (Cth)",
+    "date": "1993-12-24",
+    "court": null,
+    "lpo_tags": ["native-title"],
+    "cco_tags": ["indigenous-rights"],
+    "cultural_flags": ["First Nations"]
+  },
+  "body": "Preamble: An Act to provide for the recognition and protection of native title and for its co-existence with the national land management system, and for related purposes.\nSection 3: The objects of this Act are: (a) to provide for the recognition and protection of native title; (b) to establish ways in which future dealings affecting native title may proceed and to set standards for those dealings; and (c) to establish a mechanism for determining claims to native title."
+}

--- a/data/corpus/queensland_constitution.json
+++ b/data/corpus/queensland_constitution.json
@@ -1,0 +1,12 @@
+{
+  "metadata": {
+    "jurisdiction": "Queensland",
+    "citation": "Constitution of Queensland 2001 (Qld)",
+    "date": "2001-06-06",
+    "court": null,
+    "lpo_tags": ["state-constitution"],
+    "cco_tags": ["governance"],
+    "cultural_flags": ["Queensland"]
+  },
+  "body": "Preamble: The people of Queensland, free and equal citizens of Australia, adopt this Constitution for the good government of Queensland.\nSection 2: The Parliament of Queensland consists of the Queen and the Legislative Assembly."
+}

--- a/docs/corpus_setup.md
+++ b/docs/corpus_setup.md
@@ -1,0 +1,35 @@
+# Corpus Setup
+
+This document outlines how to expand the legal corpus using the `Document` schema.
+
+## Adding new documents
+1. Obtain authoritative text from official repositories.
+2. Create metadata and body using the `Document` model:
+
+```python
+from datetime import date
+from src.models.document import Document, DocumentMetadata
+
+metadata = DocumentMetadata(
+    jurisdiction="Example State",
+    citation="Example Act 2024 (Ex)",
+    date=date(2024, 1, 1),
+    lpo_tags=["example"],
+    cco_tags=["demo"],
+    cultural_flags=["test"]
+)
+doc = Document(metadata=metadata, body="Full text here")
+with open("data/corpus/example_act.json", "w") as f:
+    f.write(doc.to_json())
+```
+
+3. Store the resulting JSON file under `data/corpus/` using a descriptive name.
+4. Ensure minimal LPO/CCO tags and cultural flags are included for cultural context.
+5. Run `pytest` to verify integrity.
+
+## Directory structure
+- `data/corpus/` – JSON documents in the schema.
+
+## Future expansion
+For bulk additions, consider writing helper scripts that pull texts from official APIs,
+convert them using the model above, and save them into the corpus directory.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -11,6 +11,9 @@ structure and the document body text.
 - **citation** (`str`): Formal citation or identifier for the document.
 - **date** (`date`): Date the document was issued, in ISO format (`YYYY-MM-DD`).
 - **court** (`Optional[str]`): Court or body that issued the document.
+- **lpo_tags** (`Optional[List[str]]`): Legal policy objective tags.
+- **cco_tags** (`Optional[List[str]]`): Cross-cultural obligation tags.
+- **cultural_flags** (`Optional[List[str]]`): Cultural sensitivity flags.
 
 ### Document
 - **metadata** (`DocumentMetadata`): Metadata associated with the document.
@@ -26,7 +29,10 @@ structure and the document body text.
     "jurisdiction": "US",
     "citation": "410 U.S. 113",
     "date": "1973-01-22",
-    "court": "Supreme Court"
+    "court": "Supreme Court",
+    "lpo_tags": ["example"],
+    "cco_tags": ["demo"],
+    "cultural_flags": ["public-domain"]
   },
   "body": "Full text of the opinion..."
 }

--- a/src/models/document.py
+++ b/src/models/document.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, asdict
 from datetime import date, datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 import json
 
 
@@ -15,12 +15,18 @@ class DocumentMetadata:
         citation: Formal citation or identifier for the document.
         date: Date the document was issued.
         court: Optional court or body issuing the document.
+        lpo_tags: Optional list of Legal Policy Objective tags.
+        cco_tags: Optional list of cross-cultural obligation tags.
+        cultural_flags: Optional list of cultural sensitivity flags.
     """
 
     jurisdiction: str
     citation: str
     date: date
     court: Optional[str] = None
+    lpo_tags: Optional[List[str]] = None
+    cco_tags: Optional[List[str]] = None
+    cultural_flags: Optional[List[str]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize metadata to a dictionary."""
@@ -41,6 +47,9 @@ class DocumentMetadata:
             citation=data["citation"],
             date=parsed_date,
             court=data.get("court"),
+            lpo_tags=data.get("lpo_tags"),
+            cco_tags=data.get("cco_tags"),
+            cultural_flags=data.get("cultural_flags"),
         )
 
 


### PR DESCRIPTION
## Summary
- extend `DocumentMetadata` with LPO/CCO tags and cultural flags
- seed corpus with constitution, native title, state and environment acts in new schema
- document corpus setup and future expansion steps

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898da79714c8322b9c1aec0cefcd88b