### PR TITLE
feat: add case distinction engine

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -33,6 +33,19 @@ def main() -> None:
         "--cultural-flags", nargs="*", help="List of cultural sensitivity flags"
     )
 
+    dist_parser = sub.add_parser(
+        "distinguish", help="Compare two cases and show reasoning"
+    )
+    dist_parser.add_argument(
+        "--base", type=Path, required=True, help="Base case paragraphs as JSON"
+    )
+    dist_parser.add_argument(
+        "--candidate",
+        type=Path,
+        required=True,
+        help="Candidate case paragraphs as JSON",
+    )
+
     args = parser.parse_args()
     if args.command == "get":
         store = VersionedStore(args.db)
@@ -70,6 +83,18 @@ def main() -> None:
             cultural_flags=args.cultural_flags,
         )
         print(doc.to_json())
+    elif args.command == "distinguish":
+        from .distinguish.engine import (
+            compare_cases,
+            extract_case_silhouette,
+        )
+
+        base_paras = json.loads(args.base.read_text())
+        cand_paras = json.loads(args.candidate.read_text())
+        base = extract_case_silhouette(base_paras)
+        cand = extract_case_silhouette(cand_paras)
+        result = compare_cases(base, cand)
+        print(json.dumps(result))
     else:
         parser.print_help()
 

--- a/src/distinguish/__init__.py
+++ b/src/distinguish/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for case comparison and distinction."""
+
+from .engine import CaseSilhouette, extract_case_silhouette, compare_cases
+
+__all__ = ["CaseSilhouette", "extract_case_silhouette", "compare_cases"]

--- a/src/distinguish/engine.py
+++ b/src/distinguish/engine.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Sequence, List
+
+
+@dataclass
+class CaseSilhouette:
+    """Concise representation of a case for comparison.
+
+    Attributes:
+        fact_tags: Mapping of fact descriptors to paragraph index.
+        holding_hints: Mapping of holding descriptors to paragraph index.
+        paragraphs: Original paragraph texts.
+    """
+
+    fact_tags: Dict[str, int]
+    holding_hints: Dict[str, int]
+    paragraphs: Sequence[str]
+
+
+def extract_case_silhouette(paragraphs: Sequence[str]) -> CaseSilhouette:
+    """Extract a minimal silhouette from judgment paragraphs.
+
+    The first three paragraphs are treated as fact tags. Any paragraph starting
+    with "Held" (case-insensitive) is treated as a holding hint.
+    """
+
+    facts: Dict[str, int] = {}
+    holdings: Dict[str, int] = {}
+    for idx, para in enumerate(paragraphs):
+        text = para.strip()
+        if not text:
+            continue
+        if idx < 3:
+            facts[text] = idx
+        if text.lower().startswith("held"):
+            holdings[text] = idx
+    return CaseSilhouette(facts, holdings, list(paragraphs))
+
+
+def compare_cases(base: CaseSilhouette, candidate: CaseSilhouette) -> Dict[str, List[dict]]:
+    """Compare two case silhouettes.
+
+    Returns a dictionary with overlaps and missing conditions. Overlaps include
+    supporting citations to paragraph indices and texts from both cases.
+    """
+
+    overlaps: List[dict] = []
+    missing: List[dict] = []
+
+    for fact, base_idx in base.fact_tags.items():
+        if fact in candidate.fact_tags:
+            cand_idx = candidate.fact_tags[fact]
+            overlaps.append(
+                {
+                    "type": "fact",
+                    "text": fact,
+                    "base": {
+                        "index": base_idx,
+                        "paragraph": base.paragraphs[base_idx],
+                    },
+                    "candidate": {
+                        "index": cand_idx,
+                        "paragraph": candidate.paragraphs[cand_idx],
+                    },
+                }
+            )
+        else:
+            missing.append(
+                {
+                    "type": "fact",
+                    "text": fact,
+                    "base": {
+                        "index": base_idx,
+                        "paragraph": base.paragraphs[base_idx],
+                    },
+                }
+            )
+
+    for holding, base_idx in base.holding_hints.items():
+        if holding in candidate.holding_hints:
+            cand_idx = candidate.holding_hints[holding]
+            overlaps.append(
+                {
+                    "type": "holding",
+                    "text": holding,
+                    "base": {
+                        "index": base_idx,
+                        "paragraph": base.paragraphs[base_idx],
+                    },
+                    "candidate": {
+                        "index": cand_idx,
+                        "paragraph": candidate.paragraphs[cand_idx],
+                    },
+                }
+            )
+        else:
+            missing.append(
+                {
+                    "type": "holding",
+                    "text": holding,
+                    "base": {
+                        "index": base_idx,
+                        "paragraph": base.paragraphs[base_idx],
+                    },
+                }
+            )
+
+    return {"overlaps": overlaps, "missing": missing}

--- a/tests/distinguish/test_distinguish_engine.py
+++ b/tests/distinguish/test_distinguish_engine.py
@@ -1,0 +1,34 @@
+from src.distinguish.engine import compare_cases, extract_case_silhouette
+
+
+def test_extract_case_silhouette():
+    paragraphs = [
+        "Fact one",
+        "Fact two",
+        "Fact three",
+        "Held: something",
+        "Other",
+    ]
+    sil = extract_case_silhouette(paragraphs)
+    assert "Fact one" in sil.fact_tags
+    assert sil.fact_tags["Fact one"] == 0
+    assert "Held: something" in sil.holding_hints
+    assert sil.holding_hints["Held: something"] == 3
+
+
+def test_compare_cases_overlap_and_missing():
+    base_paras = [
+        "Base fact",
+        "Held: yes",
+    ]
+    cand_paras = [
+        "Other fact",
+        "Held: yes",
+    ]
+    base = extract_case_silhouette(base_paras)
+    cand = extract_case_silhouette(cand_paras)
+    result = compare_cases(base, cand)
+    texts = [o["text"] for o in result["overlaps"]]
+    assert "Held: yes" in texts
+    missing_texts = [m["text"] for m in result["missing"]]
+    assert "Base fact" in missing_texts

--- a/tests/test_distinguish_cli.py
+++ b/tests/test_distinguish_cli.py
@@ -1,0 +1,29 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_cli_distinguish(tmp_path: Path):
+    base = ["base fact", "Held: yes"]
+    candidate = ["other fact", "Held: yes"]
+    base_file = tmp_path / "base.json"
+    cand_file = tmp_path / "cand.json"
+    base_file.write_text(json.dumps(base))
+    cand_file.write_text(json.dumps(candidate))
+
+    cmd = [
+        "python",
+        "-m",
+        "src.cli",
+        "distinguish",
+        "--base",
+        str(base_file),
+        "--candidate",
+        str(cand_file),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    data = json.loads(completed.stdout)
+    texts = [o["text"] for o in data["overlaps"]]
+    assert "Held: yes" in texts
+    missing = [m["text"] for m in data["missing"]]
+    assert "base fact" in missing


### PR DESCRIPTION
## Summary
- extract fact tags and holding hints from parsed judgments
- compare case silhouettes to highlight overlaps and missing points
- expose `sensiblaw distinguish` CLI command with reasoning output

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c663b28488322936f8846c7923e1e