### PR TITLE
feat: introduce legal graph structures

### DIFF
--- a/docs/graph.md
+++ b/docs/graph.md
@@ -1,0 +1,49 @@
+# Graph Module
+
+The `graph` package provides simple data structures for building in-memory
+networks of legal entities. Nodes and edges are represented using dataclasses
+and typed with enumerations for clarity.
+
+## Node and Edge Types
+
+`NodeType` and `EdgeType` enumerate the supported entities and relationships.
+These can be extended as the project grows.
+
+## Creating Nodes and Edges
+
+```python
+from graph import (
+    GraphNode,
+    GraphEdge,
+    LegalGraph,
+    NodeType,
+    EdgeType,
+)
+from datetime import date
+
+# Create a new graph
+lg = LegalGraph()
+
+# Add two document nodes
+case = GraphNode(
+    type=NodeType.DOCUMENT,
+    identifier="case-1",
+    metadata={"title": "Example Case"},
+    date=date(2020, 1, 1),
+)
+statute = GraphNode(type=NodeType.DOCUMENT, identifier="statute-1")
+lg.add_node(case)
+lg.add_node(statute)
+
+# Connect the nodes with a citation edge
+edge = GraphEdge(
+    type=EdgeType.CITES,
+    source=case.identifier,
+    target=statute.identifier,
+    weight=1.0,
+)
+lg.add_edge(edge)
+```
+
+The `LegalGraph` manager provides `add_node` and `add_edge` helpers along with
+query methods like `get_node` and `find_edges` for exploring the network.

--- a/src/graph/__init__.py
+++ b/src/graph/__init__.py
@@ -1,0 +1,5 @@
+"""Graph utilities for representing relationships between legal entities."""
+
+from .models import EdgeType, GraphEdge, GraphNode, LegalGraph, NodeType
+
+__all__ = ["EdgeType", "GraphEdge", "GraphNode", "LegalGraph", "NodeType"]

--- a/src/graph/models.py
+++ b/src/graph/models.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class NodeType(Enum):
+    """Enumeration of supported node types within a legal graph."""
+
+    DOCUMENT = "document"
+    PROVISION = "provision"
+    PERSON = "person"
+
+
+class EdgeType(Enum):
+    """Enumeration of supported edge types within a legal graph."""
+
+    CITES = "cites"
+    REFERENCES = "references"
+    RELATED_TO = "related_to"
+
+
+@dataclass
+class GraphNode:
+    """Representation of a node in the legal graph."""
+
+    type: NodeType
+    identifier: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    date: Optional[date] = None
+
+
+@dataclass
+class GraphEdge:
+    """Representation of a directed edge in the legal graph."""
+
+    type: EdgeType
+    source: str
+    target: str
+    identifier: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    date: Optional[date] = None
+    weight: float = 1.0
+
+
+class LegalGraph:
+    """In-memory manager for a simple legal graph."""
+
+    def __init__(self) -> None:
+        self.nodes: Dict[str, GraphNode] = {}
+        self.edges: List[GraphEdge] = []
+
+    def add_node(self, node: GraphNode) -> None:
+        """Add or replace a node in the graph."""
+        self.nodes[node.identifier] = node
+
+    def add_edge(self, edge: GraphEdge) -> None:
+        """Add an edge to the graph.
+
+        Both source and target nodes must already exist.
+        """
+        if edge.source not in self.nodes or edge.target not in self.nodes:
+            raise ValueError("Both source and target nodes must exist in the graph")
+        self.edges.append(edge)
+
+    def get_node(self, identifier: str) -> Optional[GraphNode]:
+        """Retrieve a node by its identifier."""
+        return self.nodes.get(identifier)
+
+    def find_edges(
+        self,
+        *,
+        source: Optional[str] = None,
+        target: Optional[str] = None,
+        type: Optional[EdgeType] = None,
+    ) -> List[GraphEdge]:
+        """Find edges matching the provided criteria."""
+        results = self.edges
+        if source is not None:
+            results = [e for e in results if e.source == source]
+        if target is not None:
+            results = [e for e in results if e.target == target]
+        if type is not None:
+            results = [e for e in results if e.type == type]
+        return results
+
+
+__all__ = [
+    "NodeType",
+    "EdgeType",
+    "GraphNode",
+    "GraphEdge",
+    "LegalGraph",
+]


### PR DESCRIPTION
## Summary
- add graph package with enums and dataclasses for nodes and edges
- include LegalGraph manager for node and edge creation and querying
- document graph module with usage examples

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c662019ec8322a93b04630c3149fd