### PR TITLE
Expand rule reasoning for 'shall not' modality

### DIFF
--- a/src/rules/extractor.py
+++ b/src/rules/extractor.py
@@ -5,8 +5,14 @@ from typing import List
 
 from . import Rule
 
+# Include the most common English legal modalities.  The pattern is fairly
+# permissive – it captures everything before the modality as the ``actor`` and
+# the remainder as the ``rest`` of the sentence which we later split into the
+# ``action`` and optional ``conditions``/``scope``.  Support for ``shall not``
+# was added to cover provisions expressed using the more formal "shall"
+# language often found in legislation.
 _PATTERN = re.compile(
-    r"(?P<actor>.+?)\s+(?P<modality>must not|may not|must|shall|may)\s+(?P<rest>.+)",
+    r"(?P<actor>.+?)\s+(?P<modality>must not|may not|shall not|must|shall|may)\s+(?P<rest>.+)",
     re.IGNORECASE,
 )
 

--- a/tests/rules/test_rules.py
+++ b/tests/rules/test_rules.py
@@ -37,3 +37,11 @@ def test_cli_extract_and_check():
     out2 = run_cli("check", "--rules", json.dumps(rules))
     issues = json.loads(out2)
     assert any("Contradiction" in i for i in issues)
+
+
+def test_shall_not_detection():
+    text = "The driver shall not park here. The driver shall park here."
+    rules = extract_rules(text)
+    assert len(rules) == 2
+    issues = check_rules(rules)
+    assert any("Contradiction" in i for i in issues)


### PR DESCRIPTION
## Summary
- handle `shall not` modality in rule extraction
- normalise modalities in rule reasoning for better contradiction checks
- test extraction and reasoning for `shall not`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e00d39dc832281a50c81f9e6bf72