### PR TITLE
Add Graphviz SVG rendering with edge tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ Install the package in editable mode to develop locally:
 pip install -e .
 ```
 
+Graph rendering relies on the Graphviz toolchain. Install the system
+package separately, for example:
+
+```bash
+sudo apt-get install graphviz  # Debian/Ubuntu
+# or
+brew install graphviz          # macOS
+```
+
 ## CLI
 
 ### CLI Commands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "requests",
     "fastapi",
     "matplotlib",
+    "graphviz",
 ]
 
 [project.optional-dependencies]

--- a/src/cli.py
+++ b/src/cli.py
@@ -4,6 +4,7 @@ from datetime import datetime, date
 from pathlib import Path
 
 from .storage import VersionedStore
+from .proofs.render import dot_to_svg
 
 
 def main() -> None:
@@ -108,6 +109,11 @@ def main() -> None:
         "--dot",
         action="store_true",
         help="Output Graphviz DOT instead of JSON",
+    )
+    subgraph_parser.add_argument(
+        "--svg",
+        action="store_true",
+        help="Output rendered SVG",
     )
 
     tests_parser = sub.add_parser("tests", help="Run declarative tests")
@@ -298,7 +304,11 @@ def main() -> None:
                 nodes, edges = build_subgraph(
                     g, args.seeds, hops=args.hops, as_at=as_at
                 )
-                print(to_dot(nodes, edges))
+                dot_output = to_dot(nodes, edges)
+                if args.svg:
+                    print(dot_to_svg(dot_output))
+                else:
+                    print(dot_output)
             else:
                 from .api.routes import generate_subgraph
 
@@ -316,7 +326,7 @@ def main() -> None:
                     "nodes": list(combined_nodes.values()),
                     "edges": list(combined_edges.values()),
                 }
-                if args.dot:
+                if args.dot or args.svg:
                     g = Graph()
                     for n in merged["nodes"]:
                         nid = n.get("identifier") or n.get("id")
@@ -353,9 +363,13 @@ def main() -> None:
                         nodes, edges = build_subgraph(
                             g, args.seeds, hops=args.hops, as_at=as_at
                         )
-                        print(to_dot(nodes, edges))
+                        dot_output = to_dot(nodes, edges)
                     else:
-                        print(to_dot(g.nodes, g.edges))
+                        dot_output = to_dot(g.nodes, g.edges)
+                    if args.svg:
+                        print(dot_to_svg(dot_output))
+                    else:
+                        print(dot_output)
                 else:
                     print(json.dumps(merged))
         else:

--- a/src/graph/proof_tree.py
+++ b/src/graph/proof_tree.py
@@ -131,6 +131,8 @@ def to_dot(nodes: Dict[str, Node], edges: Iterable[Edge]) -> str:
             attrs.append(f'receipt="{receipt}"')
         if edge.weight is not None:
             attrs.append(f'weight="{edge.weight}"')
+        tooltip = receipt or label or "why is this here?"
+        attrs.append(f'tooltip="{tooltip}"')
         lines.append(
             f'  "{edge.source}" -> "{edge.target}" [{", ".join(attrs)}];'
         )


### PR DESCRIPTION
## Summary
- Convert DOT graphs to SVG via Graphviz and add edge tooltips
- Add `--svg` option to `sensiblaw graph subgraph` CLI
- Document Graphviz installation and declare it as a dependency

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `apt-get update` *(fails: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_689d5b8ad37c8322949d917d0094d401