### PR TITLE
feat(ui): add treatment and distinguish components

### DIFF
--- a/ui/components/DistinguishPanel.tsx
+++ b/ui/components/DistinguishPanel.tsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from "react";
+
+interface Silhouette {
+  fact_tags: Record<string, number>;
+  holding_hints: Record<string, number>;
+  paragraphs: string[];
+}
+
+interface CitationInfo {
+  index: number;
+  paragraph: string;
+  citationId?: string;
+  provisionId?: string;
+}
+
+interface ComparisonItem {
+  type: "fact" | "holding";
+  text: string;
+  base: CitationInfo;
+  candidate?: CitationInfo;
+}
+
+interface Comparison {
+  base: Silhouette;
+  candidate: Silhouette;
+  overlaps: ComparisonItem[];
+  missing: ComparisonItem[];
+}
+
+interface DistinguishPanelProps {
+  baseId: string;
+  candidateId: string;
+}
+
+const DistinguishPanel: React.FC<DistinguishPanelProps> = ({
+  baseId,
+  candidateId,
+}) => {
+  const [data, setData] = useState<Comparison | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/distinguish?base=${baseId}&candidate=${candidateId}`)
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to load comparison");
+        return r.json();
+      })
+      .then((d) => setData(d))
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [baseId, candidateId]);
+
+  if (loading) return <div>Loading comparison…</div>;
+  if (error) return <div>Error: {error}</div>;
+  if (!data) return null;
+
+  const renderItem = (
+    fact: string,
+    side: "base" | "candidate",
+    idx: number
+  ) => {
+    const overlap = data.overlaps.find(
+      (o) => o.text === fact && o.type === "fact"
+    );
+    const missing = data.missing.find(
+      (o) => o.text === fact && o.type === "fact"
+    );
+    const className = overlap
+      ? "overlap"
+      : missing && side === "base"
+      ? "missing"
+      : "";
+    const info =
+      side === "base"
+        ? data.base.paragraphs[idx]
+        : data.candidate.paragraphs[idx];
+
+    const linkSource = overlap
+      ? side === "base"
+        ? overlap.base
+        : overlap.candidate
+      : missing && side === "base"
+      ? missing.base
+      : undefined;
+    const link = linkSource
+      ? linkSource.citationId
+        ? `#/proof-tree/case/${linkSource.citationId}`
+        : linkSource.provisionId
+        ? `#/proof-tree/statute/${linkSource.provisionId}`
+        : undefined
+      : undefined;
+
+    return (
+      <div key={`${side}-${fact}`} className={`silhouette-item ${className}`}>
+        {link ? <a href={link}>{info}</a> : info}
+      </div>
+    );
+  };
+
+  const baseFacts = Object.keys(data.base.fact_tags);
+  const candidateFacts = Object.keys(data.candidate.fact_tags);
+
+  return (
+    <div className="distinguish-panel">
+      <div className="silhouettes">
+        <div className="silhouette-base">
+          <h3>Base Case</h3>
+          {baseFacts.map((fact) =>
+            renderItem(fact, "base", data.base.fact_tags[fact])
+          )}
+        </div>
+        <div className="silhouette-candidate">
+          <h3>Candidate Case</h3>
+          {candidateFacts.map((fact) =>
+            renderItem(fact, "candidate", data.candidate.fact_tags[fact])
+          )}
+        </div>
+      </div>
+      <div className="legend">
+        <span className="overlap">Overlap</span>
+        <span className="missing">Missing</span>
+      </div>
+    </div>
+  );
+};
+
+export default DistinguishPanel;

--- a/ui/components/TreatmentTable.tsx
+++ b/ui/components/TreatmentTable.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from "react";
+
+interface TreatmentRecord {
+  id: string;
+  caseName: string;
+  treatment: string;
+  citationId?: string;
+  provisionId?: string;
+}
+
+interface TreatmentTableProps {
+  caseId: string;
+}
+
+const TreatmentTable: React.FC<TreatmentTableProps> = ({ caseId }) => {
+  const [records, setRecords] = useState<TreatmentRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`/api/cases/${caseId}/treatments`)
+      .then((r) => {
+        if (!r.ok) throw new Error("Failed to load treatments");
+        return r.json();
+      })
+      .then((data) => setRecords(data))
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [caseId]);
+
+  if (loading) return <div>Loading treatments…</div>;
+  if (error) return <div>Error: {error}</div>;
+
+  return (
+    <table className="treatment-table">
+      <thead>
+        <tr>
+          <th>Case</th>
+          <th>Treatment</th>
+          <th>Proof Tree</th>
+        </tr>
+      </thead>
+      <tbody>
+        {records.map((rec) => {
+          const link = rec.citationId
+            ? `#/proof-tree/case/${rec.citationId}`
+            : rec.provisionId
+            ? `#/proof-tree/statute/${rec.provisionId}`
+            : undefined;
+          return (
+            <tr key={rec.id}>
+              <td>{rec.caseName}</td>
+              <td>{rec.treatment}</td>
+              <td>{link ? <a href={link}>View</a> : null}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};
+
+export default TreatmentTable;

--- a/ui/components/index.ts
+++ b/ui/components/index.ts
@@ -1,0 +1,2 @@
+export { default as TreatmentTable } from "./TreatmentTable";
+export { default as DistinguishPanel } from "./DistinguishPanel";


### PR DESCRIPTION
## Summary
- add TreatmentTable component to list case treatments and link to proof-tree subgraphs
- add DistinguishPanel to compare case silhouettes with overlap and missing highlighting
- export new components from components index

## Testing
- `pytest` *(fails: KeyError: 'fetchers' in test_dispatcher_triggers_fetchers)*

------
https://chatgpt.com/codex/tasks/task_e_689c6cbacea083229d4c8f28530e0ae6