### PR TITLE
Add tests for storage schema integrity and append-only checks

### DIFF
--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -32,6 +32,12 @@ CREATE TABLE IF NOT EXISTS corrections (
     data TEXT
 );
 
+CREATE TRIGGER IF NOT EXISTS prevent_corrections_delete
+BEFORE DELETE ON corrections
+BEGIN
+    SELECT RAISE(ABORT, 'corrections table is append-only');
+END;
+
 CREATE TABLE IF NOT EXISTS glossary (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     term TEXT UNIQUE NOT NULL,


### PR DESCRIPTION
## Summary
- add trigger to prevent deleting corrections rows
- cover duplicate node IDs, malformed JSON props, and correction deletion rejection

## Testing
- `pytest tests/storage/test_core_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_689d413d52488322951bb695895cc48a