### PR TITLE
Add disk-based cache with rate limiting for ingestion

### DIFF
--- a/src/ingestion/cache.py
+++ b/src/ingestion/cache.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Dict, Any
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+# Root directory for cached responses.  By default this lives inside the
+# repository's ``data`` folder but can be overridden via the
+# ``SENSIBLAW_CACHE`` environment variable.
+CACHE_DIR = Path(os.environ.get("SENSIBLAW_CACHE", Path(__file__).resolve().parents[2] / "data" / "cache"))
+
+# Ensure the cache directory exists so tests can pre-populate entries.
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+# Simple per-host rate limiting.  A one second delay is enforced between
+# network requests to the same host.  This keeps the kata polite when it needs
+# to talk to real services but still remains deterministic for tests.
+_RATE_LIMIT_SECONDS = 1.0
+_last_request: Dict[str, float] = {}
+_lock = threading.Lock()
+
+
+def _cache_path(url: str, suffix: str) -> Path:
+    """Return the on-disk path for ``url`` with file extension ``suffix``."""
+
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()
+    return CACHE_DIR / f"{digest}.{suffix}"
+
+
+def _throttle(host: str) -> None:
+    """Sleep if necessary to respect the per-host rate limit."""
+
+    with _lock:
+        now = time.time()
+        last = _last_request.get(host, 0.0)
+        wait = _RATE_LIMIT_SECONDS - (now - last)
+        if wait > 0:
+            time.sleep(wait)
+        _last_request[host] = time.time()
+
+
+def _fetch(url: str, *, suffix: str) -> bytes:
+    """Fetch ``url`` obeying cache and rate limits."""
+
+    path = _cache_path(url, suffix)
+    if path.exists():
+        return path.read_bytes()
+
+    host = urlparse(url).netloc
+    _throttle(host)
+
+    with urlopen(url) as resp:  # pragma: no cover - network
+        data = resp.read()
+
+    path.write_bytes(data)
+    return data
+
+
+def fetch_html(url: str) -> str:
+    """Return HTML text from ``url`` using the cache."""
+
+    data = _fetch(url, suffix="html")
+    return data.decode("utf-8", errors="ignore")
+
+
+def fetch_pdf(url: str) -> bytes:
+    """Return PDF bytes from ``url`` using the cache."""
+
+    return _fetch(url, suffix="pdf")
+
+
+def fetch_json(url: str) -> Dict[str, Any]:
+    """Return parsed JSON from ``url`` using the cache."""
+
+    data = _fetch(url, suffix="json")
+    return json.loads(data.decode("utf-8"))
+
+
+__all__ = ["fetch_html", "fetch_pdf", "fetch_json", "CACHE_DIR"]

--- a/src/ingestion/frl.py
+++ b/src/ingestion/frl.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Tuple, Optional
-import json
-from urllib.request import urlopen
+
+from .cache import fetch_json
 
 # ---------------------------------------------------------------------------
 # Data models
@@ -45,10 +45,9 @@ class Act:
 
 
 def _get_json(url: str) -> Dict[str, object]:
-    """Fetch JSON from ``url`` using the standard library."""
+    """Fetch JSON from ``url`` using the cache."""
 
-    with urlopen(url) as resp:  # pragma: no cover - network
-        return json.loads(resp.read().decode("utf-8"))
+    return fetch_json(url)
 
 
 def _acts_to_graph(acts: Iterable[Act]) -> Tuple[List[Dict[str, object]], List[Dict[str, object]]]:

--- a/src/ingestion/hca.py
+++ b/src/ingestion/hca.py
@@ -21,7 +21,8 @@ from datetime import datetime
 import html
 import re
 from typing import Iterable, List, Tuple, Dict, Optional
-from urllib.request import urlopen
+
+from .cache import fetch_html
 
 # ---------------------------------------------------------------------------
 # Data models
@@ -135,8 +136,7 @@ def crawl_year(year: Optional[int] = None, *, html_text: Optional[str] = None) -
         year = datetime.now().year
 
     if html_text is None:
-        with urlopen(_INDEX_URL.format(year=year)) as resp:  # pragma: no cover - network
-            html_text = resp.read().decode("utf-8", errors="ignore")
+        html_text = fetch_html(_INDEX_URL.format(year=year))
 
     nodes: List[Dict[str, object]] = []
     edges: List[Dict[str, object]] = []


### PR DESCRIPTION
## Summary
- implement SHA256-based cache storing HTML, PDF, and JSON with per-host rate limiting
- use cache in HCA and FRL ingesters

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c71f38fd88322bbe6f745df2c9600