### PR TITLE
Add text similarity signatures and receipt diff CLI

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -125,6 +125,14 @@ def main() -> None:
     cases_treat = cases_sub.add_parser("treatment", help="Fetch case treatment")
     cases_treat.add_argument("--case-id", required=True, help="Case identifier")
 
+    receipts_parser = sub.add_parser("receipts", help="Receipt operations")
+    receipts_sub = receipts_parser.add_subparsers(dest="receipts_command")
+    receipts_diff = receipts_sub.add_parser(
+        "diff", help="Compare two receipt files"
+    )
+    receipts_diff.add_argument("--old", type=Path, required=True, help="Old receipt")
+    receipts_diff.add_argument("--new", type=Path, required=True, help="New receipt")
+
     tools_parser = sub.add_parser("tools", help="Utility tools")
     tools_sub = tools_parser.add_subparsers(dest="tools_command")
     claim_builder = tools_sub.add_parser(
@@ -377,6 +385,20 @@ def main() -> None:
 
             result = fetch_case_treatment(args.case_id)
             print(json.dumps(result))
+        else:
+            parser.print_help()
+    elif args.command == "receipts":
+        if args.receipts_command == "diff":
+            from .text.similarity import minhash, simhash
+
+            old_text = Path(args.old).read_text(encoding="utf-8")
+            new_text = Path(args.new).read_text(encoding="utf-8")
+            if old_text == new_text:
+                print("identical")
+            elif minhash(old_text) == minhash(new_text):
+                print("cosmetic")
+            else:
+                print("substantive")
         else:
             parser.print_help()
     elif args.command == "tools":

--- a/src/storage/core.py
+++ b/src/storage/core.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from ..text.similarity import minhash as compute_minhash, simhash as compute_simhash
+
 
 @dataclass
 class Node:
@@ -58,6 +60,8 @@ class GlossaryEntry:
 class Receipt:
     id: Optional[int]
     data: Dict[str, Any]
+    simhash: str
+    minhash: str
 
 
 class Storage:
@@ -409,27 +413,40 @@ class Storage:
     # Receipts
     # ------------------------------------------------------------------
     def insert_receipt(self, data: Dict[str, Any]) -> int:
+        text = data.get("text") or json.dumps(data, sort_keys=True)
+        sim = compute_simhash(text)
+        m = compute_minhash(text)
         with self.conn:
             cur = self.conn.execute(
-                "INSERT INTO receipts(data) VALUES (?)", (json.dumps(data),)
+                "INSERT INTO receipts(data, simhash, minhash) VALUES (?, ?, ?)",
+                (json.dumps(data), sim, m),
             )
             return cur.lastrowid
 
     def get_receipt(self, receipt_id: int) -> Optional[Receipt]:
         row = self.conn.execute(
-            "SELECT id, data FROM receipts WHERE id = ?", (receipt_id,)
+            "SELECT id, data, simhash, minhash FROM receipts WHERE id = ?",
+            (receipt_id,),
         ).fetchone()
         if row is None:
             return None
-        return Receipt(id=row["id"], data=json.loads(row["data"]))
+        return Receipt(
+            id=row["id"],
+            data=json.loads(row["data"]),
+            simhash=row["simhash"],
+            minhash=row["minhash"],
+        )
 
     def update_receipt(
         self, receipt_id: int, data: Dict[str, Any]
     ) -> None:
+        text = data.get("text") or json.dumps(data, sort_keys=True)
+        sim = compute_simhash(text)
+        m = compute_minhash(text)
         with self.conn:
             self.conn.execute(
-                "UPDATE receipts SET data = ? WHERE id = ?",
-                (json.dumps(data), receipt_id),
+                "UPDATE receipts SET data = ?, simhash = ?, minhash = ? WHERE id = ?",
+                (json.dumps(data), sim, m, receipt_id),
             )
 
     def delete_receipt(self, receipt_id: int) -> None:

--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -47,5 +47,7 @@ CREATE TABLE IF NOT EXISTS glossary (
 
 CREATE TABLE IF NOT EXISTS receipts (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    data TEXT NOT NULL
+    data TEXT NOT NULL,
+    simhash TEXT,
+    minhash TEXT
 );

--- a/src/text/__init__.py
+++ b/src/text/__init__.py
@@ -1,0 +1,1 @@
+"""Text processing utilities."""

--- a/src/text/similarity.py
+++ b/src/text/similarity.py
@@ -1,0 +1,59 @@
+"""Utilities for computing text similarity signatures."""
+from __future__ import annotations
+
+import hashlib
+import re
+
+TOKEN_RE = re.compile(r"\w+")
+
+
+def _tokenize(text: str) -> list[str]:
+    """Return a list of lowercase word tokens."""
+    return TOKEN_RE.findall(text.lower())
+
+
+def simhash(text: str) -> str:
+    """Compute a 64-bit SimHash fingerprint of the given text.
+
+    The implementation uses token-level hashing via MD5 and aggregates bit
+    weights to derive the fingerprint.
+    """
+    tokens = _tokenize(text)
+    hashbits = 64
+    v = [0] * hashbits
+    for token in tokens:
+        h = int(hashlib.md5(token.encode("utf-8")).hexdigest(), 16)
+        for i in range(hashbits):
+            bitmask = 1 << i
+            if h & bitmask:
+                v[i] += 1
+            else:
+                v[i] -= 1
+    fingerprint = 0
+    for i in range(hashbits):
+        if v[i] >= 0:
+            fingerprint |= 1 << i
+    return f"{fingerprint:016x}"
+
+
+def minhash(text: str, num_perm: int = 8) -> str:
+    """Compute a MinHash signature for the text.
+
+    A small number of permutations are used to produce a compact signature. The
+    result is returned as a hex string.
+    """
+    tokens = set(_tokenize(text))
+    if not tokens:
+        return "0" * (num_perm * 16)
+    mins: list[int] = []
+    for i in range(num_perm):
+        min_val: int | None = None
+        for token in tokens:
+            h = hashlib.sha1(f"{i}-{token}".encode("utf-8")).digest()
+            val = int.from_bytes(h[:8], "big")
+            if min_val is None or val < min_val:
+                min_val = val
+        assert min_val is not None
+        mins.append(min_val)
+    return "".join(f"{m:016x}" for m in mins)
+

--- a/tests/storage/test_core_schema.py
+++ b/tests/storage/test_core_schema.py
@@ -45,6 +45,7 @@ def test_schema_and_crud(tmp_path):
     rec_id = store.insert_receipt({"status": "ok"})
     receipt = store.get_receipt(rec_id)
     assert receipt is not None and receipt.data["status"] == "ok"
+    assert receipt.simhash and receipt.minhash
 
     store.close()
 

--- a/tests/text/test_similarity.py
+++ b/tests/text/test_similarity.py
@@ -1,0 +1,25 @@
+import subprocess
+from pathlib import Path
+
+
+def run_diff(old: Path, new: Path) -> subprocess.CompletedProcess:
+    cmd = ["python", "-m", "src.cli", "receipts", "diff", "--old", str(old), "--new", str(new)]
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def test_cosmetic_change(tmp_path: Path):
+    old = tmp_path / "old.txt"
+    new = tmp_path / "new.txt"
+    old.write_text("Hello world\n")
+    new.write_text("Hello   world\n")
+    completed = run_diff(old, new)
+    assert completed.stdout.strip() == "cosmetic"
+
+
+def test_substantive_change(tmp_path: Path):
+    old = tmp_path / "old.txt"
+    new = tmp_path / "new.txt"
+    old.write_text("Hello world\n")
+    new.write_text("Goodbye world\n")
+    completed = run_diff(old, new)
+    assert completed.stdout.strip() == "substantive"


### PR DESCRIPTION
## Summary
- add SimHash and MinHash utilities for text
- persist similarity signatures on receipt inserts and updates
- expose `sensiblaw receipts diff` to categorize cosmetic vs substantive changes
- test receipt diff behavior and storage of signatures

## Testing
- `pytest tests/text/test_similarity.py tests/storage/test_core_schema.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi'; ModuleNotFoundError: No module named 'hypothesis')*
- `pip install fastapi hypothesis -q` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_689d8334f67c832282944408765f10c1