### PR TITLE
feat: add document schema and update ingestion

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -14,10 +14,13 @@ structure and the document body text.
 - **lpo_tags** (`Optional[List[str]]`): Legal policy objective tags.
 - **cco_tags** (`Optional[List[str]]`): Cross-cultural obligation tags.
 - **cultural_flags** (`Optional[List[str]]`): Cultural sensitivity flags.
+- **jurisdiction_codes** (`List[str]`): Standardised jurisdiction codes.
+- **ontology_tags** (`Dict[str, List[str]]`): Tags matched from configured ontologies.
 
 ### Document
 - **metadata** (`DocumentMetadata`): Metadata associated with the document.
 - **body** (`str`): Full body text of the document.
+- **provisions** (`List[Provision]`): Extracted provisions within the document.
 
 ## JSON Representation
 
@@ -32,9 +35,12 @@ structure and the document body text.
     "court": "Supreme Court",
     "lpo_tags": ["example"],
     "cco_tags": ["demo"],
-    "cultural_flags": ["public-domain"]
+    "cultural_flags": ["public-domain"],
+    "jurisdiction_codes": ["US"],
+    "ontology_tags": {"lpo": ["example"], "cco": ["demo"]}
   },
-  "body": "Full text of the opinion..."
+  "body": "Full text of the opinion...",
+  "provisions": []
 }
 ```
 

--- a/src/ingestion/parser.py
+++ b/src/ingestion/parser.py
@@ -46,4 +46,8 @@ def emit_document(record: Dict[str, Any]) -> Document:
 def emit_document_from_json(data: str) -> Document:
     """Convert a JSON string into a tagged :class:`Document` instance."""
     record = json.loads(data)
-    return emit_document(record)
+    check_consent(record)
+    doc = Document.from_json(data)
+    _apply_tags(doc)
+    _apply_jurisdiction_codes(doc)
+    return doc

--- a/src/models/document.py
+++ b/src/models/document.py
@@ -80,7 +80,7 @@ class Document:
 
     def to_json(self) -> str:
         """Serialize the document to a JSON string."""
-        return json.dumps(self.to_dict())
+        return json.dumps(self.to_dict(), ensure_ascii=False)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Document":
@@ -93,3 +93,6 @@ class Document:
     def from_json(cls, data: str) -> "Document":
         """Deserialize a document from a JSON string."""
         return cls.from_dict(json.loads(data))
+
+
+__all__ = ["Document", "DocumentMetadata"]


### PR DESCRIPTION
## Summary
- define Document and DocumentMetadata dataclasses for legal documents
- emit Document instances from ingestion parser and apply tagging and jurisdiction codes
- document available fields and JSON structure in docs/schema.md

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898e26a121483229aed7839b2476731