### PR TITLE
Add tests for holding and fact token comparison

### DIFF
--- a/src/distinguish/__init__.py
+++ b/src/distinguish/__init__.py
@@ -1,5 +1,15 @@
 """Utilities for case comparison and distinction."""
 
-from .engine import CaseSilhouette, extract_case_silhouette, compare_cases
+from .engine import (
+    CaseSilhouette,
+    extract_case_silhouette,
+    extract_holding_and_facts,
+    compare_cases,
+)
 
-__all__ = ["CaseSilhouette", "extract_case_silhouette", "compare_cases"]
+__all__ = [
+    "CaseSilhouette",
+    "extract_case_silhouette",
+    "extract_holding_and_facts",
+    "compare_cases",
+]

--- a/tests/distinguish/test_extract_holding_and_compare_tokens.py
+++ b/tests/distinguish/test_extract_holding_and_compare_tokens.py
@@ -1,0 +1,29 @@
+from src.distinguish.engine import (
+    extract_holding_and_facts,
+    extract_case_silhouette,
+    compare_cases,
+)
+
+
+def test_extract_holding_and_facts():
+    paragraphs = [
+        "Fact alpha",
+        "Fact beta",
+        "Fact gamma",
+        "Held: something",
+        "Other text",
+    ]
+    holdings, facts = extract_holding_and_facts(paragraphs)
+    assert holdings == {"Held: something"}
+    assert facts == {"Fact alpha", "Fact beta", "Fact gamma"}
+
+
+def test_compare_cases_token_sets():
+    base_paras = ["Fact A", "Common fact"]
+    cand_paras = ["Common fact", "Fact B"]
+    base = extract_case_silhouette(base_paras)
+    cand = extract_case_silhouette(cand_paras)
+    result = compare_cases(base, cand)
+    assert result["overlap_tokens"] == ["Common fact"]
+    assert result["a_only_tokens"] == ["Fact A"]
+    assert result["b_only_tokens"] == ["Fact B"]


### PR DESCRIPTION
## Summary
- expose `extract_holding_and_facts` for simple retrieval of holding hints and fact tags
- augment `compare_cases` to report overlap and exclusive fact tokens
- test holding extraction and token comparison between cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c751186e483228360aa2c0f1559d3