### PR TITLE
Add harm weighting index and color-coded proof rendering

### DIFF
--- a/data/harm_index.yaml
+++ b/data/harm_index.yaml
@@ -1,0 +1,14 @@
+# Mapping of entities to harm weights
+# Weight values range from 0 (no harm) to 1 (maximum harm)
+person:
+  category: physical
+  weight: 1.0
+property:
+  category: economic
+  weight: 0.5
+reputation:
+  category: reputational
+  weight: 0.3
+environment:
+  category: environmental
+  weight: 0.8

--- a/examples/harm_overlay/demo.py
+++ b/examples/harm_overlay/demo.py
@@ -1,0 +1,44 @@
+"""Example generating a proof tree with harm overlay."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Ensure the src directory is importable when running from repository root
+SRC_DIR = Path(__file__).resolve().parents[2] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from graph.proof_tree import Graph, Node, Edge
+from proofs.render import load_harm_index, to_dot_with_harm
+
+
+def main() -> None:
+    here = Path(__file__).resolve().parent
+    harm_path = SRC_DIR.parent / "data" / "harm_index.yaml"
+    harm_index = load_harm_index(harm_path)
+
+    graph = Graph()
+    graph.add_node(Node(id="claim", type="claim", metadata={"label": "Claim", "entity": "person"}))
+    graph.add_node(Node(id="evidence", type="evidence", metadata={"label": "Evidence", "entity": "property"}))
+    graph.add_edge(Edge(source="claim", target="evidence", type="supports"))
+
+    dot = to_dot_with_harm(graph.nodes, graph.edges, harm_index)
+    dot_path = here / "proof_tree.dot"
+    dot_path.write_text(dot)
+
+    try:
+        subprocess.run(
+            ["dot", "-Tpng", str(dot_path), "-o", str(here / "proof_tree.png")],
+            check=True,
+            cwd=here,
+        )
+    except FileNotFoundError:
+        print("Graphviz 'dot' not found; skipping PNG generation.")
+    print("Wrote", dot_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/harm_overlay/proof_tree.dot
+++ b/examples/harm_overlay/proof_tree.dot
@@ -1,0 +1,5 @@
+digraph G {
+  "claim" [label="Claim", style=filled, fillcolor="#ff0000"];
+  "evidence" [label="Evidence", style=filled, fillcolor="#7f7f00"];
+  "claim" -> "evidence" [label="supports"];
+}

--- a/src/proofs/render.py
+++ b/src/proofs/render.py
@@ -1,0 +1,79 @@
+"""Render proof graphs with optional harm overlay."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable
+
+from graph.proof_tree import Edge, Node
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - dependency may not be present
+    yaml = None  # type: ignore
+
+
+def load_harm_index(path: Path) -> Dict[str, float]:
+    """Load harm weights from a YAML file.
+
+    Parameters
+    ----------
+    path:
+        Location of the YAML file mapping entities to harm weights.
+    """
+
+    text = path.read_text()
+    if yaml is not None:
+        data = yaml.safe_load(text)
+        return {entity: float(info["weight"]) for entity, info in data.items()}
+    # Fallback minimal parser supporting the file structure used in this repo
+    index: Dict[str, float] = {}
+    current: str | None = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if not line.startswith("-") and line.endswith(":"):
+            current = line[:-1]
+        elif line.startswith("weight:") and current:
+            index[current] = float(line.split(":", 1)[1].strip())
+            current = None
+    return index
+
+
+def _weight_to_color(weight: float) -> str:
+    """Map a weight in [0,1] to a hex color from green to red."""
+
+    weight = max(0.0, min(1.0, weight))
+    r = int(weight * 255)
+    g = int((1 - weight) * 255)
+    return f"#{r:02x}{g:02x}00"
+
+
+def to_dot_with_harm(
+    nodes: Dict[str, Node],
+    edges: Iterable[Edge],
+    harm_index: Dict[str, float],
+) -> str:
+    """Export nodes and edges to DOT format with harm-based colouring."""
+
+    lines = ["digraph G {"]
+    for node in nodes.values():
+        label = str(node.metadata.get("label", node.id))
+        entity = node.metadata.get("entity")
+        attrs = [f'label="{label}"']
+        if entity:
+            weight = harm_index.get(entity, 0.0)
+            color = _weight_to_color(weight)
+            attrs.extend(["style=filled", f'fillcolor="{color}"'])
+        lines.append(f'  "{node.id}" [{", ".join(attrs)}];')
+    for edge in edges:
+        label = str(edge.metadata.get("label", edge.type))
+        attrs = [f'label="{label}"']
+        if edge.weight is not None:
+            attrs.append(f'weight="{edge.weight}"')
+        lines.append(
+            f'  "{edge.source}" -> "{edge.target}" [{", ".join(attrs)}];'
+        )
+    lines.append("}")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Define harm categories with weights in `data/harm_index.yaml`
- Render proof graphs with harm-based node colouring via `src/proofs/render.py`
- Add example demonstrating harm overlay rendering

## Testing
- `python examples/harm_overlay/demo.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_689d3bc543c883228dce79f2c9e9a1ab