### PR TITLE
Add legal test templates and fixtures

### DIFF
--- a/src/tests/templates.py
+++ b/src/tests/templates.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, List
+import json
 
 
 @dataclass(frozen=True)
@@ -20,25 +22,38 @@ class TestTemplate:
 
     concept_id: str
     name: str
+    threshold: int
     factors: List[Factor]
 
 
-# ---------------------------------------------------------------------------
-# Example templates
-# ---------------------------------------------------------------------------
+def _load_template(path: Path) -> TestTemplate:
+    """Load a :class:`TestTemplate` from a JSON file."""
 
-PERMANENT_STAY_TEST = TestTemplate(
-    concept_id="permanent_stay",
-    name="Permanent Stay Test",
-    factors=[
-        Factor("delay", "Extent and impact of any prosecutorial delay"),
-        Factor("abuse_of_process", "Whether continuation would be an abuse of process"),
-        Factor("fair_trial_possible", "Possibility of a fair trial despite the delay"),
-    ],
-)
+    data = json.loads(path.read_text())
+    return TestTemplate(
+        concept_id=data["concept_id"],
+        name=data["name"],
+        threshold=data["threshold"],
+        factors=[Factor(**f) for f in data.get("factors", [])],
+    )
+
+
+# Directory containing template JSON files
+TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "tests" / "templates"
+
+# Load template definitions from JSON files
+GLJ_PERMANENT_STAY_TEST = _load_template(TEMPLATES_DIR / "glj_permanent_stay.json")
+S4AA_TEMPLATE = _load_template(TEMPLATES_DIR / "au_cth_family_s4AA.json")
+S90SB_TEMPLATE = _load_template(TEMPLATES_DIR / "au_cth_family_s90SB.json")
+S90SM_TEMPLATE = _load_template(TEMPLATES_DIR / "au_cth_family_s90SM.json")
+
+# Backwards compatibility alias
+PERMANENT_STAY_TEST = GLJ_PERMANENT_STAY_TEST
 
 # Registry mapping concept IDs to templates for lookup during evaluation
 TEMPLATE_REGISTRY: Dict[str, TestTemplate] = {
-    PERMANENT_STAY_TEST.concept_id: PERMANENT_STAY_TEST,
+    GLJ_PERMANENT_STAY_TEST.concept_id: GLJ_PERMANENT_STAY_TEST,
+    S4AA_TEMPLATE.concept_id: S4AA_TEMPLATE,
+    S90SB_TEMPLATE.concept_id: S90SB_TEMPLATE,
+    S90SM_TEMPLATE.concept_id: S90SM_TEMPLATE,
 }
-

--- a/tests/fixtures/au_cth_family_s4AA_story.json
+++ b/tests/fixtures/au_cth_family_s4AA_story.json
@@ -1,0 +1,8 @@
+{
+  "template_id": "au:cth:family:s4AA",
+  "facts": {
+    "child_wishes": true,
+    "relationship": false,
+    "safety": true
+  }
+}

--- a/tests/fixtures/au_cth_family_s90SB_story.json
+++ b/tests/fixtures/au_cth_family_s90SB_story.json
@@ -1,0 +1,8 @@
+{
+  "template_id": "au:cth:family:s90SB",
+  "facts": {
+    "signed": true,
+    "independent_advice": true,
+    "statement": false
+  }
+}

--- a/tests/fixtures/au_cth_family_s90SM_story.json
+++ b/tests/fixtures/au_cth_family_s90SM_story.json
@@ -1,0 +1,8 @@
+{
+  "template_id": "au:cth:family:s90SM",
+  "facts": {
+    "fraud": false,
+    "impracticable": true,
+    "public_policy": false
+  }
+}

--- a/tests/fixtures/glj_permanent_stay_story.json
+++ b/tests/fixtures/glj_permanent_stay_story.json
@@ -1,0 +1,8 @@
+{
+  "template_id": "glj:permanent_stay",
+  "facts": {
+    "delay": true,
+    "abuse_of_process": true,
+    "fair_trial_possible": false
+  }
+}

--- a/tests/templates/au_cth_family_s4AA.json
+++ b/tests/templates/au_cth_family_s4AA.json
@@ -1,0 +1,10 @@
+{
+  "concept_id": "au:cth:family:s4AA",
+  "name": "Best Interests of the Child",
+  "threshold": 2,
+  "factors": [
+    {"id": "child_wishes", "description": "Consideration of the child's expressed wishes"},
+    {"id": "relationship", "description": "Nature of the child's relationship with parents"},
+    {"id": "safety", "description": "Need to protect the child from harm"}
+  ]
+}

--- a/tests/templates/au_cth_family_s90SB.json
+++ b/tests/templates/au_cth_family_s90SB.json
@@ -1,0 +1,10 @@
+{
+  "concept_id": "au:cth:family:s90SB",
+  "name": "Binding Financial Agreement Requirements",
+  "threshold": 2,
+  "factors": [
+    {"id": "signed", "description": "Agreement is signed by both parties"},
+    {"id": "independent_advice", "description": "Each party received independent legal advice"},
+    {"id": "statement", "description": "Signed statement from each lawyer"}
+  ]
+}

--- a/tests/templates/au_cth_family_s90SM.json
+++ b/tests/templates/au_cth_family_s90SM.json
@@ -1,0 +1,10 @@
+{
+  "concept_id": "au:cth:family:s90SM",
+  "name": "Setting Aside a Financial Agreement",
+  "threshold": 1,
+  "factors": [
+    {"id": "fraud", "description": "Agreement obtained by fraud"},
+    {"id": "impracticable", "description": "Impracticable for part or all of agreement to be carried out"},
+    {"id": "public_policy", "description": "Circumstances have arisen making it unjust"}
+  ]
+}

--- a/tests/templates/glj_permanent_stay.json
+++ b/tests/templates/glj_permanent_stay.json
@@ -1,0 +1,10 @@
+{
+  "concept_id": "glj:permanent_stay",
+  "name": "GLJ Permanent Stay",
+  "threshold": 2,
+  "factors": [
+    {"id": "delay", "description": "Extent and impact of any prosecutorial delay"},
+    {"id": "abuse_of_process", "description": "Whether continuation would be an abuse of process"},
+    {"id": "fair_trial_possible", "description": "Possibility of a fair trial despite the delay"}
+  ]
+}


### PR DESCRIPTION
## Summary
- Define JSON templates for family law sections s4AA, s90SB, s90SM and GLJ permanent stay
- Load and register templates for evaluator lookup
- Provide fixture stories to exercise new templates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c73b0efd483229699bd935880d06f