### PR TITLE
Remove sys.path hacks in tests

### DIFF
--- a/tests/austlii/test_parsing.py
+++ b/tests/austlii/test_parsing.py
@@ -1,11 +1,8 @@
 import json
 from types import SimpleNamespace
-from pathlib import Path
-import sys
 
 import pytest
 
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 from src import austlii_client
 
 

--- a/tests/models/test_document_serialization.py
+++ b/tests/models/test_document_serialization.py
@@ -1,9 +1,5 @@
 from datetime import date, datetime
-from pathlib import Path
 import json
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from src.models.document import Document, DocumentMetadata
 from src.models.provision import Provision

--- a/tests/policy/test_engine.py
+++ b/tests/policy/test_engine.py
@@ -1,8 +1,4 @@
 import json
-import sys
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from src.policy.engine import CulturalFlags, PolicyEngine
 from src.graph import GraphNode, NodeType

--- a/tests/rules/test_rules.py
+++ b/tests/rules/test_rules.py
@@ -1,9 +1,5 @@
 import json
 import subprocess
-import sys
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from src.rules.extractor import extract_rules
 from src.rules.reasoner import check_rules

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,9 +2,6 @@ import json
 import subprocess
 from datetime import date, datetime
 from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from src.models.document import Document, DocumentMetadata
 from src.storage import VersionedStore

--- a/tests/test_versioned_store.py
+++ b/tests/test_versioned_store.py
@@ -1,8 +1,5 @@
 from datetime import date, datetime
 from pathlib import Path
-import sys
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from src.models.document import Document, DocumentMetadata
 from src.storage import VersionedStore


### PR DESCRIPTION
## Summary
- drop manual sys.path hacks and import the installed package in test modules

## Testing
- `pip install -e .[test]` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c7b2b9d308322ab9af4e1fa3ea9d3