### PR TITLE
Add concept seeds and trigger loader

### DIFF
--- a/concepts/seeds.json
+++ b/concepts/seeds.json
@@ -1,0 +1,10 @@
+{
+  "concepts": [
+    {"id": "terra_nullius", "label": "Terra Nullius"},
+    {"id": "mabo", "label": "Mabo"},
+    {"id": "permanent_stay", "label": "Permanent Stay"}
+  ],
+  "relations": [
+    {"source": "terra_nullius", "type": "REJECTS", "target": "mabo"}
+  ]
+}

--- a/concepts/triggers/permanent_stay.json
+++ b/concepts/triggers/permanent_stay.json
@@ -1,0 +1,4 @@
+{
+  "id": "permanent_stay",
+  "phrases": ["permanent stay"]
+}

--- a/concepts/triggers/terra_nullius.json
+++ b/concepts/triggers/terra_nullius.json
@@ -1,0 +1,4 @@
+{
+  "id": "terra_nullius",
+  "phrases": ["terra nullius"]
+}

--- a/src/concepts/__init__.py
+++ b/src/concepts/__init__.py
@@ -1,5 +1,6 @@
 """Utilities for concept-related graph operations."""
 
 from .cloud import build_cloud, score_node
+from .loader import GRAPH, TRIGGERS, load
 
-__all__ = ["build_cloud", "score_node"]
+__all__ = ["build_cloud", "score_node", "GRAPH", "TRIGGERS", "load"]

--- a/src/concepts/loader.py
+++ b/src/concepts/loader.py
@@ -1,0 +1,69 @@
+"""Load concept seeds and triggers into the graph."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Tuple
+
+from ..graph.models import EdgeType, GraphEdge, GraphNode, LegalGraph, NodeType
+
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "concepts"
+
+
+def load() -> Tuple[LegalGraph, Dict[str, str]]:
+    """Load seed concepts and trigger phrases.
+
+    Returns
+    -------
+    Tuple[LegalGraph, Dict[str, str]]
+        The populated :class:`~SensibLaw.graph.models.LegalGraph` and a
+        mapping of trigger phrases to concept identifiers.
+    """
+
+    graph = LegalGraph()
+
+    seeds_file = DATA_DIR / "seeds.json"
+    if seeds_file.exists():
+        with seeds_file.open("r", encoding="utf-8") as fh:
+            seeds = json.load(fh)
+        for concept in seeds.get("concepts", []):
+            graph.add_node(
+                GraphNode(
+                    type=NodeType.CONCEPT,
+                    identifier=concept["id"],
+                    metadata={"label": concept.get("label", "")},
+                )
+            )
+        for rel in seeds.get("relations", []):
+            edge_type = EdgeType[rel["type"]]
+            graph.add_edge(
+                GraphEdge(
+                    type=edge_type,
+                    source=rel["source"],
+                    target=rel["target"],
+                )
+            )
+
+    triggers: Dict[str, str] = {}
+    triggers_dir = DATA_DIR / "triggers"
+    if triggers_dir.exists():
+        for path in triggers_dir.glob("*.json"):
+            with path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            if "id" in data and "phrases" in data:
+                concept_id = data["id"]
+                for phrase in data["phrases"]:
+                    triggers[phrase.lower()] = concept_id
+            else:
+                for phrase, concept_id in data.items():
+                    triggers[str(phrase).lower()] = str(concept_id)
+
+    return graph, triggers
+
+
+GRAPH, TRIGGERS = load()
+
+
+__all__ = ["GRAPH", "TRIGGERS", "load"]

--- a/src/graph/models.py
+++ b/src/graph/models.py
@@ -13,6 +13,7 @@ class NodeType(Enum):
     PROVISION = "provision"
     PERSON = "person"
     EXTRINSIC = "extrinsic"
+    CONCEPT = "concept"
 
 
 class EdgeType(Enum):
@@ -21,6 +22,7 @@ class EdgeType(Enum):
     CITES = "cites"
     REFERENCES = "references"
     RELATED_TO = "related_to"
+    REJECTS = "rejects"
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- add seed concepts and trigger phrase mappings for Terra Nullius, Mabo, and Permanent Stay
- extend graph model with concept nodes and REJECTS edges
- implement loader to ingest seed data and trigger mappings into a LegalGraph at startup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c73a9a4e88322a80cc0b1661f673d