### PR TITLE
Tag provisions during ingestion and expand ontology tagging tests

### DIFF
--- a/src/ingestion/parser.py
+++ b/src/ingestion/parser.py
@@ -1,10 +1,11 @@
 """Utility functions for ingesting raw records into :class:`Document` objects."""
 
 import json
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from ..models.document import Document
-from ..ontology.tagger import tag_text
+from ..models.provision import Provision
+from ..ontology.tagger import tag_provision
 from .consent_gate import check_consent
 
 # Mapping of human-readable jurisdictions to standard codes.
@@ -15,9 +16,8 @@ JURISDICTION_MAP = {
 }
 
 
-def _apply_tags(doc: Document) -> None:
+def _apply_tags(doc: Document, tags: Dict[str, List[str]]) -> None:
     """Populate ontology tags on the document metadata."""
-    tags = tag_text(doc.body)
     doc.metadata.ontology_tags = tags
     # Populate legacy fields for backward compatibility
     if "lpo" in tags:
@@ -38,7 +38,10 @@ def emit_document(record: Dict[str, Any]) -> Document:
     """Convert a raw record dictionary into a tagged :class:`Document` instance."""
     check_consent(record)
     doc = Document.from_dict(record)
-    _apply_tags(doc)
+    provision = Provision(text=record["body"])
+    tags = tag_provision(provision)
+    doc.provisions = [provision]
+    _apply_tags(doc, tags)
     _apply_jurisdiction_codes(doc)
     return doc
 
@@ -48,6 +51,9 @@ def emit_document_from_json(data: str) -> Document:
     record = json.loads(data)
     check_consent(record)
     doc = Document.from_json(data)
-    _apply_tags(doc)
+    provision = Provision(text=record["body"])
+    tags = tag_provision(provision)
+    doc.provisions = [provision]
+    _apply_tags(doc, tags)
     _apply_jurisdiction_codes(doc)
     return doc

--- a/tests/ingestion/test_tagging.py
+++ b/tests/ingestion/test_tagging.py
@@ -15,10 +15,14 @@ def test_australian_tagging():
             "citation": "ABC123",
             "date": "2023-01-01",
         },
-        "body": "The law promotes fair treatment and environmental protection.",
+        "body": "The law promotes fair treatment, common business practice, and environmental protection.",
     }
     doc = emit_document(record)
     assert "AU" in doc.metadata.jurisdiction_codes
     tags = doc.metadata.ontology_tags
     assert "lpo" in tags and "fairness" in tags["lpo"]
+    assert "cco" in tags and "business_practice" in tags["cco"]
     assert "environment" in tags and "conservation" in tags["environment"]
+    prov = doc.provisions[0]
+    assert "fairness" in prov.principles
+    assert "business_practice" in prov.customs

--- a/tests/ontology/test_tagger.py
+++ b/tests/ontology/test_tagger.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+from src.models.provision import Provision
+from src.ontology.tagger import tag_text, tag_provision
+
+
+def test_tag_text_creates_provision():
+    prov = tag_text("Fair business practices support environmental protection.")
+    assert "fairness" in prov.principles
+    assert "business_practice" in prov.customs
+
+
+def test_tag_provision_updates_in_place():
+    prov = Provision(text="Fair business practices support environmental protection.")
+    tags = tag_provision(prov)
+    assert "fairness" in prov.principles
+    assert "business_practice" in prov.customs
+    assert "environment" in tags and "conservation" in tags["environment"]

--- a/tests/test_pdf_ingest.py
+++ b/tests/test_pdf_ingest.py
@@ -13,6 +13,7 @@ def test_extract_pdf(monkeypatch, tmp_path):
         return "Heading 1\nHello  \nWorld\fHeading2\nSecond\tPage"
 
     sys.modules["pdfminer.high_level"] = types.SimpleNamespace(extract_text=fake_extract_text)
+    sys.modules.pop("src.pdf_ingest", None)
     pdf_ingest = importlib.import_module("src.pdf_ingest")
 
     pdf_path = tmp_path / "sample.pdf"


### PR DESCRIPTION
## Summary
- Build provision-aware tagging utilities `tag_provision` and updated `tag_text`
- Populate `Document.provisions` and metadata via `tag_provision` in parser
- Add regression tests for ontology tagger and ensure ingestion tags provisions

## Testing
- `pytest tests/ingestion/test_tagging.py tests/ontology/test_tagger.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898ea4d46e88322b29e12422fa6901d