### PR TITLE
Add regex-based section parser with rule extraction and tests

### DIFF
--- a/src/austlii_client.py
+++ b/src/austlii_client.py
@@ -12,6 +12,7 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover
     requests = None  # type: ignore
 
+
 from .models import Document, DocumentMetadata, Provision
 
 logger = logging.getLogger(__name__)
@@ -188,41 +189,6 @@ class AustLIIClient:
             stack.append((level, prov.children))
         return root
 
-        soup = BeautifulSoup(response.content, "html.parser")
-        title = soup.find("h1").get_text(strip=True) if soup.find("h1") else ""
-        text = self._normalize_text(soup)
-        data = {
-            "url": url,
-            "title": title,
-            "text": text,
-            "retrieved_at": int(time.time()),
-        }
-        filename = JUDGMENT_DIR / f"{self._slugify(title) or int(time.time())}.json"
-        self._write_json(filename, data)
-        return data
-
-    def fetch_legislation(self, url: str) -> Dict[str, Any]:
-        """Download and parse a legislation page from AustLII.
-
-        The extracted title and raw text are written to a JSON file within
-        ``data/austlii/legislation`` and returned as a dictionary.
-        """
-
-        logger.info("Fetching legislation %s", url)
-        response = self._get(url)
-        soup = BeautifulSoup(response.content, "html.parser")
-        title = soup.find("h1").get_text(strip=True) if soup.find("h1") else ""
-        text = self._normalize_text(soup)
-        data = {
-            "url": url,
-            "title": title,
-            "text": text,
-            "retrieved_at": int(time.time()),
-        }
-        filename = LEGISLATION_DIR / f"{self._slugify(title) or int(time.time())}.json"
-        self._write_json(filename, data)
-        return data
-
     # ------------------------------------------------------------------
     # Internal utilities
     # ------------------------------------------------------------------
@@ -230,14 +196,6 @@ class AustLIIClient:
         """Write *data* to *path* in JSON format."""
         with path.open("w", encoding="utf-8") as fh:
             json.dump(data, fh, ensure_ascii=False, indent=2)
-
-    @staticmethod
-    def _normalize_text(soup: BeautifulSoup) -> str:
-        """Return a whitespace-normalized string from a soup document."""
-        # BeautifulSoup#get_text collapses multiple spaces and removes tags.
-        text = soup.get_text(" ", strip=True)
-        # Extra normalization to ensure consistent single spacing.
-        return " ".join(text.split())
 
     @staticmethod
     def _slugify(text: str) -> str:

--- a/src/ingestion/section_parser.py
+++ b/src/ingestion/section_parser.py
@@ -1,0 +1,91 @@
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+# Precompiled regex to capture leading numbering/heading from a block of text
+HEADING_RE = re.compile(r"^(?P<number>\d+(?:\.\d+)*)\s+(?P<heading>.+)$")
+
+# Single-pass combined regex mimicking an Aho–Corasick matcher for keywords
+TOKEN_RE = re.compile(
+    r"(?P<modality>must not|must|may)|"
+    r"(?P<condition>if|unless|subject to|despite)|"
+    r"(?P<xref>s\s+\d+[A-Za-z]?|this\s+Part)",
+    re.IGNORECASE,
+)
+
+
+def _strip_tags(html: str) -> str:
+    """Remove simple HTML tags, returning the text content."""
+    return re.sub(r"<[^>]+>", "", html).strip()
+
+
+@dataclass
+class Section:
+    """Representation of a single legislative section with extracted rules."""
+
+    number: Optional[str]
+    heading: Optional[str]
+    text: str
+    modality: Optional[str]
+    conditions: List[str]
+    references: List[str]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "number": self.number,
+            "heading": self.heading,
+            "text": self.text,
+            "rules": {
+                "modality": self.modality,
+                "conditions": list(self.conditions),
+                "references": list(self.references),
+            },
+        }
+
+
+def parse_html_section(html: str) -> Section:
+    """Parse an HTML fragment representing a numbered section.
+
+    The extractor runs a single combined regex over the text to detect
+    modalities (``must``, ``must not``, ``may``), conditional triggers
+    (``if``, ``unless``, ``subject to``, ``despite``) and simple
+    cross references (e.g. ``s 5B``, ``this Part``).
+    """
+
+    text = _strip_tags(html)
+
+    heading_match = HEADING_RE.match(text)
+    number: Optional[str] = None
+    heading: Optional[str] = None
+    if heading_match:
+        number = heading_match.group("number")
+        heading = heading_match.group("heading")
+
+    modality: Optional[str] = None
+    conditions: List[str] = []
+    references: List[str] = []
+
+    for match in TOKEN_RE.finditer(text):
+        token = match.group().strip()
+        group = match.lastgroup
+        if group == "modality" and modality is None:
+            modality = token.lower()
+        elif group == "condition":
+            conditions.append(token.lower())
+        elif group == "xref":
+            references.append(token)
+
+    return Section(
+        number=number,
+        heading=heading,
+        text=text,
+        modality=modality,
+        conditions=conditions,
+        references=references,
+    )
+
+
+def fetch_section(html: str) -> Dict[str, object]:
+    """Parse *html* and return raw text together with extracted rule metadata."""
+    section = parse_html_section(html)
+    return section.to_dict()

--- a/tests/ingestion/test_section_parser.py
+++ b/tests/ingestion/test_section_parser.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+from src.ingestion.section_parser import fetch_section
+
+
+def test_extract_modality_conditions_and_refs():
+    html = "<p>1 A person must not drive if intoxicated under s 5B.</p>"
+    data = fetch_section(html)
+    assert data["number"] == "1"
+    assert data["rules"]["modality"] == "must not"
+    assert data["rules"]["conditions"] == ["if"]
+    assert data["rules"]["references"] == ["s 5B"]
+
+
+def test_subject_to_and_this_part():
+    html = "<div>2 The authority may issue permits subject to this Part.</div>"
+    data = fetch_section(html)
+    assert data["number"] == "2"
+    assert data["rules"]["modality"] == "may"
+    assert data["rules"]["conditions"] == ["subject to"]
+    assert data["rules"]["references"] == ["this Part"]
+
+
+def test_multiple_conditions_and_references():
+    html = "<div>3 A body must comply unless exempt despite s 10.</div>"
+    data = fetch_section(html)
+    assert data["number"] == "3"
+    assert data["rules"]["modality"] == "must"
+    assert data["rules"]["conditions"] == ["unless", "despite"]
+    assert data["rules"]["references"] == ["s 10"]


### PR DESCRIPTION
## Summary
- Implement section parser that captures heading numbers and extracts modalities, conditions, and cross-references in a single pass.
- Provide `fetch_section` helper that returns raw text with parsed rule metadata.
- Clean up AustLII client to remove unused BeautifulSoup-based implementation.
- Add unit tests for section parser covering modalities, conditions, and references.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e49beb18832284777dea3e4b909d