### PR TITLE
Add checklist evaluator and tests CLI

### DIFF
--- a/src/tests/evaluator.py
+++ b/src/tests/evaluator.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Evaluation utilities for declarative concept tests."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping
+
+from .templates import Factor, TestTemplate
+
+
+@dataclass
+class FactorResult:
+    """Result for a single factor in a test."""
+
+    factor: Factor
+    status: str
+    evidence: List[str]
+
+
+@dataclass
+class Evaluation:
+    """Full evaluation output for a concept."""
+
+    template: TestTemplate
+    results: List[FactorResult]
+
+
+# ---------------------------------------------------------------------------
+# Template loading
+# ---------------------------------------------------------------------------
+
+def load_templates(path: Path | str) -> Dict[str, TestTemplate]:
+    """Load test templates from a JSON file.
+
+    The JSON structure is expected to be a list of templates, where each template
+    has ``concept_id``, ``name`` and ``factors`` (list of ``{"id", "description"}``).
+    """
+
+    data = json.loads(Path(path).read_text())
+    templates: Dict[str, TestTemplate] = {}
+    for tmpl in data:
+        factors = [Factor(**f) for f in tmpl.get("factors", [])]
+        templates[tmpl["concept_id"]] = TestTemplate(
+            concept_id=tmpl["concept_id"],
+            name=tmpl.get("name", tmpl["concept_id"]),
+            factors=factors,
+        )
+    return templates
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+def _determine_status(records: Iterable[Mapping[str, object]]) -> str:
+    statuses = [rec.get("met") for rec in records if "met" in rec]
+    if True in statuses:
+        return "met"
+    if False in statuses:
+        return "not_met"
+    return "unknown"
+
+
+def evaluate(*, concept_id: str, story_path: Path | str, templates_path: Path | str) -> Evaluation:
+    """Evaluate a story against the specified concept template."""
+
+    templates = load_templates(templates_path)
+    if concept_id not in templates:
+        raise KeyError(f"Unknown concept_id: {concept_id}")
+    template = templates[concept_id]
+
+    story = json.loads(Path(story_path).read_text())
+    facts = story.get("facts", [])
+
+    results: List[FactorResult] = []
+    for factor in template.factors:
+        relevant = [f for f in facts if f.get("factor") == factor.id]
+        status = _determine_status(relevant)
+        evidence = [f.get("evidence", "") for f in relevant if f.get("evidence")]
+        results.append(FactorResult(factor=factor, status=status, evidence=evidence))
+
+    return Evaluation(template=template, results=results)
+
+
+__all__ = ["FactorResult", "Evaluation", "load_templates", "evaluate"]
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,12 @@ def run_cli(db_path: str, *args: str) -> str:
     return completed.stdout.strip()
 
 
+def run_tests_cli(*args: str) -> str:
+    cmd = ["python", "-m", "src.cli", "tests", "run", *args]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return completed.stdout.strip()
+
+
 def test_cli_as_at(tmp_path: Path):
     db_path, doc_id = setup_db(tmp_path)
     out = run_cli(db_path, "--id", str(doc_id), "--as-at", "2020-06-01")
@@ -45,3 +51,49 @@ def test_cli_as_at(tmp_path: Path):
     out2 = run_cli(db_path, "--id", str(doc_id), "--as-at", "2021-06-01")
     data2 = json.loads(out2)
     assert data2["body"] == "new"
+
+
+def test_tests_run(tmp_path: Path):
+    templates = [
+        {
+            "concept_id": "permanent_stay",
+            "name": "Permanent Stay Test",
+            "factors": [
+                {"id": "delay", "description": "Extent and impact of any prosecutorial delay"},
+                {
+                    "id": "abuse_of_process",
+                    "description": "Whether continuation would be an abuse of process",
+                },
+                {
+                    "id": "fair_trial_possible",
+                    "description": "Possibility of a fair trial despite the delay",
+                },
+            ],
+        }
+    ]
+    tmpl_path = tmp_path / "templates.json"
+    tmpl_path.write_text(json.dumps(templates))
+
+    story = {
+        "concept_id": "permanent_stay",
+        "facts": [
+            {"factor": "delay", "met": True, "evidence": "para 1"},
+            {"factor": "abuse_of_process", "met": False, "evidence": "para 2"},
+        ],
+    }
+    story_path = tmp_path / "story.json"
+    story_path.write_text(json.dumps(story))
+
+    out = run_tests_cli(
+        "--templates",
+        str(tmpl_path),
+        "--story",
+        str(story_path),
+        "--concept",
+        "permanent_stay",
+    )
+
+    # Ensure the output lists each factor with the correct status
+    assert "delay" in out and "met" in out
+    assert "abuse_of_process" in out and "not_met" in out
+    assert "fair_trial_possible" in out and "unknown" in out


### PR DESCRIPTION
## Summary
- Add evaluator for legal concept checklists to compute factor statuses from stories
- Extend CLI with `tests run` command to evaluate stories and display a results table
- Provide end-to-end tests for the new CLI command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c751bfecc832284d1b61cae09a529