### PR TITLE
feat: add basic query pipeline

### DIFF
--- a/docs/end_to_end.md
+++ b/docs/end_to_end.md
@@ -1,0 +1,53 @@
+# End-to-End Query Flow
+
+This document demonstrates the experimental query pipeline that powers
+`sensiblaw query`. The command accepts different forms of user input and
+converts them into a concept cloud.
+
+The high level steps are:
+
+1. **Parse input** – flatten questions, keyword lists or story graphs into
+   plain text.
+2. **Normalise** – perform simple text normalisation (currently just
+   lower‑casing).
+3. **Match concepts** – identify concepts in the text. The current
+   implementation merely splits the text into tokens.
+4. **Build cloud** – aggregate matched concepts into a frequency cloud.
+5. **Proof tree** – forthcoming stage that will explain how concepts relate
+   to authorities.
+
+## Examples
+
+### Question
+
+```bash
+sensiblaw query --text "Can a native title be extinguished by state law?"
+```
+
+### Keyword search
+
+```bash
+sensiblaw query --text "native title extinguishment"
+```
+
+### Story graph
+
+Given a minimal story graph JSON file:
+
+```json
+{
+  "nodes": [
+    {"text": "State passes land act"},
+    {"text": "Aboriginal group claims native title"}
+  ]
+}
+```
+
+Invoke the command with the path to the file:
+
+```bash
+sensiblaw query --graph story.json
+```
+
+Each of the above inputs will produce a simple concept cloud based on the
+matched tokens.

--- a/src/ingestion/dispatcher.py
+++ b/src/ingestion/dispatcher.py
@@ -94,7 +94,26 @@ class SourceDispatcher:
                     nodes, edges = frl.fetch_acts(api_url)
                 except Exception:  # pragma: no cover - network/parse errors
                     nodes, edges = [], []
-                results.append({"name": source["name"], "nodes": nodes, "edges": edges})
+
+                # Even though a bespoke adapter is used, expose the generic
+                # fetcher information so that callers can inspect how the data
+                # was sourced.  This mirrors the structure returned by other
+                # sources and keeps tests simple.
+                fetchers: List[str] = []
+                formats_upper = [f.upper() for f in source.get("formats", [])]
+                if any("HTML" in f for f in formats_upper):
+                    fetchers.append(fetch_official_register(source))
+                if any("PDF" in f for f in formats_upper):
+                    fetchers.append(fetch_pdf(source))
+
+                results.append(
+                    {
+                        "name": source["name"],
+                        "nodes": nodes,
+                        "edges": edges,
+                        "fetchers": fetchers,
+                    }
+                )
                 continue
 
             # Generic fetchers -------------------------------------------------

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -1,0 +1,35 @@
+"""Lightweight processing pipeline utilities."""
+from __future__ import annotations
+
+from collections import Counter
+from typing import List, Dict
+
+
+def normalise(text: str) -> str:
+    """Basic text normalisation.
+
+    Currently this is a placeholder that lowercases the text. Future
+    implementations may perform tokenisation, lemmatisation and more.
+    """
+    return text.lower()
+
+
+def match_concepts(text: str) -> List[str]:
+    """Match concepts within the text.
+
+    This stub implementation simply splits the text into whitespace
+    separated tokens.
+    """
+    return text.split()
+
+
+def build_cloud(concepts: List[str]) -> Dict[str, int]:
+    """Build a frequency cloud of concepts.
+
+    The current version counts the occurrences of each concept. This will
+    eventually be replaced with richer semantic representations.
+    """
+    return dict(Counter(concepts))
+
+
+__all__ = ["normalise", "match_concepts", "build_cloud"]

--- a/src/pipeline/input_handler.py
+++ b/src/pipeline/input_handler.py
@@ -1,0 +1,47 @@
+"""Utilities for handling user input for the processing pipeline."""
+from __future__ import annotations
+
+from typing import List, TypedDict
+
+
+class StoryNode(TypedDict, total=False):
+    """A minimal representation of a node within a story graph."""
+
+    text: str
+
+
+class StoryGraph(TypedDict, total=False):
+    """A lightweight story graph structure.
+
+    Only the pieces required for `parse_input` are represented here. A
+    StoryGraph consists of a list of nodes where each node may contain some
+    textual description under the `text` key.
+    """
+
+    nodes: List[StoryNode]
+
+
+def parse_input(query: str | StoryGraph) -> str:
+    """Flatten different query types into raw text.
+
+    Parameters
+    ----------
+    query:
+        The user supplied query which may either be a free-form string or a
+        `StoryGraph` structure.
+
+    Returns
+    -------
+    str
+        The textual representation of the query.
+    """
+    if isinstance(query, str):
+        return query
+
+    # Extract text from each node of the story graph, ignoring missing fields
+    nodes = query.get("nodes", [])
+    parts = [n.get("text", "") for n in nodes]
+    return " ".join(p for p in parts if p)
+
+
+__all__ = ["StoryGraph", "parse_input"]


### PR DESCRIPTION
## Summary
- handle text and story-graph inputs via `parse_input`
- expose new `sensiblaw query` command that normalises text, matches concepts and builds a simple concept cloud
- document the end-to-end query flow
- ensure FRL dispatcher includes fetcher metadata even when using special adapter

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c6cb58a148322976105698df39008