### PR TITLE
Add loader and story comparison for distinguishing cases

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -34,16 +34,18 @@ def main() -> None:
     )
 
     dist_parser = sub.add_parser(
-        "distinguish", help="Compare two cases and show reasoning"
+        "distinguish", help="Compare a story against a case silhouette"
     )
     dist_parser.add_argument(
-        "--base", type=Path, required=True, help="Base case paragraphs as JSON"
+        "--case",
+        required=True,
+        help="Neutral citation identifying the base case",
     )
     dist_parser.add_argument(
-        "--candidate",
+        "--story",
         type=Path,
         required=True,
-        help="Candidate case paragraphs as JSON",
+        help="Path to a fact-tagged story JSON file",
     )
 
     query_parser = sub.add_parser(
@@ -112,16 +114,13 @@ def main() -> None:
         )
         print(doc.to_json())
     elif args.command == "distinguish":
-        from .distinguish.engine import (
-            compare_cases,
-            extract_case_silhouette,
-        )
+        from .distinguish.loader import load_case_silhouette
+        from .distinguish.engine import compare_story_to_case
 
-        base_paras = json.loads(args.base.read_text())
-        cand_paras = json.loads(args.candidate.read_text())
-        base = extract_case_silhouette(base_paras)
-        cand = extract_case_silhouette(cand_paras)
-        result = compare_cases(base, cand)
+        case_sil = load_case_silhouette(args.case)
+        story_data = json.loads(args.story.read_text())
+        story_tags = story_data.get("facts", {})
+        result = compare_story_to_case(story_tags, case_sil)
         print(json.dumps(result))
     elif args.command == "query":
         from .pipeline import build_cloud, match_concepts, normalise

--- a/src/distinguish/__init__.py
+++ b/src/distinguish/__init__.py
@@ -5,11 +5,15 @@ from .engine import (
     extract_case_silhouette,
     extract_holding_and_facts,
     compare_cases,
+    compare_story_to_case,
 )
+from .loader import load_case_silhouette
 
 __all__ = [
     "CaseSilhouette",
     "extract_case_silhouette",
     "extract_holding_and_facts",
     "compare_cases",
+    "compare_story_to_case",
+    "load_case_silhouette",
 ]

--- a/src/distinguish/factors.py
+++ b/src/distinguish/factors.py
@@ -1,0 +1,22 @@
+"""Factor cue definitions for distinguishing cases.
+
+Currently contains minimal heuristics for the GLJ permanent stay example.
+Each factor ID maps to a regular expression that is searched for within
+case paragraphs when comparing a story against a base case.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+# Mapping of factor identifiers to regular expression patterns (case-insensitive).
+GLJ_PERMANENT_STAY_CUES: Dict[str, str] = {
+    # Extent and impact of any prosecutorial delay
+    "delay": r"delay",
+    # Prejudice resulting from the delay
+    "prejudice": r"prejudice",
+    # References to evidence being lost or unavailable
+    "lost_evidence": r"lost\s+evidence|evidence\s+.*lost",
+    # Indicators that continuing would be an abuse of process
+    "abuse_indicators": r"abuse",
+}

--- a/src/distinguish/loader.py
+++ b/src/distinguish/loader.py
@@ -1,0 +1,37 @@
+"""Helpers for retrieving case silhouettes for distinction exercises."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .engine import CaseSilhouette
+
+# Base directory of examples used in tests.  In a fuller system this would be
+# replaced by a database or ingestion pipeline.
+_EXAMPLE_DIR = Path(__file__).resolve().parents[2] / "examples" / "distinguish_glj"
+
+# Mapping of neutral citations (case-insensitive) to silhouette files.
+_CITATION_MAP = {
+    "glj": _EXAMPLE_DIR / "glj_silhouette.json",
+}
+
+
+def load_case_silhouette(citation: str) -> CaseSilhouette:
+    """Return the :class:`CaseSilhouette` for ``citation``.
+
+    The current implementation is intentionally simple and only looks up a
+    small set of example data shipped with the repository.  A ``KeyError`` is
+    raised if the citation is unknown.
+    """
+
+    path = _CITATION_MAP.get(citation.lower())
+    if path is None or not path.exists():
+        raise KeyError(f"Unknown case citation: {citation}")
+
+    data = json.loads(path.read_text())
+    return CaseSilhouette(
+        fact_tags=data.get("fact_tags", {}),
+        holding_hints=data.get("holding_hints", {}),
+        paragraphs=data.get("paragraphs", []),
+    )

--- a/tests/distinguish/test_distinguish_engine.py
+++ b/tests/distinguish/test_distinguish_engine.py
@@ -1,4 +1,9 @@
-from src.distinguish.engine import compare_cases, extract_case_silhouette
+from src.distinguish.engine import (
+    CaseSilhouette,
+    compare_cases,
+    compare_story_to_case,
+    extract_case_silhouette,
+)
 
 
 def test_extract_case_silhouette():
@@ -32,3 +37,21 @@ def test_compare_cases_overlap_and_missing():
     assert "Held: yes" in texts
     missing_texts = [m["text"] for m in result["missing"]]
     assert "Base fact" in missing_texts
+
+
+def test_compare_story_to_case_overlap_and_missing():
+    case = CaseSilhouette(
+        fact_tags={},
+        holding_hints={},
+        paragraphs=[
+            "There was a significant delay before trial.",
+            "Some evidence was lost causing prejudice to the defence.",
+        ],
+    )
+    story_tags = {"delay": True, "abuse_indicators": True, "lost_evidence": True}
+    result = compare_story_to_case(story_tags, case)
+    overlap_ids = {o["id"] for o in result["overlaps"]}
+    missing_ids = {m["id"] for m in result["missing"]}
+    assert "delay" in overlap_ids
+    assert "lost_evidence" in overlap_ids
+    assert "abuse_indicators" in missing_ids

--- a/tests/test_distinguish_cli.py
+++ b/tests/test_distinguish_cli.py
@@ -3,27 +3,20 @@ import subprocess
 from pathlib import Path
 
 
-def test_cli_distinguish(tmp_path: Path):
-    base = ["base fact", "Held: yes"]
-    candidate = ["other fact", "Held: yes"]
-    base_file = tmp_path / "base.json"
-    cand_file = tmp_path / "cand.json"
-    base_file.write_text(json.dumps(base))
-    cand_file.write_text(json.dumps(candidate))
-
+def test_cli_distinguish():
+    story_path = Path("tests/fixtures/glj_permanent_stay_story.json")
     cmd = [
         "python",
         "-m",
         "src.cli",
         "distinguish",
-        "--base",
-        str(base_file),
-        "--candidate",
-        str(cand_file),
+        "--case",
+        "glj",
+        "--story",
+        str(story_path),
     ]
     completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
     data = json.loads(completed.stdout)
-    texts = [o["text"] for o in data["overlaps"]]
-    assert "Held: yes" in texts
-    missing = [m["text"] for m in data["missing"]]
-    assert "base fact" in missing
+    assert "overlaps" in data
+    missing_ids = {m["id"] for m in data["missing"]}
+    assert "delay" in missing_ids


### PR DESCRIPTION
## Summary
- allow `sensiblaw distinguish` to compare a fact-tagged story with a known case silhouette
- load case silhouettes by neutral citation and provide cue-based factor matching
- expose `compare_story_to_case` and factor regex cues for GLJ permanent stay examples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c7c52e0208322a9a7918c1b465a3c