### PR TITLE
Add roadmap todo and link from contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing
 
-Contributions to SensibLaw are welcome. To get started, install the development
-dependencies and run the test suite:
+Contributions to SensibLaw are welcome. For a high-level roadmap linking tools
+to implementation areas, see [todo.md](todo.md). To get started, install the
+development dependencies and run the test suite:
 
 ```bash
 pip install -e .[dev,test]

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,9 @@
+# TODO
+
+- Graphviz → proof tree rendering
+- NetworkX → graph traversal
+- SQLite + FTS5 → storage and full-text search
+- pdfminer.six → PDF parsing
+- FastAPI → API service
+- Requests → external data retrieval
+- Matplotlib → visualisation


### PR DESCRIPTION
## Summary
- Add `todo.md` bullet list mapping key tools (Graphviz, NetworkX, SQLite+FTS5, etc.) to their intended implementation areas
- Reference the roadmap from `CONTRIBUTING.md` for newcomers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -e .[dev,test]` *(fails: Could not connect to proxy for setuptools)*

------
https://chatgpt.com/codex/tasks/task_e_689d5b88c5d08322af9206d7e0190e46