### PR TITLE
Parse definitions and citations from FRL sections

### DIFF
--- a/tests/ingestion/test_frl_relations.py
+++ b/tests/ingestion/test_frl_relations.py
@@ -1,0 +1,32 @@
+from src.ingestion.frl import fetch_acts
+
+
+def test_fetch_acts_extracts_definitions_and_citations():
+    data = {
+        "results": [
+            {
+                "id": "Act1",
+                "title": "Sample Act",
+                "sections": [
+                    {
+                        "number": "1",
+                        "title": "Definitions",
+                        "body": '"Dog" means a domesticated animal.',
+                    },
+                    {
+                        "number": "2",
+                        "title": "Care",
+                        "body": "A person must care for their dog. See section 1.",
+                    },
+                ],
+            }
+        ]
+    }
+
+    nodes, edges = fetch_acts("http://example", data=data)
+
+    defines_edges = [e for e in edges if e["type"] == "defines"]
+    cites_edges = [e for e in edges if e["type"] == "cites"]
+
+    assert {"from": "Act1:1", "to": "Act1:2", "type": "defines", "text": "dog"} in defines_edges
+    assert {"from": "Act1:2", "to": "Act1:1", "type": "cites", "text": "section 1"} in cites_edges


### PR DESCRIPTION
## Summary
- Parse section bodies from FRL data to extract defined terms and cross-references
- Emit `defines` and `cites` edges between provisions including source text snippets
- Add regression tests for FRL edge extraction

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c7a5bffe0832298ef2604b435b756