### PR TITLE
Add CI workflow and status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install ruff
+      - name: Lint
+        run: ruff src tests
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+      - name: Test
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # SensibLaw
+
+[![CI](https://github.com/SensibLaw/SensibLaw/actions/workflows/ci.yml/badge.svg)](https://github.com/SensibLaw/SensibLaw/actions/workflows/ci.yml)
+
 Like coleslaw, it just makes sense.
 
 ## CLI


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for linting with ruff and running pytest on Python 3.x
- show CI status badge in README

## Testing
- `ruff check src tests` *(fails: E402 Module level import not at top of file)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c6ed5424083229b1bcb0b269b589b