### PR TITLE
Add deterministic frame compiler tests

### DIFF
--- a/src/frame/__init__.py
+++ b/src/frame/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for constructing and compiling frames."""

--- a/src/frame/compile.py
+++ b/src/frame/compile.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Dict, Mapping, Sequence
+
+
+def compile_frame(
+    node: Mapping[str, object],
+    neighbors: Sequence[Mapping[str, object]],
+    factors: Sequence[Mapping[str, object]],
+) -> Dict[str, str]:
+    """Build a deterministic textual summary for a node.
+
+    Parameters
+    ----------
+    node:
+        Mapping containing at least an ``id`` or ``label``.
+    neighbors:
+        Sequence of neighbor mappings. Each may include ``receipts`` listing
+        associated receipt identifiers.
+    factors:
+        Sequence of factor mappings, potentially carrying ``receipts``.
+
+    Returns
+    -------
+    dict with ``thesis``, ``summary`` and ``brief`` text.
+    """
+
+    if not neighbors:
+        return {
+            "thesis": "No neighbors to summarise.",
+            "summary": "No receipts.",
+            "brief": "No receipts.",
+        }
+
+    receipts: list[str] = []
+    for neighbor in neighbors:
+        receipts.extend(str(r) for r in neighbor.get("receipts", []))
+    for factor in factors:
+        receipts.extend(str(r) for r in factor.get("receipts", []))
+
+    thesis = f"{node.get('label', 'node')} references {len(neighbors)} sources"
+    receipts_str = ", ".join(receipts)
+    summary = f"Receipts referenced: {receipts_str}"
+    brief = f"Receipts: {receipts_str}"
+    return {"thesis": thesis, "summary": summary, "brief": brief}

--- a/tests/frame/test_compile.py
+++ b/tests/frame/test_compile.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+from src.frame.compile import compile_frame
+
+
+def test_compile_deterministic_and_receipts():
+    node = {"id": "n1", "label": "Alpha"}
+    neighbors = [
+        {"id": "n2", "receipts": ["r-001"]},
+        {"id": "n3", "receipts": ["r-002"]},
+    ]
+    factors = [{"id": "f1", "receipts": ["r-003"]}]
+
+    first = compile_frame(node, neighbors, factors)
+    second = compile_frame(node, neighbors, factors)
+
+    assert len(first["thesis"].split()) <= 12
+    assert any(r in first["summary"] for r in ["r-001", "r-002", "r-003"])
+    assert any(r in first["brief"] for r in ["r-001", "r-002", "r-003"])
+    assert first == second
+
+
+def test_compile_no_neighbors():
+    node = {"id": "n1", "label": "Alpha"}
+    result = compile_frame(node, [], [])
+    assert "no neighbors" in result["thesis"].lower()


### PR DESCRIPTION
## Summary
- add `compile_frame` helper to summarise nodes with receipts and fallback when no neighbors
- include tests covering word-count limit, receipt inclusion, deterministic output, and zero-neighbor fallback

## Testing
- `pytest tests/frame/test_compile.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*
- `pip install fastapi -q` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_689d414528048322a9db3a2b55b51c4b