### PR TITLE
Add correction ledger with hash chain verification

### DIFF
--- a/src/ledger/__init__.py
+++ b/src/ledger/__init__.py
@@ -1,0 +1,5 @@
+"""Ledger utilities for tracking corrections."""
+
+from .write import append_correction
+
+__all__ = ["append_correction"]

--- a/src/ledger/feed.py
+++ b/src/ledger/feed.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from xml.etree.ElementTree import Element, SubElement, tostring
+
+DB_PATH = Path(os.environ.get("LEDGER_DB", "corrections.db"))
+FEED_PATH = Path(os.environ.get("LEDGER_FEED", "corrections/feed.atom"))
+
+
+def build_feed() -> None:
+    """Build an Atom feed of corrections ordered by insertion."""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT node_id, before_hash, after_hash, reason, reporter, prev_hash, this_hash FROM corrections ORDER BY rowid"
+        ).fetchall()
+
+    feed = Element("feed", xmlns="http://www.w3.org/2005/Atom")
+    now = datetime.utcnow().isoformat() + "Z"
+    SubElement(feed, "title").text = "Corrections"
+    SubElement(feed, "updated").text = now
+    SubElement(feed, "id").text = "urn:sensiblaw:corrections"
+
+    for row in rows:
+        entry = SubElement(feed, "entry")
+        SubElement(entry, "id").text = row["this_hash"]
+        SubElement(entry, "title").text = f"Correction for {row['node_id']}"
+        SubElement(entry, "updated").text = now
+        body = "|".join(
+            [
+                row["node_id"],
+                row["before_hash"],
+                row["after_hash"],
+                row["reason"],
+                row["reporter"],
+                row["prev_hash"] or "",
+            ]
+        )
+        SubElement(entry, "content").text = body
+
+    FEED_PATH.parent.mkdir(parents=True, exist_ok=True)
+    FEED_PATH.write_bytes(tostring(feed, encoding="utf-8", xml_declaration=True))

--- a/src/ledger/write.py
+++ b/src/ledger/write.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path(os.environ.get("LEDGER_DB", "corrections.db"))
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS corrections (
+            node_id TEXT NOT NULL,
+            before_hash TEXT NOT NULL,
+            after_hash TEXT NOT NULL,
+            reason TEXT NOT NULL,
+            reporter TEXT NOT NULL,
+            prev_hash TEXT,
+            this_hash TEXT NOT NULL
+        )
+        """
+    )
+
+
+def append_correction(
+    node_id: str,
+    before_hash: str,
+    after_hash: str,
+    reason: str,
+    reporter: str,
+    prev_hash: str | None,
+) -> str:
+    """Append a correction entry to the ledger.
+
+    The entry body is a pipe-separated string of the provided fields. A SHA-256
+    hash of this body is computed and stored as ``this_hash``. The new entry is
+    inserted into the ``corrections`` table of the SQLite database configured by
+    the ``LEDGER_DB`` environment variable (default ``corrections.db``).
+
+    Returns the computed ``this_hash``.
+    """
+
+    body = "|".join(
+        [node_id, before_hash, after_hash, reason, reporter, prev_hash or ""]
+    )
+    this_hash = hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+    with sqlite3.connect(DB_PATH) as conn:
+        _ensure_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO corrections (
+                node_id, before_hash, after_hash, reason, reporter, prev_hash, this_hash
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                node_id,
+                before_hash,
+                after_hash,
+                reason,
+                reporter,
+                prev_hash,
+                this_hash,
+            ),
+        )
+    return this_hash

--- a/tests/ledger/test_hash_chain.py
+++ b/tests/ledger/test_hash_chain.py
@@ -1,0 +1,35 @@
+import hashlib
+import sqlite3
+
+
+def test_hash_chain(tmp_path, monkeypatch):
+    db_path = tmp_path / "corr.db"
+    monkeypatch.setenv("LEDGER_DB", str(db_path))
+
+    from src.ledger import append_correction
+
+    h1 = append_correction("n1", "a", "b", "r1", "alice", "")
+    h2 = append_correction("n1", "b", "c", "r2", "bob", h1)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT node_id, before_hash, after_hash, reason, reporter, prev_hash, this_hash FROM corrections ORDER BY rowid"
+        ).fetchall()
+
+    assert rows[1]["prev_hash"] == h1
+    assert rows[1]["this_hash"] == h2
+
+    for row in rows:
+        body = "|".join(
+            [
+                row["node_id"],
+                row["before_hash"],
+                row["after_hash"],
+                row["reason"],
+                row["reporter"],
+                row["prev_hash"] or "",
+            ]
+        )
+        recomputed = hashlib.sha256(body.encode("utf-8")).hexdigest()
+        assert recomputed == row["this_hash"]

--- a/ui/corrections/banner.html
+++ b/ui/corrections/banner.html
@@ -1,0 +1,1 @@
+Updated &bull; <a href="{{ diff_url }}">view diff</a>


### PR DESCRIPTION
## Summary
- implement `append_correction` to store correction entries with SHA-256 hash chaining
- generate Atom feed for corrections
- add UI banner for viewing diffs
- test hash chaining integrity

## Testing
- `PYTHONPATH=. pytest tests/ledger/test_hash_chain.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3ea72d788322ad3337ba95c7487a