### PR TITLE
Add token bucket HTTP cache with conditional revalidation

### DIFF
--- a/data/frl_manifest.json
+++ b/data/frl_manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "Federal Register of Legislation",
+  "base_url": "https://www.legislation.gov.au/",
+  "sample": "https://www.legislation.gov.au/federalregister.json"
+}
+

--- a/data/hca_manifest.json
+++ b/data/hca_manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "High Court of Australia Judgments",
+  "base_url": "https://eresources.hcourt.gov.au/",
+  "sample": "https://eresources.hcourt.gov.au/showbyYear.php?year=2023"
+}
+

--- a/src/ingestion/cache.py
+++ b/src/ingestion/cache.py
@@ -1,85 +1,195 @@
+"""HTTP caching utilities with per-host rate limiting.
+
+This module provides small helper functions for fetching web resources while
+respecting a polite request rate. Responses are stored on disk keyed by the
+SHA256 digest of their body which allows de-duplication of identical content.
+Each URL additionally has a metadata file recording the ``ETag`` and
+``Last-Modified`` headers returned by the server. Subsequent requests use
+``If-None-Match`` and ``If-Modified-Since`` so that servers may respond with
+``304 Not Modified``.
+
+Network requests are throttled via a token bucket implementation allowing no
+more than 30 requests per minute to any single host. This keeps the project
+polite when it needs to talk to real services but still remains deterministic
+for tests.
+"""
+
 from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import threading
 import time
 from pathlib import Path
 from typing import Dict, Any
+from urllib.error import HTTPError
 from urllib.parse import urlparse
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
+
+# ---------------------------------------------------------------------------
+# Cache directories
+# ---------------------------------------------------------------------------
 
 # Root directory for cached responses.  By default this lives inside the
 # repository's ``data`` folder but can be overridden via the
 # ``SENSIBLAW_CACHE`` environment variable.
-CACHE_DIR = Path(os.environ.get("SENSIBLAW_CACHE", Path(__file__).resolve().parents[2] / "data" / "cache"))
+CACHE_DIR = Path(
+    os.environ.get(
+        "SENSIBLAW_CACHE", Path(__file__).resolve().parents[2] / "data" / "cache"
+    )
+)
 
-# Ensure the cache directory exists so tests can pre-populate entries.
-CACHE_DIR.mkdir(parents=True, exist_ok=True)
+# Store metadata separate from the response bodies.  ``objects`` holds files
+# named by the SHA256 digest of their content while ``meta`` maps each URL to
+# the digest and any caching headers.
+_OBJECT_DIR = CACHE_DIR / "objects"
+_META_DIR = CACHE_DIR / "meta"
+for _d in (_OBJECT_DIR, _META_DIR):
+    _d.mkdir(parents=True, exist_ok=True)
 
-# Simple per-host rate limiting.  A one second delay is enforced between
-# network requests to the same host.  This keeps the kata polite when it needs
-# to talk to real services but still remains deterministic for tests.
-_RATE_LIMIT_SECONDS = 1.0
-_last_request: Dict[str, float] = {}
+
+# ---------------------------------------------------------------------------
+# Token bucket rate limiting
+# ---------------------------------------------------------------------------
+
+_REQUESTS_PER_MINUTE = 30
+_REFILL_RATE = _REQUESTS_PER_MINUTE / 60.0  # tokens per second
+_CAPACITY = _REQUESTS_PER_MINUTE
+
+
+class _TokenBucket:
+    """Simple token bucket for throttling requests per host."""
+
+    def __init__(self) -> None:
+        self.tokens = float(_CAPACITY)
+        self.timestamp = time.monotonic()
+
+    def consume(self, tokens: float = 1.0) -> None:
+        while True:
+            with _lock:
+                now = time.monotonic()
+                elapsed = now - self.timestamp
+                # Refill tokens based on time passed since last check
+                self.tokens = min(_CAPACITY, self.tokens + elapsed * _REFILL_RATE)
+                if self.tokens >= tokens:
+                    self.tokens -= tokens
+                    self.timestamp = now
+                    return
+                # Not enough tokens; calculate wait time outside the lock
+                need = tokens - self.tokens
+                wait = need / _REFILL_RATE
+            time.sleep(wait)
+
+
+_buckets: Dict[str, _TokenBucket] = {}
 _lock = threading.Lock()
 
 
-def _cache_path(url: str, suffix: str) -> Path:
-    """Return the on-disk path for ``url`` with file extension ``suffix``."""
+def _get_bucket(host: str) -> _TokenBucket:
+    with _lock:
+        bucket = _buckets.get(host)
+        if bucket is None:
+            bucket = _TokenBucket()
+            _buckets[host] = bucket
+        return bucket
+
+
+# ---------------------------------------------------------------------------
+# Helpers for file paths
+# ---------------------------------------------------------------------------
+
+
+def _meta_path(url: str) -> Path:
+    """Return the on-disk path for ``url``'s metadata file."""
 
     digest = hashlib.sha256(url.encode("utf-8")).hexdigest()
-    return CACHE_DIR / f"{digest}.{suffix}"
+    return _META_DIR / f"{digest}.json"
 
 
-def _throttle(host: str) -> None:
-    """Sleep if necessary to respect the per-host rate limit."""
+def _body_path(digest: str) -> Path:
+    """Return the path for a cached response body."""
 
