### PR TITLE
Add Hypothesis property-based tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest coverage[toml] pytest-cov
+          pip install pytest coverage[toml] pytest-cov hypothesis
       - name: Test
         run: pytest --cov=src --cov-report=xml
       - name: Upload coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
 ]
 test = [
     "pytest",
+    "hypothesis",
 ]
 
 [project.scripts]

--- a/tests/checklists/test_evaluator_props.py
+++ b/tests/checklists/test_evaluator_props.py
@@ -1,0 +1,20 @@
+import json
+import string
+from pathlib import Path
+
+from hypothesis import given, settings, strategies as st
+
+from src.checklists.run import evaluate
+
+BASE = Path(__file__).parent
+CHECKLIST = json.loads((BASE / "basic.json").read_text())
+
+
+@settings(max_examples=50)
+@given(st.sets(st.text(alphabet=string.ascii_lowercase, min_size=1), max_size=5))
+def test_evaluate_deterministic_and_non_negative_score(tags):
+    result1 = evaluate(CHECKLIST, tags)
+    result2 = evaluate(CHECKLIST, tags)
+    assert result1 == result2
+    score = sum(1 for f in result1["factors"] if f["passed"])
+    assert score >= 0

--- a/tests/storage/test_core_props.py
+++ b/tests/storage/test_core_props.py
@@ -1,0 +1,33 @@
+import string
+
+from hypothesis import given, settings, strategies as st
+
+from src.storage.core import Storage
+
+json_value = st.one_of(
+    st.integers(),
+    st.booleans(),
+    st.floats(allow_nan=False, allow_infinity=False),
+    st.text(alphabet=string.ascii_letters),
+)
+
+data_strategy = st.dictionaries(
+    st.text(alphabet=string.ascii_letters, min_size=1),
+    json_value,
+    max_size=5,
+)
+
+
+@settings(max_examples=25)
+@given(type_str=st.text(alphabet=string.ascii_letters, min_size=1, max_size=10), data=data_strategy)
+def test_node_round_trip(tmp_path, type_str, data):
+    store = Storage(tmp_path / "test.db")
+    try:
+        node_id = store.insert_node(type_str, data)
+        node = store.get_node(node_id)
+        assert node is not None
+        assert node.id == node_id
+        assert node.type == type_str
+        assert node.data == data
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary
- add Hypothesis to test extras and CI
- add property-based tests for checklist evaluation and storage serialization

## Testing
- `pytest tests/checklists/test_evaluator_props.py tests/storage/test_core_props.py` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_689d43f2081c832283ac950ad8ea59a9