### PR TITLE
feat: add ontology tagging and jurisdiction codes

### DIFF
--- a/data/ontology/environment.json
+++ b/data/ontology/environment.json
@@ -1,0 +1,6 @@
+{
+  "taxonomy": {
+    "conservation": ["environmental", "biodiversity"],
+    "climate_change": ["climate", "emissions"]
+  }
+}

--- a/src/models/document.py
+++ b/src/models/document.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass, asdict, field
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional
-
-from typing import Any, Dict, Optional, List
 import json
 
 from .provision import Provision
@@ -22,6 +20,8 @@ class DocumentMetadata:
         lpo_tags: Optional list of Legal Policy Objective tags.
         cco_tags: Optional list of cross-cultural obligation tags.
         cultural_flags: Optional list of cultural sensitivity flags.
+        jurisdiction_codes: Optional list of standardized jurisdiction codes.
+        ontology_tags: Mapping of ontology names to matched tags.
     """
 
     jurisdiction: str
@@ -31,6 +31,8 @@ class DocumentMetadata:
     lpo_tags: Optional[List[str]] = None
     cco_tags: Optional[List[str]] = None
     cultural_flags: Optional[List[str]] = None
+    jurisdiction_codes: List[str] = field(default_factory=list)
+    ontology_tags: Dict[str, List[str]] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize metadata to a dictionary."""
@@ -54,6 +56,8 @@ class DocumentMetadata:
             lpo_tags=data.get("lpo_tags"),
             cco_tags=data.get("cco_tags"),
             cultural_flags=data.get("cultural_flags"),
+            jurisdiction_codes=list(data.get("jurisdiction_codes", [])),
+            ontology_tags=dict(data.get("ontology_tags", {})),
         )
 
 

--- a/src/ontology/tagger.py
+++ b/src/ontology/tagger.py
@@ -1,4 +1,4 @@
-"""Utilities for tagging provisions with ontology-based labels."""
+"""Utilities for tagging text with ontology-based labels."""
 
 from __future__ import annotations
 
@@ -6,31 +6,32 @@ import json
 from pathlib import Path
 from typing import Dict, List
 
-from ..models.provision import Provision
-
 # Directory where ontology JSON files are stored.
 ONTOLOGY_DIR = Path(__file__).resolve().parents[2] / "data" / "ontology"
 
 
-def _load_ontology(filename: str) -> Dict[str, Dict[str, List[str]]]:
-    """Load an ontology definition from a JSON file.
+def _load_ontology(path: Path) -> Dict[str, List[str]]:
+    """Load and normalise an ontology definition.
 
-    The JSON file is expected to map tag names to a list of keywords.  The
-    function returns the parsed dictionary or an empty mapping if the file is
-    missing.
+    Each ontology file is a JSON mapping of ontology names to a mapping of tag
+    names and their associated keywords. The file may wrap the mapping in a
+    single top-level key which is unwrapped for convenience.
     """
-    path = ONTOLOGY_DIR / filename
-    if not path.exists():
-        return {}
     with path.open() as f:
-        return json.load(f)
+        data = json.load(f)
+    # Unwrap a single top-level key if present
+    if isinstance(data, dict) and len(data) == 1:
+        data = next(iter(data.values()))
+    return data
 
 
-# Load ontologies at module import time.  These serve as simple rule bases
-# for the tagging process.  A real implementation could replace this with an
-# ML model or more sophisticated pipeline.
-LPO = _load_ontology("lpo.json").get("principles", {})
-CCO = _load_ontology("cco.json").get("customs", {})
+# Load all ontology definitions at import time.
+ONTOLOGIES: Dict[str, Dict[str, List[str]]] = {}
+for file in ONTOLOGY_DIR.glob("*.json"):
+    try:
+        ONTOLOGIES[file.stem] = _load_ontology(file)
+    except Exception:
+        ONTOLOGIES[file.stem] = {}
 
 
 def _match_terms(text: str, mapping: Dict[str, List[str]]) -> List[str]:
@@ -39,17 +40,22 @@ def _match_terms(text: str, mapping: Dict[str, List[str]]) -> List[str]:
     return [tag for tag, kws in mapping.items() if any(kw.lower() in lower for kw in kws)]
 
 
-def tag_provision(provision: Provision) -> Provision:
-    """Assign principle and custom tags to a provision.
+def tag_text(text: str) -> Dict[str, List[str]]:
+    """Tag the provided text with all loaded ontologies.
 
-    The function mutates the provided :class:`Provision` instance and also
-    returns it for convenience.
+    Parameters
+    ----------
+    text:
+        The text to analyse.
+
+    Returns
+    -------
+    Dict[str, List[str]]
+        Mapping of ontology name to the list of matching tags.
     """
-    provision.principles = _match_terms(provision.text, LPO)
-    provision.customs = _match_terms(provision.text, CCO)
-    return provision
-
-
-def tag_text(text: str) -> Provision:
-    """Create and tag a provision directly from raw text."""
-    return tag_provision(Provision(text=text))
+    tags: Dict[str, List[str]] = {}
+    for name, mapping in ONTOLOGIES.items():
+        matched = _match_terms(text, mapping)
+        if matched:
+            tags[name] = matched
+    return tags

--- a/tests/ingestion/test_tagging.py
+++ b/tests/ingestion/test_tagging.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+from src.ingestion.parser import emit_document
+
+
+def test_australian_tagging():
+    record = {
+        "metadata": {
+            "jurisdiction": "Australia",
+            "citation": "ABC123",
+            "date": "2023-01-01",
+        },
+        "body": "The law promotes fair treatment and environmental protection.",
+    }
+    doc = emit_document(record)
+    assert "AU" in doc.metadata.jurisdiction_codes
+    tags = doc.metadata.ontology_tags
+    assert "lpo" in tags and "fairness" in tags["lpo"]
+    assert "environment" in tags and "conservation" in tags["environment"]


### PR DESCRIPTION
## Summary
- add environmental ontology taxonomy
- implement generic ontology tagger and extend document metadata with jurisdiction codes
- tag ingested documents and test Australian tagging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898dda1fb088322abf1ab936d337719