### PR TITLE
Add provenance metadata and time-travel retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # SensibLaw
 Like coleslaw, it just makes sense.
+
+## CLI
+
+Retrieve a document revision as it existed on a given date:
+
+```bash
+sensiblaw get --id 1 --as-at 2023-01-01
+```
+
+See [docs/versioning.md](docs/versioning.md) for details on the versioned
+storage layer and available provenance metadata.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -11,6 +11,13 @@ queries.
 - `revisions` – holds each revision with its effective date, metadata and body.
 - `revisions_fts` – FTS5 index over revision text and metadata for search.
 
+Each revision also records provenance fields:
+
+- `source_url` – where the document was downloaded from.
+- `retrieved_at` – timestamp when it was fetched.
+- `checksum` – optional hash of the retrieved content.
+- `licence` – the licence governing the text.
+
 ## Snapshots
 
 Use the `snapshot(doc_id, as_at)` method to retrieve the version of a document
@@ -19,6 +26,9 @@ in effect on a given date.  The CLI exposes this via:
 ```bash
 sensiblaw get --id 1 --as-at 2023-01-01
 ```
+
+The returned JSON includes the provenance metadata captured for the selected
+revision.
 
 ## Diffs
 

--- a/src/models/document.py
+++ b/src/models/document.py
@@ -22,6 +22,10 @@ class DocumentMetadata:
         cultural_flags: Optional list of cultural sensitivity flags.
         jurisdiction_codes: Optional list of standardized jurisdiction codes.
         ontology_tags: Mapping of ontology names to matched tags.
+        source_url: URL from which the document was retrieved.
+        retrieved_at: Timestamp when the document was fetched.
+        checksum: Optional checksum of the document contents.
+        licence: Licence under which the document text is distributed.
     """
 
     jurisdiction: str
@@ -33,11 +37,17 @@ class DocumentMetadata:
     cultural_flags: Optional[List[str]] = None
     jurisdiction_codes: List[str] = field(default_factory=list)
     ontology_tags: Dict[str, List[str]] = field(default_factory=dict)
+    source_url: Optional[str] = None
+    retrieved_at: Optional[datetime] = None
+    checksum: Optional[str] = None
+    licence: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize metadata to a dictionary."""
         data = asdict(self)
         data["date"] = self.date.isoformat()
+        if self.retrieved_at:
+            data["retrieved_at"] = self.retrieved_at.isoformat()
         return data
 
     @classmethod
@@ -48,6 +58,10 @@ class DocumentMetadata:
             if isinstance(data["date"], date)
             else datetime.fromisoformat(data["date"]).date()
         )
+        retrieved = data.get("retrieved_at")
+        if retrieved and not isinstance(retrieved, datetime):
+            retrieved = datetime.fromisoformat(retrieved)
+
         return cls(
             jurisdiction=data["jurisdiction"],
             citation=data["citation"],
@@ -58,6 +72,10 @@ class DocumentMetadata:
             cultural_flags=data.get("cultural_flags"),
             jurisdiction_codes=list(data.get("jurisdiction_codes", [])),
             ontology_tags=dict(data.get("ontology_tags", {})),
+            source_url=data.get("source_url"),
+            retrieved_at=retrieved,
+            checksum=data.get("checksum"),
+            licence=data.get("licence"),
         )
 
 

--- a/tests/test_versioned_store.py
+++ b/tests/test_versioned_store.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 import sys
 
@@ -12,7 +12,15 @@ def make_store(tmp_path: Path) -> tuple[VersionedStore, int]:
     db_path = tmp_path / "store.db"
     store = VersionedStore(str(db_path))
     doc_id = store.generate_id()
-    meta = DocumentMetadata(jurisdiction="US", citation="123", date=date(2020, 1, 1))
+    meta = DocumentMetadata(
+        jurisdiction="US",
+        citation="123",
+        date=date(2020, 1, 1),
+        source_url="http://example.com",
+        retrieved_at=datetime(2020, 1, 2, 3, 4, 5),
+        checksum="abc123",
+        licence="CC-BY",
+    )
     store.add_revision(doc_id, Document(meta, "first"), date(2020, 1, 1))
     store.add_revision(doc_id, Document(meta, "second"), date(2021, 1, 1))
     return store, doc_id
@@ -33,4 +41,16 @@ def test_diff(tmp_path: Path):
     diff = store.diff(doc_id, 1, 2)
     assert "-first" in diff
     assert "+second" in diff
+    store.close()
+
+
+def test_provenance_metadata(tmp_path: Path):
+    store, doc_id = make_store(tmp_path)
+    snap = store.snapshot(doc_id, date(2022, 1, 1))
+    assert snap is not None
+    meta = snap.metadata
+    assert meta.source_url == "http://example.com"
+    assert meta.retrieved_at == datetime(2020, 1, 2, 3, 4, 5)
+    assert meta.checksum == "abc123"
+    assert meta.licence == "CC-BY"
     store.close()


### PR DESCRIPTION
## Summary
- capture provenance fields (source URL, retrieval time, checksum, licence) in document metadata
- store provenance in SQLite revisions table and expose via CLI
- document `sensiblaw get --as-at` workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e29b73ac8322b1b0243b2f999a40