### PR TITLE
feat: add GLJ story comparison demo

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,9 +2,8 @@
 
 ## Distinguish GLJ Demo
 
-This demo runs a small pipeline consisting of concept matching, checklist
-evaluation and proof‑tree generation against a sample story. The fixture
-includes a simplified silhouette of the GLJ case and a short story.
+This demo compares a short story to a simplified silhouette of the GLJ case
+using the `compare_story_to_case` helper.
 
 ### Running the demo
 
@@ -14,9 +13,13 @@ From the repository root execute:
 python examples/distinguish_glj/demo.py
 ```
 
-The script creates `results.json` containing concept matching and checklist
-outputs and `proof_tree.dot` representing the proof tree. To render the proof
- tree you can use Graphviz:
+The script loads `glj_silhouette.json` and `story.json`, compares them and
+prints overlaps and differences with paragraph citations.
+
+### Visualising results
+
+The textual output can be further processed or visualised. For example, proof
+structures can be exported to Graphviz DOT format and rendered:
 
 ```bash
 dot -Tpng examples/distinguish_glj/proof_tree.dot -o proof_tree.png

--- a/examples/distinguish_glj/story.json
+++ b/examples/distinguish_glj/story.json
@@ -1,0 +1,5 @@
+[
+  "GLJ took a radio from a store but there was a long delay before the case went to court.",
+  "The defence argued the delay was an abuse of process and that a fair trial was not possible.",
+  "The court agreed that the intention to pay later was for the jury to assess."
+]


### PR DESCRIPTION
## Summary
- replace GLJ demo with script comparing a story JSON to the GLJ silhouette via `compare_story_to_case`
- document running the demo and visualising results in examples README
- add JSON story fixture for demo inputs

## Testing
- `pytest`
- `python examples/distinguish_glj/demo.py`


------
https://chatgpt.com/codex/tasks/task_e_689c7c72188c8322888a417f980ce839