### PR TITLE
Add PDF rule extraction pipeline and CLI hook

### DIFF
--- a/src/pdf_ingest.py
+++ b/src/pdf_ingest.py
@@ -1,17 +1,37 @@
+"""PDF ingestion utilities producing :class:`Document` objects."""
+
 import argparse
 import json
 import re
+from datetime import date
 from pathlib import Path
+from typing import List, Optional
 
 from pdfminer.high_level import extract_text
 
+from .models.document import Document, DocumentMetadata, Provision
+from .rules.extractor import extract_rules
 
-def extract_pdf_text(pdf_path: Path):
+# ``section_parser`` is optional – tests may monkeypatch it.  If it's not
+# available, a trivial fallback is used which treats the entire body as a single
+# provision.
+try:  # pragma: no cover - executed conditionally
+    from . import section_parser  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    section_parser = None  # type: ignore
+
+
+def extract_pdf_text(pdf_path: Path) -> List[dict]:
     """Extract text and headings from a PDF, returning pages with numbers."""
+
     raw = extract_text(str(pdf_path)) or ""
     pages = []
     for i, page_text in enumerate(raw.split("\f"), start=1):
-        lines = [re.sub(r"\s+", " ", line).strip() for line in page_text.splitlines() if line.strip()]
+        lines = [
+            re.sub(r"\s+", " ", line).strip()
+            for line in page_text.splitlines()
+            if line.strip()
+        ]
         if not lines:
             continue
         heading = lines[0]
@@ -20,7 +40,9 @@ def extract_pdf_text(pdf_path: Path):
     return pages
 
 
-def save_json(pages, output_path: Path, source: Path):
+def save_json(pages: List[dict], output_path: Path, source: Path) -> None:
+    """Legacy helper to save extracted pages as JSON."""
+
     output_path.parent.mkdir(parents=True, exist_ok=True)
     data = {
         "source": str(source),
@@ -31,16 +53,97 @@ def save_json(pages, output_path: Path, source: Path):
         json.dump(data, f, ensure_ascii=False, indent=2)
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Extract text from a PDF and save as JSON")
+def _rules_to_strings(rules) -> List[str]:
+    texts: List[str] = []
+    for r in rules:
+        t = f"{r.actor} {r.modality} {r.action}".strip()
+        if r.conditions:
+            t += f" {r.conditions}"
+        if r.scope:
+            t += f" {r.scope}"
+        texts.append(t.strip())
+    return texts
+
+
+def build_document(
+    pages: List[dict],
+    source: Path,
+    jurisdiction: Optional[str] = None,
+    citation: Optional[str] = None,
+    cultural_flags: Optional[List[str]] = None,
+) -> Document:
+    """Create a :class:`Document` from extracted pages."""
+
+    body = "\n\n".join(f"{p['heading']}\n{p['text']}".strip() for p in pages)
+    metadata = DocumentMetadata(
+        jurisdiction=jurisdiction or "",
+        citation=citation or "",
+        date=date.today(),
+        cultural_flags=cultural_flags,
+        provenance=str(source),
+    )
+
+    if section_parser and hasattr(section_parser, "parse_sections"):
+        provisions = section_parser.parse_sections(body)  # type: ignore[attr-defined]
+    else:  # Fallback: single provision containing entire body
+        provisions = [Provision(text=body)]
+
+    for prov in provisions:
+        rules = extract_rules(prov.text)
+        prov.principles.extend(_rules_to_strings(rules))
+
+    return Document(metadata=metadata, body=body, provisions=provisions)
+
+
+def save_document(doc: Document, output_path: Path) -> None:
+    """Persist a document to disk as JSON."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as f:
+        f.write(doc.to_json())
+
+
+def process_pdf(
+    pdf: Path,
+    output: Optional[Path] = None,
+    jurisdiction: Optional[str] = None,
+    citation: Optional[str] = None,
+    cultural_flags: Optional[List[str]] = None,
+) -> Document:
+    """Extract text, parse sections, run rule extraction and persist."""
+
+    pages = extract_pdf_text(pdf)
+    doc = build_document(pages, pdf, jurisdiction, citation, cultural_flags)
+    out = output or Path("data/pdfs") / (pdf.stem + ".json")
+    save_document(doc, out)
+    return doc
+
+
+def main() -> None:
+    """Command line entry point."""
+
+    parser = argparse.ArgumentParser(
+        description="Extract rules from a PDF and save as a Document"
+    )
     parser.add_argument("pdf", type=Path, help="Path to PDF file")
     parser.add_argument("-o", "--output", type=Path, help="Output JSON path")
+    parser.add_argument("--jurisdiction", help="Jurisdiction metadata")
+    parser.add_argument("--citation", help="Citation metadata")
+    parser.add_argument(
+        "--cultural-flags", nargs="*", help="List of cultural sensitivity flags"
+    )
     args = parser.parse_args()
 
-    output = args.output or Path("data/pdfs") / (args.pdf.stem + ".json")
-    pages = extract_pdf_text(args.pdf)
-    save_json(pages, output, args.pdf)
+    doc = process_pdf(
+        args.pdf,
+        output=args.output,
+        jurisdiction=args.jurisdiction,
+        citation=args.citation,
+        cultural_flags=args.cultural_flags,
+    )
+    print(doc.to_json())
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()
+

--- a/tests/pdf_ingest/test_rule_extraction.py
+++ b/tests/pdf_ingest/test_rule_extraction.py
@@ -1,0 +1,47 @@
+import json
+import sys
+import types
+from pathlib import Path
+
+
+def test_rule_extraction(monkeypatch, tmp_path):
+    root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(root))
+
+    def fake_extract_text(path):
+        return "Heading\nThe agent must file reports."
+
+    sys.modules["pdfminer.high_level"] = types.SimpleNamespace(extract_text=fake_extract_text)
+
+    from src.models.provision import Provision
+    import src.pdf_ingest as pdf_ingest
+
+    def fake_parse_sections(text):
+        body = text.split("\n", 1)[1] if "\n" in text else text
+        return [Provision(text=body)]
+
+    monkeypatch.setattr(
+        pdf_ingest,
+        "section_parser",
+        types.SimpleNamespace(parse_sections=fake_parse_sections),
+        raising=False,
+    )
+
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4")
+    out = tmp_path / "out.json"
+    doc = pdf_ingest.process_pdf(
+        pdf_path,
+        output=out,
+        jurisdiction="US",
+        citation="CIT",
+    )
+
+    assert doc.provisions
+    assert doc.provisions[0].principles
+    assert "must file reports" in doc.provisions[0].principles[0]
+
+    with out.open() as f:
+        saved = json.load(f)
+    assert saved["metadata"]["provenance"] == str(pdf_path)
+    assert saved["provisions"][0]["principles"]


### PR DESCRIPTION
## Summary
- Enhance `pdf_ingest` to create `Document` objects with optional metadata and provenance
- Run section parsing and rule extraction on PDF text
- Provide `sensiblaw pdf-fetch` CLI command
- Add test covering PDF rule extraction

## Testing
- `pytest tests/pdf_ingest/test_rule_extraction.py -q`
- `pytest -q` *(fails: NameError: name 'BeautifulSoup' is not defined; dependency `beautifulsoup4` unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6898e4bede5c83228e9bc6e88029b031