### PR TITLE
Add reproducibility ledger and CLI

### DIFF
--- a/data/corrections.csv
+++ b/data/corrections.csv
@@ -1,0 +1,1 @@
+date,description,author

--- a/src/repro/ledger.py
+++ b/src/repro/ledger.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+import csv
+import os
+from typing import List, Optional
+
+
+@dataclass
+class CorrectionEntry:
+    date: str
+    description: str
+    author: str
+
+
+DEFAULT_LEDGER_PATH = (
+    Path(__file__).resolve().parents[2] / "data" / "corrections.csv"
+)
+
+
+def _resolve_path(path: Optional[Path] = None) -> Path:
+    """Resolve ledger file path, optionally overridden via env var."""
+    if path is not None:
+        return Path(path)
+    env_path = os.getenv("SENSIBLAW_CORRECTIONS_FILE")
+    if env_path:
+        return Path(env_path)
+    return DEFAULT_LEDGER_PATH
+
+
+class CorrectionLedger:
+    """Append-only ledger for corrections."""
+
+    def __init__(self, path: Optional[Path] = None):
+        self.path = _resolve_path(path)
+
+    def append(self, description: str, author: str, date: Optional[str] = None) -> CorrectionEntry:
+        entry = CorrectionEntry(
+            date=date or datetime.utcnow().date().isoformat(),
+            description=description,
+            author=author,
+        )
+        is_new = not self.path.exists()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", newline="") as f:
+            writer = csv.writer(f)
+            if is_new:
+                writer.writerow(["date", "description", "author"])
+            writer.writerow([entry.date, entry.description, entry.author])
+        return entry
+
+    def list_entries(self) -> List[CorrectionEntry]:
+        if not self.path.exists():
+            return []
+        with self.path.open() as f:
+            reader = csv.DictReader(f)
+            return [CorrectionEntry(**row) for row in reader]
+
+    def to_dicts(self) -> List[dict]:
+        return [asdict(e) for e in self.list_entries()]

--- a/tests/test_repro_cli.py
+++ b/tests/test_repro_cli.py
@@ -1,0 +1,27 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def run_repro(tmp_path: Path, *args: str) -> str:
+    env = os.environ.copy()
+    ledger = tmp_path / "ledger.csv"
+    env["SENSIBLAW_CORRECTIONS_FILE"] = str(ledger)
+    env["USER"] = "tester"
+    cmd = ["python", "-m", "src.cli", "repro", *args]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True, env=env)
+    return completed.stdout.strip()
+
+
+def test_log_and_list(tmp_path: Path):
+    issue = tmp_path / "issue.txt"
+    issue.write_text("Something is wrong")
+    out = run_repro(tmp_path, "log-correction", "--file", str(issue))
+    data = json.loads(out)
+    assert data["description"] == "Something is wrong"
+    assert data["author"] == "tester"
+    out2 = run_repro(tmp_path, "list-corrections")
+    entries = json.loads(out2)
+    assert len(entries) == 1
+    assert entries[0]["description"] == "Something is wrong"

--- a/tests/test_repro_ledger.py
+++ b/tests/test_repro_ledger.py
@@ -1,0 +1,13 @@
+from src.repro.ledger import CorrectionLedger
+
+
+def test_append_and_list(tmp_path):
+    ledger_file = tmp_path / "corrections.csv"
+    ledger = CorrectionLedger(ledger_file)
+    ledger.append("First", "alice", date="2024-01-01")
+    ledger.append("Second", "bob", date="2024-01-02")
+    entries = ledger.list_entries()
+    assert len(entries) == 2
+    assert entries[0].description == "First"
+    assert entries[0].author == "alice"
+    assert entries[1].author == "bob"


### PR DESCRIPTION
## Summary
- Add append-only correction ledger with dataclass entries and CSV persistence
- Store default ledger at `data/corrections.csv`
- Extend `sensiblaw` CLI with `repro` commands for logging and listing corrections
- Provide tests for ledger and CLI behaviors

## Testing
- `PYTHONPATH=. pytest tests/test_repro_ledger.py tests/test_repro_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3bac08a083228d22dc965adf03c7