### PR TITLE
feat: enforce cultural consent

### DIFF
--- a/src/graph/models.py
+++ b/src/graph/models.py
@@ -25,12 +25,31 @@ class EdgeType(Enum):
 
 @dataclass
 class GraphNode:
-    """Representation of a node in the legal graph."""
+    """Representation of a node in the legal graph.
+
+    Attributes
+    ----------
+    type:
+        The :class:`NodeType` of the node.
+    identifier:
+        Unique identifier for the node within the graph.
+    metadata:
+        Arbitrary metadata associated with the node.
+    date:
+        Optional date for the node, typically the date of the underlying
+        document or event.
+    cultural_flags:
+        Optional list of cultural sensitivity flags attached to the node.
+    consent_required:
+        Indicates whether access to this node requires explicit consent.
+    """
 
     type: NodeType
     identifier: str
     metadata: Dict[str, Any] = field(default_factory=dict)
     date: Optional[date] = None
+    cultural_flags: Optional[List[str]] = None
+    consent_required: bool = False
 
 
 @dataclass

--- a/src/ingestion/consent_gate.py
+++ b/src/ingestion/consent_gate.py
@@ -20,10 +20,12 @@ def check_consent(record: Dict[str, Any]) -> None:
     """
 
     flags = set(record.get("cultural_flags", []))
-    if flags & SENSITIVE_FLAGS:
+    consent_required = record.get("consent_required", False)
+    if flags & SENSITIVE_FLAGS or consent_required:
         if not record.get("consent"):
             logger.warning(
-                "Blocked record %s due to missing consent", record.get("metadata", {}).get("citation")
+                "Blocked record %s due to missing consent",
+                record.get("metadata", {}).get("citation"),
             )
             raise ConsentError("Consent required for records with cultural flags")
         logger.info(

--- a/tests/ingestion/test_consent_gate.py
+++ b/tests/ingestion/test_consent_gate.py
@@ -2,6 +2,7 @@ import json
 import logging
 import sys
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -13,7 +14,9 @@ from src.ingestion.parser import emit_document, emit_document_from_json
 from src.ingestion.consent_gate import ConsentError
 
 
-def sample_record(consent: bool = False):
+def sample_record(
+    *, consent: bool = False, flags: Optional[list[str]] = None, consent_required: bool = False
+):
     record = {
         "metadata": {
             "jurisdiction": "US",
@@ -21,8 +24,10 @@ def sample_record(consent: bool = False):
             "date": "2020-01-01",
         },
         "body": "example body",
-        "cultural_flags": ["restricted"],
+        "cultural_flags": flags if flags is not None else ["restricted"],
     }
+    if consent_required:
+        record["consent_required"] = True
     if consent:
         record.update({"consent": True, "consent_receipt": "rcpt-001"})
     return record
@@ -47,3 +52,17 @@ def test_from_json_enforces_policy():
     data = json.dumps(record)
     with pytest.raises(ConsentError):
         emit_document_from_json(data)
+
+
+def test_consent_required_field_blocks():
+    record = sample_record(consent=False, flags=[], consent_required=True)
+    with pytest.raises(ConsentError):
+        emit_document(record)
+
+
+def test_consent_required_allows_with_consent(caplog):
+    record = sample_record(consent=True, flags=[], consent_required=True)
+    with caplog.at_level(logging.INFO):
+        doc = emit_document(record)
+    assert doc.body == "example body"
+    assert "Consent receipt" in caplog.text

--- a/tests/policy/test_engine.py
+++ b/tests/policy/test_engine.py
@@ -5,6 +5,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from src.policy.engine import CulturalFlags, PolicyEngine
+from src.graph import GraphNode, NodeType
 
 policy_json = json.dumps(
     {
@@ -60,3 +61,27 @@ def test_default_allow():
     engine = PolicyEngine(policy)
     action = engine.evaluate({CulturalFlags.PUBLIC_DOMAIN})
     assert action == "allow"
+
+
+def test_enforce_redacts_without_consent():
+    engine = PolicyEngine({})
+    node = GraphNode(
+        type=NodeType.DOCUMENT,
+        identifier="n1",
+        metadata={"secret": "x"},
+        consent_required=True,
+    )
+    redacted = engine.enforce(node, consent=False)
+    assert redacted.metadata == {}
+
+
+def test_enforce_allows_with_consent():
+    engine = PolicyEngine({})
+    node = GraphNode(
+        type=NodeType.DOCUMENT,
+        identifier="n1",
+        metadata={"secret": "x"},
+        consent_required=True,
+    )
+    allowed = engine.enforce(node, consent=True)
+    assert allowed.metadata == {"secret": "x"}


### PR DESCRIPTION
## Summary
- track cultural flags and consent needs on graph nodes
- block or redact access when consent missing
- test consent gate and policy engine enforcement

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c71eb34fc8322a68d9d440dba0b91