### PR TITLE
Add declarative legal test templates and registry

### DIFF
--- a/src/tests/__init__.py
+++ b/src/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Utility tests and evaluation support."""
+

--- a/src/tests/templates.py
+++ b/src/tests/templates.py
@@ -1,0 +1,44 @@
+"""Declarative factor checklists for legal concept tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass(frozen=True)
+class Factor:
+    """A single factor considered in a legal test."""
+
+    id: str
+    description: str
+
+
+@dataclass(frozen=True)
+class TestTemplate:
+    """Template describing the factors for evaluating a concept."""
+
+    concept_id: str
+    name: str
+    factors: List[Factor]
+
+
+# ---------------------------------------------------------------------------
+# Example templates
+# ---------------------------------------------------------------------------
+
+PERMANENT_STAY_TEST = TestTemplate(
+    concept_id="permanent_stay",
+    name="Permanent Stay Test",
+    factors=[
+        Factor("delay", "Extent and impact of any prosecutorial delay"),
+        Factor("abuse_of_process", "Whether continuation would be an abuse of process"),
+        Factor("fair_trial_possible", "Possibility of a fair trial despite the delay"),
+    ],
+)
+
+# Registry mapping concept IDs to templates for lookup during evaluation
+TEMPLATE_REGISTRY: Dict[str, TestTemplate] = {
+    PERMANENT_STAY_TEST.concept_id: PERMANENT_STAY_TEST,
+}
+


### PR DESCRIPTION
## Summary
- add `src/tests/templates.py` defining dataclasses for factor-based legal tests
- include example `Permanent Stay Test` and registry for concept lookup
- provide `src/tests/__init__.py` for package initialization

## Testing
- `pytest -q` *(fails: KeyError: 'fetchers')*


------
https://chatgpt.com/codex/tasks/task_e_689c6cb1532083229a926b41c75c3135