### PR TITLE
Add corrections UI and ledger API

### DIFF
--- a/docs/corrections_ui.md
+++ b/docs/corrections_ui.md
@@ -1,0 +1,18 @@
+# Corrections UI
+
+This interface provides a minimal form for submitting corrections to an in-memory ledger.
+
+## Deployment
+
+1. Install server dependencies:
+   ```bash
+   pip install fastapi uvicorn
+   ```
+2. Launch the API server:
+   ```bash
+   uvicorn src.server.ledger_api:app --reload
+   ```
+3. Open the UI in your browser:
+   [http://localhost:8000/ui/corrections/](http://localhost:8000/ui/corrections/)
+
+Submitting the form sends a POST request to `/ledger`, which stores the entry in memory.

--- a/src/repro/__init__.py
+++ b/src/repro/__init__.py
@@ -1,0 +1,1 @@
+"""Reproducibility utilities."""

--- a/src/repro/ledger.py
+++ b/src/repro/ledger.py
@@ -1,0 +1,35 @@
+"""Simple in-memory ledger for corrections.
+
+This module provides a minimal API for storing correction entries.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class LedgerEntry:
+    """Represents a single correction entry."""
+
+    name: str
+    message: str
+
+
+class Ledger:
+    """Store :class:`LedgerEntry` items in memory."""
+
+    def __init__(self) -> None:
+        self._entries: List[LedgerEntry] = []
+
+    def add_entry(self, entry: LedgerEntry) -> None:
+        """Add a new ``entry`` to the ledger."""
+        self._entries.append(entry)
+
+    def list_entries(self) -> List[LedgerEntry]:
+        """Return all stored entries."""
+        return list(self._entries)
+
+
+# A module-level singleton for convenience
+ledger = Ledger()

--- a/src/server/__init__.py
+++ b/src/server/__init__.py
@@ -1,0 +1,1 @@
+"""Server application modules."""

--- a/src/server/ledger_api.py
+++ b/src/server/ledger_api.py
@@ -1,0 +1,31 @@
+"""FastAPI application exposing the corrections ledger."""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from src.repro.ledger import LedgerEntry, ledger
+
+app = FastAPI(title="Corrections Ledger")
+app.mount("/ui", StaticFiles(directory="ui", html=True), name="ui")
+
+
+class Entry(BaseModel):
+    """Pydantic model for incoming entries."""
+
+    name: str
+    message: str
+
+
+@app.post("/ledger")
+def add_entry(entry: Entry) -> dict[str, str]:
+    """Store a new entry and return a confirmation message."""
+    ledger.add_entry(LedgerEntry(**entry.model_dump()))
+    return {"status": "ok"}
+
+
+@app.get("/ledger")
+def list_entries() -> list[LedgerEntry]:
+    """Return the list of stored entries."""
+    return ledger.list_entries()

--- a/ui/corrections/index.html
+++ b/ui/corrections/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Corrections Ledger</title>
+  </head>
+  <body>
+    <h1>Submit a correction</h1>
+    <form id="correction-form">
+      <label>Name: <input type="text" id="name" required></label><br>
+      <label>Message:<br><textarea id="message" rows="4" cols="40" required></textarea></label><br>
+      <button type="submit">Submit</button>
+    </form>
+    <script>
+      const form = document.getElementById('correction-form');
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const name = document.getElementById('name').value;
+        const message = document.getElementById('message').value;
+        await fetch('/ledger', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, message })
+        });
+        form.reset();
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add in-memory ledger module and FastAPI endpoints
- provide a simple HTML corrections form
- document how to deploy the corrections UI and API

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_689d3c07a6148322af48b3925f4f78ed