### PR TITLE
Add sample corpus documents and generation script

### DIFF
--- a/data/corpus/mabo_v_queensland_no2.json
+++ b/data/corpus/mabo_v_queensland_no2.json
@@ -1,0 +1,12 @@
+{
+  "metadata": {
+    "jurisdiction": "High Court of Australia",
+    "citation": "Mabo v Queensland (No 2) [1992] HCA 23",
+    "date": "1992-06-03",
+    "court": "High Court of Australia",
+    "lpo_tags": ["indigenous_rights"],
+    "cco_tags": ["land_rights"],
+    "cultural_flags": ["historic"]
+  },
+  "body": "The High Court recognised native title in Australia and rejected the doctrine of terra nullius."
+}

--- a/data/corpus/privacy_act.json
+++ b/data/corpus/privacy_act.json
@@ -1,0 +1,12 @@
+{
+  "metadata": {
+    "jurisdiction": "Commonwealth of Australia",
+    "citation": "Privacy Act 1988",
+    "date": "1988-12-09",
+    "court": null,
+    "lpo_tags": ["privacy"],
+    "cco_tags": ["data_protection"],
+    "cultural_flags": ["modern"]
+  },
+  "body": "Section 1: An Act to protect the privacy of individuals and regulate the collection of personal information by government agencies."
+}

--- a/docs/corpus_setup.md
+++ b/docs/corpus_setup.md
@@ -27,6 +27,17 @@ with open("data/corpus/example_act.json", "w") as f:
 4. Ensure minimal LPO/CCO tags and cultural flags are included for cultural context.
 5. Run `pytest` to verify integrity.
 
+### Sample generation script
+
+A helper script is provided to create example Act and judgment files. Run:
+
+```bash
+python scripts/generate_sample_corpus.py
+```
+
+This writes `sample_act.json` and `sample_judgment.json` into `data/corpus/`,
+demonstrating the required metadata fields.
+
 ## Directory structure
 - `data/corpus/` – JSON documents in the schema.
 

--- a/scripts/generate_sample_corpus.py
+++ b/scripts/generate_sample_corpus.py
@@ -1,0 +1,46 @@
+"""Generate sample act and judgment documents in data/corpus/.
+
+This helper script illustrates how to use the Document model to
+produce JSON files that comply with the project schema.
+"""
+
+from datetime import date
+from src.models.document import Document, DocumentMetadata
+
+
+def create_sample_act() -> None:
+    metadata = DocumentMetadata(
+        jurisdiction="Sample State",
+        citation="Sample Act 2024",
+        date=date(2024, 1, 1),
+        lpo_tags=["sample"],
+        cco_tags=["demo"],
+        cultural_flags=["test"],
+    )
+    doc = Document(metadata=metadata, body="Section 1: Sample act text.")
+    with open("data/corpus/sample_act.json", "w") as f:
+        f.write(doc.to_json())
+
+
+def create_sample_judgment() -> None:
+    metadata = DocumentMetadata(
+        jurisdiction="Sample Jurisdiction",
+        citation="Sample v Example [2024] EX 1",
+        date=date(2024, 1, 1),
+        court="Sample Court",
+        lpo_tags=["sample"],
+        cco_tags=["demo"],
+        cultural_flags=["test"],
+    )
+    doc = Document(
+        metadata=metadata,
+        body="The court held sample principles in this illustrative judgment.",
+    )
+    with open("data/corpus/sample_judgment.json", "w") as f:
+        f.write(doc.to_json())
+
+
+if __name__ == "__main__":
+    create_sample_act()
+    create_sample_judgment()
+    print("Sample documents written to data/corpus/.")


### PR DESCRIPTION
## Summary
- add sample Privacy Act and Mabo judgment JSON files with basic metadata, LPO/CCO tags and cultural flags
- provide script for generating example documents in the corpus
- document corpus seeding steps and script usage in `docs/corpus_setup.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898e295cde88322bebc317a008b2a9a