### PR TITLE
Capture paragraph anchors in distinguish comparisons

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -142,7 +142,8 @@ def main() -> None:
         story_data = json.loads(args.story.read_text())
         story_tags = story_data.get("facts", {})
         result = compare_story_to_case(story_tags, case_sil)
-        print(json.dumps(result))
+        # Pretty-print to expose paragraph anchors in output
+        print(json.dumps(result, indent=2))
     elif args.command == "query":
         if args.query_command == "case":
             from .api import routes

--- a/src/distinguish/engine.py
+++ b/src/distinguish/engine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import re
 from typing import Dict, Sequence, List, Tuple, Set
 
@@ -20,6 +20,7 @@ class CaseSilhouette:
     fact_tags: Dict[str, int]
     holding_hints: Dict[str, int]
     paragraphs: Sequence[str]
+    anchors: Dict[int, str] = field(default_factory=dict)
 
 
 def extract_case_silhouette(paragraphs: Sequence[str]) -> CaseSilhouette:
@@ -31,15 +32,33 @@ def extract_case_silhouette(paragraphs: Sequence[str]) -> CaseSilhouette:
 
     facts: Dict[str, int] = {}
     holdings: Dict[str, int] = {}
+    anchors: Dict[int, str] = {}
+
+    bracket_re = re.compile(r"\[(\d+)\]")
+    pilcrow_re = re.compile(r"¶(\d+)")
+    heading_re = re.compile(r"^\s*(\d+)[\.\)]?\s+")
+
     for idx, para in enumerate(paragraphs):
         text = para.strip()
         if not text:
             continue
+        # anchor detection
+        anchor_match = bracket_re.search(text)
+        if anchor_match:
+            anchors[idx] = anchor_match.group(0)
+        else:
+            anchor_match = pilcrow_re.search(text)
+            if anchor_match:
+                anchors[idx] = anchor_match.group(0)
+            else:
+                heading_match = heading_re.match(text)
+                if heading_match:
+                    anchors[idx] = heading_match.group(1)
         if idx < 3:
             facts[text] = idx
         if text.lower().startswith("held"):
             holdings[text] = idx
-    return CaseSilhouette(facts, holdings, list(paragraphs))
+    return CaseSilhouette(facts, holdings, list(paragraphs), anchors)
 
 
 def extract_holding_and_facts(paragraphs: Sequence[str]) -> Tuple[Set[str], Set[str]]:
@@ -77,10 +96,12 @@ def compare_cases(base: CaseSilhouette, candidate: CaseSilhouette) -> Dict[str, 
                     "base": {
                         "index": base_idx,
                         "paragraph": base.paragraphs[base_idx],
+                        "anchor": base.anchors.get(base_idx),
                     },
                     "candidate": {
                         "index": cand_idx,
                         "paragraph": candidate.paragraphs[cand_idx],
+                        "anchor": candidate.anchors.get(cand_idx),
                     },
                 }
             )
@@ -92,6 +113,7 @@ def compare_cases(base: CaseSilhouette, candidate: CaseSilhouette) -> Dict[str, 
                     "base": {
                         "index": base_idx,
                         "paragraph": base.paragraphs[base_idx],
+                        "anchor": base.anchors.get(base_idx),
                     },
                 }
             )
@@ -106,10 +128,12 @@ def compare_cases(base: CaseSilhouette, candidate: CaseSilhouette) -> Dict[str, 
                     "base": {
                         "index": base_idx,
                         "paragraph": base.paragraphs[base_idx],
+                        "anchor": base.anchors.get(base_idx),
                     },
                     "candidate": {
                         "index": cand_idx,
                         "paragraph": candidate.paragraphs[cand_idx],
+                        "anchor": candidate.anchors.get(cand_idx),
                     },
                 }
             )
@@ -121,6 +145,7 @@ def compare_cases(base: CaseSilhouette, candidate: CaseSilhouette) -> Dict[str, 
                     "base": {
                         "index": base_idx,
                         "paragraph": base.paragraphs[base_idx],
+                        "anchor": base.anchors.get(base_idx),
                     },
                 }
             )
