### PR TITLE
Model extrinsic material weighting in graph

### DIFF
--- a/docs/graph.md
+++ b/docs/graph.md
@@ -47,3 +47,32 @@ lg.add_edge(edge)
 
 The `LegalGraph` manager provides `add_node` and `add_edge` helpers along with
 query methods like `get_node` and `find_edges` for exploring the network.
+
+## Extrinsic material and weights
+
+Parliamentary contributions or other extrinsic materials can be modelled with
+an `ExtrinsicNode`. Each node records the speaker's role (e.g. *Minister*) and
+the legislative stage (e.g. *2nd reading*). The ingestion helper computes a
+weight that reflects the relative influence of the contribution.
+
+```python
+from graph import LegalGraph, NodeType, GraphNode, ingest_extrinsic
+
+graph = LegalGraph()
+bill = GraphNode(type=NodeType.DOCUMENT, identifier="bill-1")
+graph.add_node(bill)
+
+# Minister during the second reading carries more weight than a backbencher
+ingest_extrinsic(
+    graph,
+    identifier="speech-1",
+    role="Minister",
+    stage="2nd reading",
+    target=bill.identifier,
+)
+
+heavy_edges = graph.find_edges(min_weight=2.0)
+```
+
+Filtering by `min_weight` allows consumers to focus on more authoritative
+extrinsic statements when interpreting legislation.

--- a/src/graph/__init__.py
+++ b/src/graph/__init__.py
@@ -1,5 +1,15 @@
 """Graph utilities for representing relationships between legal entities."""
 
-from .models import EdgeType, GraphEdge, GraphNode, LegalGraph, NodeType
+from .ingest import compute_weight, ingest_extrinsic
+from .models import EdgeType, ExtrinsicNode, GraphEdge, GraphNode, LegalGraph, NodeType
 
-__all__ = ["EdgeType", "GraphEdge", "GraphNode", "LegalGraph", "NodeType"]
+__all__ = [
+    "EdgeType",
+    "GraphEdge",
+    "GraphNode",
+    "ExtrinsicNode",
+    "LegalGraph",
+    "NodeType",
+    "ingest_extrinsic",
+    "compute_weight",
+]

--- a/src/graph/ingest.py
+++ b/src/graph/ingest.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .models import EdgeType, ExtrinsicNode, GraphEdge, LegalGraph, NodeType
+
+# Basic weighting rules for roles and legislative stages.
+ROLE_WEIGHTS: Dict[str, float] = {
+    "minister": 2.0,
+    "shadow minister": 1.5,
+    "backbencher": 1.0,
+}
+
+STAGE_WEIGHTS: Dict[str, float] = {
+    "1st reading": 1.0,
+    "first reading": 1.0,
+    "2nd reading": 1.5,
+    "second reading": 1.5,
+    "committee": 1.2,
+    "3rd reading": 1.1,
+    "third reading": 1.1,
+}
+
+
+def compute_weight(role: str, stage: str) -> float:
+    """Return a numeric weight from the supplied role and stage."""
+    role_weight = ROLE_WEIGHTS.get(role.lower(), 1.0)
+    stage_weight = STAGE_WEIGHTS.get(stage.lower(), 1.0)
+    return role_weight * stage_weight
+
+
+def ingest_extrinsic(
+    graph: LegalGraph,
+    *,
+    identifier: str,
+    role: str,
+    stage: str,
+    target: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> ExtrinsicNode:
+    """Create an ``ExtrinsicNode`` and connect it to a target with weighted edge."""
+    node = ExtrinsicNode(
+        type=NodeType.EXTRINSIC,
+        identifier=identifier,
+        role=role,
+        stage=stage,
+        metadata=metadata or {},
+    )
+    graph.add_node(node)
+    weight = compute_weight(role, stage)
+    edge = GraphEdge(
+        type=EdgeType.RELATED_TO,
+        source=identifier,
+        target=target,
+        weight=weight,
+    )
+    graph.add_edge(edge)
+    return node
+
+
+__all__ = ["ingest_extrinsic", "compute_weight", "ROLE_WEIGHTS", "STAGE_WEIGHTS"]

--- a/src/graph/models.py
+++ b/src/graph/models.py
@@ -12,6 +12,7 @@ class NodeType(Enum):
     DOCUMENT = "document"
     PROVISION = "provision"
     PERSON = "person"
+    EXTRINSIC = "extrinsic"
 
 
 class EdgeType(Enum):
@@ -30,6 +31,14 @@ class GraphNode:
     identifier: str
     metadata: Dict[str, Any] = field(default_factory=dict)
     date: Optional[date] = None
+
+
+@dataclass
+class ExtrinsicNode(GraphNode):
+    """Node representing extrinsic materials such as parliamentary debates."""
+
+    role: str = ""
+    stage: str = ""
 
 
 @dataclass
@@ -75,6 +84,7 @@ class LegalGraph:
         source: Optional[str] = None,
         target: Optional[str] = None,
         type: Optional[EdgeType] = None,
+        min_weight: Optional[float] = None,
     ) -> List[GraphEdge]:
         """Find edges matching the provided criteria."""
         results = self.edges
@@ -84,6 +94,8 @@ class LegalGraph:
             results = [e for e in results if e.target == target]
         if type is not None:
             results = [e for e in results if e.type == type]
+        if min_weight is not None:
+            results = [e for e in results if e.weight >= min_weight]
         return results
 
 
@@ -91,6 +103,7 @@ __all__ = [
     "NodeType",
     "EdgeType",
     "GraphNode",
+    "ExtrinsicNode",
     "GraphEdge",
     "LegalGraph",
 ]

--- a/tests/graph/test_extrinsic.py
+++ b/tests/graph/test_extrinsic.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+from src.graph import GraphNode, LegalGraph, NodeType, ingest_extrinsic
+
+
+def test_extrinsic_weighting():
+    graph = LegalGraph()
+    bill = GraphNode(type=NodeType.DOCUMENT, identifier="bill-1")
+    graph.add_node(bill)
+
+    ingest_extrinsic(
+        graph,
+        identifier="speech-minister",
+        role="Minister",
+        stage="2nd reading",
+        target=bill.identifier,
+    )
+    ingest_extrinsic(
+        graph,
+        identifier="speech-backbencher",
+        role="Backbencher",
+        stage="2nd reading",
+        target=bill.identifier,
+    )
+
+    minister_edge = graph.find_edges(source="speech-minister")[0]
+    backbencher_edge = graph.find_edges(source="speech-backbencher")[0]
+    assert minister_edge.weight > backbencher_edge.weight
+
+    heavy_edges = graph.find_edges(min_weight=2.0)
+    assert all(e.weight >= 2.0 for e in heavy_edges)


### PR DESCRIPTION
## Summary
- Add `ExtrinsicNode` with role and stage fields for extrinsic material
- Provide ingestion helper that computes weighted edges from role/stage
- Support weight filtering in `LegalGraph.find_edges` and document usage

## Testing
- `pytest` *(fails: tests/ingestion/test_dispatcher.py::test_dispatcher_triggers_fetchers - KeyError: 'fetchers')*

------
https://chatgpt.com/codex/tasks/task_e_689c6cc4ab4483229676461b9b9a6739