### PR TITLE
Add concept matcher and CLI

### DIFF
--- a/data/concepts/triggers.au.json
+++ b/data/concepts/triggers.au.json
@@ -1,0 +1,5 @@
+{
+  "terra nullius": "Concept#terra_nullius",
+  "permanent stay": "Concept#permanent_stay",
+  "mabo": "Concept#mabo"
+}

--- a/src/concepts/matcher.py
+++ b/src/concepts/matcher.py
@@ -1,0 +1,66 @@
+"""Concept phrase matcher using compiled regular expressions.
+
+Provides :class:`ConceptMatcher` which loads phrase→concept mappings and
+returns deterministic hit spans when matching against text.  The matcher is
+case-insensitive and orders results by appearance in the input string.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+
+class ConceptMatcher:
+    """Match phrases to concept identifiers.
+
+    Parameters
+    ----------
+    patterns:
+        Mapping of trigger phrase to concept identifier.
+    """
+
+    def __init__(self, patterns: Dict[str, str]):
+        self.patterns = {p.lower(): cid for p, cid in patterns.items()}
+        self._group_to_id: Dict[str, str] = {}
+
+        parts: List[str] = []
+        # Sort to ensure deterministic group assignment
+        for idx, phrase in enumerate(sorted(self.patterns)):
+            group = f"g{idx}"
+            parts.append(f"(?P<{group}>{re.escape(phrase)})")
+            self._group_to_id[group] = self.patterns[phrase]
+        pattern = "|".join(parts)
+        self._regex = re.compile(pattern, flags=re.IGNORECASE)
+
+    def match(self, text: str) -> List[Tuple[str, Tuple[int, int]]]:
+        """Return ordered matches of concepts in *text*.
+
+        Returns
+        -------
+        List[Tuple[str, Tuple[int, int]]]
+            Each tuple contains the concept identifier and the ``(start, end)``
+            span of the match in *text*.
+        """
+
+        hits: List[Tuple[str, Tuple[int, int]]] = []
+        for match in self._regex.finditer(text):
+            group = match.lastgroup
+            if group:
+                concept_id = self._group_to_id[group]
+                hits.append((concept_id, match.span()))
+        # Ensure deterministic ordering in case of overlaps
+        hits.sort(key=lambda h: (h[1][0], h[1][1] - h[1][0], h[0]))
+        return hits
+
+
+def load_patterns(path: Path | str) -> Dict[str, str]:
+    """Load phrase→concept mappings from JSON file."""
+
+    p = Path(path)
+    data = json.loads(p.read_text())
+    return {str(k): str(v) for k, v in data.items()}
+
+
+__all__ = ["ConceptMatcher", "load_patterns"]

--- a/tests/concepts/test_match_cli.py
+++ b/tests/concepts/test_match_cli.py
@@ -1,0 +1,33 @@
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PATTERNS = ROOT / "data/concepts/triggers.au.json"
+
+
+def run_cli(text: str) -> list[dict]:
+    cmd = [
+        "python",
+        "-m",
+        "src.cli",
+        "concepts",
+        "match",
+        "--patterns-file",
+        str(PATTERNS),
+        "--text",
+        text,
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(completed.stdout)
+
+
+def test_match_cli_deterministic():
+    text = "The doctrine of terra nullius was overturned; no permanent stay followed."
+    out1 = run_cli(text)
+    out2 = run_cli(text)
+    assert out1 == out2
+    ids = [n["id"] for n in out1]
+    assert ids == ["Concept#terra_nullius", "Concept#permanent_stay"]
+    starts = [n["start"] for n in out1]
+    assert starts == sorted(starts)


### PR DESCRIPTION
## Summary
- add AU trigger mappings
- implement deterministic concept matcher
- build clouds from matcher hits with optional layout precompute
- expose `concepts match` CLI command and verify ordering

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest tests/concepts/test_match_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3eae46ec8322bde280e1ba1516b9