@@ -170,11 +195,21 @@ def compare_story_to_case(
             overlaps.append(
                 {
                     "id": tag,
-                    "index": match_idx,
-                    "paragraph": case.paragraphs[match_idx],
+                    "base": {"anchor": None},
+                    "candidate": {
+                        "index": match_idx,
+                        "paragraph": case.paragraphs[match_idx],
+                        "anchor": case.anchors.get(match_idx),
+                    },
                 }
             )
         else:
-            missing.append({"id": tag})
+            missing.append(
+                {
+                    "id": tag,
+                    "base": {"anchor": None},
+                    "candidate": {"anchor": None},
+                }
+            )
 
     return {"overlaps": overlaps, "missing": missing}

--- a/src/distinguish/loader.py
+++ b/src/distinguish/loader.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from .engine import CaseSilhouette
+from .engine import CaseSilhouette, extract_case_silhouette
 
 # Base directory of examples used in tests.  In a fuller system this would be
 # replaced by a database or ingestion pipeline.
@@ -30,8 +30,9 @@ def load_case_silhouette(citation: str) -> CaseSilhouette:
         raise KeyError(f"Unknown case citation: {citation}")
 
     data = json.loads(path.read_text())
-    return CaseSilhouette(
-        fact_tags=data.get("fact_tags", {}),
-        holding_hints=data.get("holding_hints", {}),
-        paragraphs=data.get("paragraphs", []),
-    )
+    paragraphs = data.get("paragraphs", [])
+    silhouette = extract_case_silhouette(paragraphs)
+    # Allow explicit fact/holding tags from the JSON to override heuristics
+    silhouette.fact_tags = data.get("fact_tags", silhouette.fact_tags)
+    silhouette.holding_hints = data.get("holding_hints", silhouette.holding_hints)
+    return silhouette

--- a/tests/distinguish/test_distinguish_engine.py
+++ b/tests/distinguish/test_distinguish_engine.py
@@ -8,46 +8,56 @@ from src.distinguish.engine import (
 
 def test_extract_case_silhouette():
     paragraphs = [
-        "Fact one",
-        "Fact two",
-        "Fact three",
+        "[1] Fact one",
+        "¶2 Fact two",
+        "3 Fact three",
         "Held: something",
         "Other",
     ]
     sil = extract_case_silhouette(paragraphs)
-    assert "Fact one" in sil.fact_tags
-    assert sil.fact_tags["Fact one"] == 0
+    assert "[1] Fact one" in sil.fact_tags
+    assert sil.fact_tags["[1] Fact one"] == 0
+    assert sil.anchors[0] == "[1]"
+    assert sil.anchors[1] == "¶2"
+    assert sil.anchors[2] == "3"
     assert "Held: something" in sil.holding_hints
     assert sil.holding_hints["Held: something"] == 3
 
 
 def test_compare_cases_overlap_and_missing():
     base_paras = [
-        "Base fact",
-        "Held: yes",
+        "[1] Base fact",
+        "¶2 Held: yes",
     ]
     cand_paras = [
-        "Other fact",
-        "Held: yes",
+        "[3] Other fact",
+        "¶2 Held: yes",
     ]
     base = extract_case_silhouette(base_paras)
     cand = extract_case_silhouette(cand_paras)
     result = compare_cases(base, cand)
     texts = [o["text"] for o in result["overlaps"]]
-    assert "Held: yes" in texts
+    assert "¶2 Held: yes" in texts
     missing_texts = [m["text"] for m in result["missing"]]
-    assert "Base fact" in missing_texts
+    assert "[1] Base fact" in missing_texts
+    # token overlaps unaffected by anchors
+    assert result["overlap_tokens"] == ["¶2 Held: yes"]
+    assert result["a_only_tokens"] == ["[1] Base fact"]
+    assert result["b_only_tokens"] == ["[3] Other fact"]
+    # anchors propagated in results
+    assert result["overlaps"][0]["base"]["anchor"] == "¶2"
+    assert result["overlaps"][0]["candidate"]["anchor"] == "¶2"
+    assert result["missing"][0]["base"]["anchor"] == "[1]"
 
 
 def test_compare_story_to_case_overlap_and_missing():
-    case = CaseSilhouette(
-        fact_tags={},
-        holding_hints={},
-        paragraphs=[
-            "There was a significant delay before trial.",
-            "Some evidence was lost causing prejudice to the defence.",
-        ],
-    )
+    paragraphs = [
+        "[1] There was a significant delay before trial.",
+        "¶2 Some evidence was lost causing prejudice to the defence.",
+    ]
+    case = extract_case_silhouette(paragraphs)
+    case.fact_tags = {}
+    case.holding_hints = {}
     story_tags = {"delay": True, "abuse_indicators": True, "lost_evidence": True}
     result = compare_story_to_case(story_tags, case)
     overlap_ids = {o["id"] for o in result["overlaps"]}
@@ -55,3 +65,7 @@ def test_compare_story_to_case_overlap_and_missing():
     assert "delay" in overlap_ids
     assert "lost_evidence" in overlap_ids
     assert "abuse_indicators" in missing_ids
+    # anchors included
+    assert any(o["candidate"]["anchor"] for o in result["overlaps"])
+    assert all("anchor" in o["base"] and "anchor" in o["candidate"] for o in result["overlaps"])
+    assert all("anchor" in m["base"] and "anchor" in m["candidate"] for m in result["missing"])


### PR DESCRIPTION
## Summary
- detect paragraph anchors (e.g. `[12]`, `¶7`, numeric headings) when extracting case silhouettes
- include anchors in compare_cases and compare_story_to_case results
- expose anchors via CLI `sensiblaw distinguish`
- test anchor extraction and stable token overlaps

## Testing
- `PYTHONPATH=. pytest tests/distinguish -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3f295a5c8322b6393f3d16a5777f