### PR TITLE
Add GLJ distinction demo

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,23 @@
+# Examples
+
+## Distinguish GLJ Demo
+
+This demo runs a small pipeline consisting of concept matching, checklist
+evaluation and proof‑tree generation against a sample story. The fixture
+includes a simplified silhouette of the GLJ case and a short story.
+
+### Running the demo
+
+From the repository root execute:
+
+```bash
+python examples/distinguish_glj/demo.py
+```
+
+The script creates `results.json` containing concept matching and checklist
+outputs and `proof_tree.dot` representing the proof tree. To render the proof
+ tree you can use Graphviz:
+
+```bash
+dot -Tpng examples/distinguish_glj/proof_tree.dot -o proof_tree.png
+```

--- a/examples/distinguish_glj/demo.py
+++ b/examples/distinguish_glj/demo.py
@@ -1,0 +1,84 @@
+"""Run concept matching, checklist evaluation and proof-tree generation."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict
+
+# Ensure the src directory is importable when running from repository root
+SRC_DIR = Path(__file__).resolve().parents[2] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from distinguish.engine import (
+    CaseSilhouette,
+    compare_cases,
+    extract_case_silhouette,
+)
+from pipeline import normalise, match_concepts, build_cloud
+from tests.templates import TEMPLATE_REGISTRY
+
+
+def load_base_silhouette(path: Path) -> CaseSilhouette:
+    data = json.loads(path.read_text())
+    return CaseSilhouette(
+        fact_tags=data["fact_tags"],
+        holding_hints=data["holding_hints"],
+        paragraphs=data["paragraphs"],
+    )
+
+
+def evaluate_checklist(tokens: list[str]) -> Dict[str, bool]:
+    template = TEMPLATE_REGISTRY["permanent_stay"]
+    token_set = set(tokens)
+    results: Dict[str, bool] = {}
+    for factor in template.factors:
+        # Very naive matching: factor id split into tokens
+        keywords = factor.id.split("_")
+        results[factor.id] = any(k in token_set for k in keywords)
+    return results
+
+
+def build_proof_tree(evaluation: Dict[str, bool]) -> str:
+    lines = ["digraph ProofTree {", '  concept [label="Permanent Stay"]']
+    template = TEMPLATE_REGISTRY["permanent_stay"]
+    for factor in template.factors:
+        present = evaluation.get(factor.id, False)
+        node_label = f"{factor.description}\\n{'YES' if present else 'NO'}"
+        lines.append(f'  {factor.id} [label="{node_label}"]')
+        lines.append(f'  concept -> {factor.id}')
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    here = Path(__file__).resolve().parent
+    base = load_base_silhouette(here / "glj_silhouette.json")
+
+    story_text = (here / "story.txt").read_text()
+    story_paragraphs = [p.strip() for p in story_text.split(".") if p.strip()]
+    candidate = extract_case_silhouette(story_paragraphs)
+
+    comparison = compare_cases(base, candidate)
+
+    normalised = normalise(story_text)
+    tokens = match_concepts(normalised)
+    cloud = build_cloud(tokens)
+    evaluation = evaluate_checklist(tokens)
+    proof_tree_dot = build_proof_tree(evaluation)
+
+    result = {
+        "concept_cloud": cloud,
+        "comparison": comparison,
+        "evaluation": evaluation,
+    }
+
+    (here / "results.json").write_text(json.dumps(result, indent=2))
+    (here / "proof_tree.dot").write_text(proof_tree_dot)
+    print("Wrote results.json and proof_tree.dot to", here)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/distinguish_glj/glj_silhouette.json
+++ b/examples/distinguish_glj/glj_silhouette.json
@@ -1,0 +1,16 @@
+{
+  "fact_tags": {
+    "GLJ took a radio from a store": 0,
+    "Security stopped GLJ outside": 1,
+    "GLJ said he intended to pay later": 2
+  },
+  "holding_hints": {
+    "Held: intention to pay is a question for the jury": 3
+  },
+  "paragraphs": [
+    "GLJ took a radio from a store.",
+    "Security stopped GLJ outside.",
+    "GLJ said he intended to pay later.",
+    "Held: intention to pay is a question for the jury."
+  ]
+}

--- a/examples/distinguish_glj/story.txt
+++ b/examples/distinguish_glj/story.txt
@@ -1,0 +1,1 @@
+GLJ took a radio from a store but there was a long delay before the case went to court. The defence argued the delay was an abuse of process and that a fair trial was not possible. The court agreed that the intention to pay later was for the jury to assess.


### PR DESCRIPTION
## Summary
- Add `examples` folder with README describing how to run demos.
- Provide `distinguish_glj` sample including GLJ case silhouette, sample story and demonstration script for concept matching, checklist evaluation and proof-tree generation.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c73b484a0832298003d1d4455f71f