-    with _lock:
-        now = time.time()
-        last = _last_request.get(host, 0.0)
-        wait = _RATE_LIMIT_SECONDS - (now - last)
-        if wait > 0:
-            time.sleep(wait)
-        _last_request[host] = time.time()
+    return _OBJECT_DIR / digest
 
 
-def _fetch(url: str, *, suffix: str) -> bytes:
-    """Fetch ``url`` obeying cache and rate limits."""
+# ---------------------------------------------------------------------------
+# Fetching logic with cache revalidation
+# ---------------------------------------------------------------------------
 
-    path = _cache_path(url, suffix)
-    if path.exists():
-        return path.read_bytes()
+
+logger = logging.getLogger(__name__)
+
+
+def _fetch(url: str) -> bytes:
+    """Fetch ``url`` obeying cache, conditional requests and rate limits."""
+
+    meta_path = _meta_path(url)
+    headers: Dict[str, str] = {}
+    meta: Dict[str, Any] = {}
+
+    if meta_path.exists():
+        meta = json.loads(meta_path.read_text())
+        if etag := meta.get("etag"):
+            headers["If-None-Match"] = etag
+        if last_mod := meta.get("last_modified"):
+            headers["If-Modified-Since"] = last_mod
 
     host = urlparse(url).netloc
-    _throttle(host)
+    _get_bucket(host).consume()
 
-    with urlopen(url) as resp:  # pragma: no cover - network
-        data = resp.read()
+    request = Request(url, headers=headers)
 
-    path.write_bytes(data)
-    return data
+    try:
+        with urlopen(request) as resp:  # pragma: no cover - network
+            data = resp.read()
+            etag = resp.headers.get("ETag")
+            last_mod = resp.headers.get("Last-Modified")
+
+        digest = hashlib.sha256(data).hexdigest()
+        body_path = _body_path(digest)
+        if not body_path.exists():
+            body_path.write_bytes(data)
+
+        meta_path.write_text(
+            json.dumps({"etag": etag, "last_modified": last_mod, "digest": digest})
+        )
+        return data
+
+    except HTTPError as exc:  # pragma: no cover - network
+        if exc.code == 304 and meta:
+            logger.info("304 Not Modified: %s", url)
+            digest = meta.get("digest")
+            if digest:
+                return _body_path(digest).read_bytes()
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 def fetch_html(url: str) -> str:
     """Return HTML text from ``url`` using the cache."""
 
-    data = _fetch(url, suffix="html")
+    data = _fetch(url)
     return data.decode("utf-8", errors="ignore")
 
 
 def fetch_pdf(url: str) -> bytes:
     """Return PDF bytes from ``url`` using the cache."""
 
-    return _fetch(url, suffix="pdf")
+    return _fetch(url)
 
 
 def fetch_json(url: str) -> Dict[str, Any]:
     """Return parsed JSON from ``url`` using the cache."""
 
-    data = _fetch(url, suffix="json")
+    data = _fetch(url)
     return json.loads(data.decode("utf-8"))
 
 
 __all__ = ["fetch_html", "fetch_pdf", "fetch_json", "CACHE_DIR"]
+

--- a/tests/ingestion/test_cache.py
+++ b/tests/ingestion/test_cache.py
@@ -1,0 +1,71 @@
+import hashlib
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from email.utils import formatdate
+
+import importlib
+import json
+import logging
+import sys
+
+
+def _start_server(body: bytes) -> tuple[HTTPServer, str]:
+    etag = hashlib.sha256(body).hexdigest()
+    last_mod = formatdate(usegmt=True)
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 (method name from BaseHTTPRequestHandler)
+            if (
+                self.headers.get("If-None-Match") == etag
+                or self.headers.get("If-Modified-Since") == last_mod
+            ):
+                self.send_response(304)
+                self.end_headers()
+            else:
+                self.send_response(200)
+                self.send_header("ETag", etag)
+                self.send_header("Last-Modified", last_mod)
+                self.end_headers()
+                self.wfile.write(body)
+
+        def log_message(self, format, *args):  # pragma: no cover - silence
+            pass
+
+    server = HTTPServer(("localhost", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://localhost:{server.server_port}/"
+    return server, url
+
+
+def test_cache_revalidation(tmp_path, monkeypatch, caplog):
+    # Use a temporary cache directory
+    monkeypatch.setenv("SENSIBLAW_CACHE", str(tmp_path))
+    # Ensure the repository root is on ``sys.path`` then import and reload the
+    # cache module so it picks up the temporary path.
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    cache = importlib.import_module("src.ingestion.cache")
+    importlib.reload(cache)
+
+    body = b"hello world"
+    server, url = _start_server(body)
+
+    with caplog.at_level(logging.INFO):
+        first = cache.fetch_html(url)
+        second = cache.fetch_html(url)
+
+    server.shutdown()
+
+    assert first == second == body.decode("utf-8")
+    # Ensure the cache logged the 304 response on the second request
+    assert any("304 Not Modified" in r.message for r in caplog.records)
+
+
+def test_source_manifests_exist():
+    base = Path("data")
+    frl = json.loads((base / "frl_manifest.json").read_text())
+    hca = json.loads((base / "hca_manifest.json").read_text())
+    assert frl["base_url"].startswith("https://")
+    assert hca["base_url"].startswith("https://")
+


### PR DESCRIPTION
## Summary
- implement token-bucket fetcher limiting hosts to 30 req/min
- cache responses by SHA256 and revalidate using ETag/Last-Modified
- add FRL and HCA source manifests and tests exercising 304 caching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c7b72f3d883228ee42d910714d656