### PR TITLE
Use pdfminer for PDF ingestion

### DIFF
--- a/src/pdf_ingest.py
+++ b/src/pdf_ingest.py
@@ -3,18 +3,36 @@ import json
 import re
 from pathlib import Path
 
-import pdfplumber
+from pdfminer.high_level import extract_pages
+from pdfminer.layout import LTTextContainer
 
 
 def extract_pdf_text(pdf_path: Path):
-    """Extract text from a PDF, returning list of pages with numbers."""
+    """Extract normalized text from a PDF, keeping page numbers and headings."""
     pages = []
-    with pdfplumber.open(pdf_path) as pdf:
-        for i, page in enumerate(pdf.pages, start=1):
-            text = page.extract_text() or ""
-            text = re.sub(r"\s+", " ", text).strip()
-            pages.append({"page": i, "text": text})
+    for page_num, page_layout in enumerate(extract_pages(pdf_path), start=1):
+        text_chunks = []
+        for element in page_layout:
+            if isinstance(element, LTTextContainer):
+                text_chunks.append(element.get_text())
+        raw_text = "".join(text_chunks)
+        lines = [
+            re.sub(r"\s+", " ", line).strip()
+            for line in raw_text.splitlines()
+            if line.strip()
+        ]
+        normalized = "\n".join(lines)
+        pages.append({"page": page_num, "text": normalized})
     return pages
+
+
+def build_metadata(pdf_path: Path, pages):
+    """Create metadata wrapper for extracted pages."""
+    return {
+        "source": pdf_path.name,
+        "page_count": len(pages),
+        "pages": pages,
+    }
 
 
 def save_json(data, output_path: Path):
@@ -24,14 +42,17 @@ def save_json(data, output_path: Path):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Extract text from a PDF and save as JSON")
+    parser = argparse.ArgumentParser(
+        description="Extract text from a PDF and save as JSON"
+    )
     parser.add_argument("pdf", type=Path, help="Path to PDF file")
     parser.add_argument("-o", "--output", type=Path, help="Output JSON path")
     args = parser.parse_args()
 
-    output = args.output or Path("data/pdfs") / (args.pdf.stem + ".json")
     pages = extract_pdf_text(args.pdf)
-    save_json(pages, output)
+    data = build_metadata(args.pdf, pages)
+    output = args.output or Path("data/pdfs") / (args.pdf.stem + ".json")
+    save_json(data, output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace pdfplumber with pdfminer.six for page-by-page text extraction
- Normalize whitespace while preserving headings and page numbers
- Output JSON with basic metadata under data/pdfs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e2614fb483228894f58bb7e96f81