### PR TITLE
Add coverage reporting and threshold to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest
+          pip install pytest coverage[toml] pytest-cov
       - name: Test
-        run: pytest
+        run: pytest --cov=src --cov-report=xml
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,6 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 "src" = ["data/foundation_sources.json"]
+
+[tool.coverage.report]
+fail_under = 80


### PR DESCRIPTION
## Summary
- install coverage and pytest-cov in CI, run tests with coverage, and upload XML report
- enforce minimum coverage of 80% via pyproject

## Testing
- `pytest --cov=src --cov-report=xml` *(fails: unrecognized arguments --cov=src --cov-report=xml)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_689d413543d08322b973d89fa9a8abfa