### PR TITLE
Add case node type and legal edge relationships

### DIFF
--- a/docs/graph.md
+++ b/docs/graph.md
@@ -7,12 +7,16 @@ and typed with enumerations for clarity.
 ## Node and Edge Types
 
 `NodeType` and `EdgeType` enumerate the supported entities and relationships.
-These can be extended as the project grows.
+`NodeType` now includes a `CASE` variant for judicial decisions, while
+`EdgeType` offers additional relationships such as `FOLLOWS`, `APPLIES`,
+`CONSIDERS`, `DISTINGUISHES` and `OVERRULES`. These can be extended as the
+project grows.
 
 ## Creating Nodes and Edges
 
 ```python
 from graph import (
+    CaseNode,
     GraphNode,
     GraphEdge,
     LegalGraph,
@@ -24,12 +28,13 @@ from datetime import date
 # Create a new graph
 lg = LegalGraph()
 
-# Add two document nodes
-case = GraphNode(
-    type=NodeType.DOCUMENT,
+# Add a case and a statute
+case = CaseNode(
     identifier="case-1",
     metadata={"title": "Example Case"},
     date=date(2020, 1, 1),
+    court_rank=2,
+    panel_size=3,
 )
 statute = GraphNode(type=NodeType.DOCUMENT, identifier="statute-1")
 lg.add_node(case)
@@ -37,7 +42,7 @@ lg.add_node(statute)
 
 # Connect the nodes with a citation edge
 edge = GraphEdge(
-    type=EdgeType.CITES,
+    type=EdgeType.APPLIES,
     source=case.identifier,
     target=statute.identifier,
     weight=1.0,

--- a/src/graph/__init__.py
+++ b/src/graph/__init__.py
@@ -1,13 +1,22 @@
 """Graph utilities for representing relationships between legal entities."""
 
 from .ingest import compute_weight, ingest_extrinsic
-from .models import EdgeType, ExtrinsicNode, GraphEdge, GraphNode, LegalGraph, NodeType
+from .models import (
+    CaseNode,
+    EdgeType,
+    ExtrinsicNode,
+    GraphEdge,
+    GraphNode,
+    LegalGraph,
+    NodeType,
+)
 
 __all__ = [
     "EdgeType",
     "GraphEdge",
     "GraphNode",
     "ExtrinsicNode",
+    "CaseNode",
     "LegalGraph",
     "NodeType",
     "ingest_extrinsic",

--- a/src/graph/models.py
+++ b/src/graph/models.py
@@ -14,6 +14,7 @@ class NodeType(Enum):
     PERSON = "person"
     EXTRINSIC = "extrinsic"
     CONCEPT = "concept"
+    CASE = "case"
 
 
 class EdgeType(Enum):
@@ -23,6 +24,11 @@ class EdgeType(Enum):
     REFERENCES = "references"
     RELATED_TO = "related_to"
     REJECTS = "rejects"
+    FOLLOWS = "follows"
+    APPLIES = "applies"
+    CONSIDERS = "considers"
+    DISTINGUISHES = "distinguishes"
+    OVERRULES = "overrules"
 
 
 @dataclass
@@ -60,6 +66,15 @@ class ExtrinsicNode(GraphNode):
 
     role: str = ""
     stage: str = ""
+
+
+@dataclass(kw_only=True)
+class CaseNode(GraphNode):
+    """Node representing a judicial decision."""
+
+    court_rank: int
+    panel_size: Optional[int] = None
+    type: NodeType = field(default=NodeType.CASE, init=False)
 
 
 @dataclass
@@ -125,6 +140,7 @@ __all__ = [
     "EdgeType",
     "GraphNode",
     "ExtrinsicNode",
+    "CaseNode",
     "GraphEdge",
     "LegalGraph",
 ]

--- a/tests/graph/test_case_node.py
+++ b/tests/graph/test_case_node.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+from src.graph import CaseNode, EdgeType, GraphEdge, LegalGraph, NodeType
+
+
+def test_case_node_and_edges():
+    graph = LegalGraph()
+    c1 = CaseNode(identifier="case-1", court_rank=1)
+    c2 = CaseNode(identifier="case-2", court_rank=2, panel_size=5)
+    graph.add_node(c1)
+    graph.add_node(c2)
+
+    edge = GraphEdge(
+        type=EdgeType.FOLLOWS,
+        source=c2.identifier,
+        target=c1.identifier,
+    )
+    graph.add_edge(edge)
+
+    assert c1.type == NodeType.CASE
+    matches = graph.find_edges(
+        source=c2.identifier, target=c1.identifier, type=EdgeType.FOLLOWS
+    )
+    assert matches == [edge]
+


### PR DESCRIPTION
## Summary
- add `NodeType.CASE` with accompanying `CaseNode` dataclass including `court_rank` and optional `panel_size`
- expand `EdgeType` with `FOLLOWS`, `APPLIES`, `CONSIDERS`, `DISTINGUISHES`, and `OVERRULES`
- document and test case nodes and new edge relationships

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c7be026b88322ab31a0c631eb17e4