### PR TITLE
Add transitive reduction toggle for graph API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "requests",
     "fastapi",
     "matplotlib",
+    "networkx",
 ]
 
 [project.optional-dependencies]

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import asdict
 from typing import Dict, Any, List
 from collections import defaultdict
 
@@ -8,14 +7,19 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from ..graph.models import LegalGraph, GraphEdge
+from ..graph.api import serialize_graph
 from ..tests.templates import TEMPLATE_REGISTRY
 
 router = APIRouter()
 _graph = LegalGraph()
 
 
-def generate_subgraph(seed: str, hops: int) -> Dict[str, Any]:
-    """Return a subgraph around ``seed`` up to ``hops`` hops."""
+def generate_subgraph(seed: str, hops: int, reduced: bool = False) -> Dict[str, Any]:
+    """Return a subgraph around ``seed`` up to ``hops`` hops.
+
+    When ``reduced`` is ``True`` the returned edge set has undergone a
+    transitive reduction to remove edges that are implied by transitivity.
+    """
     if seed not in _graph.nodes:
         raise HTTPException(status_code=404, detail="Seed node not found")
     visited = {seed}
@@ -33,18 +37,25 @@ def generate_subgraph(seed: str, hops: int) -> Dict[str, Any]:
                 visited.add(tgt)
                 nodes[tgt] = _graph.nodes[tgt]
                 frontier.append((tgt, depth + 1))
-    return {
-        "nodes": [asdict(n) for n in nodes.values()],
-        "edges": [asdict(e) for e in edges],
-    }
+
+    subgraph = LegalGraph()
+    for node in nodes.values():
+        subgraph.add_node(node)
+    for edge in edges:
+        subgraph.add_edge(edge)
+
+    return serialize_graph(subgraph, reduced=reduced)
 
 
 @router.get("/subgraph")
 def subgraph_endpoint(
     seed: str = Query(..., description="Identifier for the seed node"),
     hops: int = Query(1, ge=1, le=5, description="Number of hops from seed"),
+    reduced: bool = Query(
+        False, description="Apply transitive reduction to edge set"
+    ),
 ) -> Dict[str, Any]:
-    return generate_subgraph(seed, hops)
+    return generate_subgraph(seed, hops, reduced)
 
 
 class TestRunRequest(BaseModel):

--- a/src/graph/__init__.py
+++ b/src/graph/__init__.py
@@ -10,6 +10,7 @@ from .models import (
     LegalGraph,
     NodeType,
 )
+from .api import serialize_graph
 
 __all__ = [
     "EdgeType",
@@ -19,6 +20,7 @@ __all__ = [
     "CaseNode",
     "LegalGraph",
     "NodeType",
+    "serialize_graph",
     "ingest_extrinsic",
     "compute_weight",
 ]

--- a/src/graph/api.py
+++ b/src/graph/api.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Serialization helpers for :mod:`SensibLaw.graph`.
+
+This module provides utilities to turn a :class:`~SensibLaw.graph.models.LegalGraph`
+into a JSON-serialisable structure.  When requested the edge set is first
+reduced using a transitive reduction computed by :mod:`networkx`.  This removes
+redundant edges that are implied by transitive paths while preserving the
+reachability between nodes.
+"""
+
+from dataclasses import asdict
+from typing import Dict, Any
+
+import networkx as nx
+
+from .models import LegalGraph
+
+
+def serialize_graph(graph: LegalGraph, reduced: bool = False) -> Dict[str, Any]:
+    """Serialise ``graph`` to a dictionary.
+
+    Parameters
+    ----------
+    graph:
+        The :class:`~SensibLaw.graph.models.LegalGraph` instance to serialise.
+    reduced:
+        If ``True`` the edges are first subjected to a transitive reduction
+        which prunes those that are implied by transitive reachability.
+    """
+
+    g = nx.DiGraph()
+    for node in graph.nodes.values():
+        g.add_node(node.identifier, obj=node)
+    for edge in graph.edges:
+        g.add_edge(edge.source, edge.target, obj=edge)
+
+    if reduced:
+        g = nx.transitive_reduction(g)
+
+    nodes = [asdict(data["obj"]) for _, data in g.nodes(data=True)]
+    edges = [asdict(data["obj"]) for _, _, data in g.edges(data=True)]
+    return {"nodes": nodes, "edges": edges}
+
+
+__all__ = ["serialize_graph"]

--- a/tests/graph/test_transitive_reduction.py
+++ b/tests/graph/test_transitive_reduction.py
@@ -1,0 +1,29 @@
+from src.graph.api import serialize_graph
+from src.graph.models import LegalGraph, GraphNode, GraphEdge, NodeType, EdgeType
+
+
+def build_sample_graph() -> LegalGraph:
+    g = LegalGraph()
+    g.add_node(GraphNode(type=NodeType.CASE, identifier="A"))
+    g.add_node(GraphNode(type=NodeType.CASE, identifier="B"))
+    g.add_node(GraphNode(type=NodeType.CASE, identifier="C"))
+    g.add_edge(GraphEdge(type=EdgeType.CITES, source="A", target="B"))
+    g.add_edge(GraphEdge(type=EdgeType.CITES, source="B", target="C"))
+    g.add_edge(GraphEdge(type=EdgeType.CITES, source="A", target="C"))
+    return g
+
+
+def test_edges_removed_in_reduction():
+    g = build_sample_graph()
+    reduced = serialize_graph(g, reduced=True)
+    assert not any(
+        e["source"] == "A" and e["target"] == "C" for e in reduced["edges"]
+    )
+
+
+def test_edges_reappear_when_not_reduced():
+    g = build_sample_graph()
+    full = serialize_graph(g, reduced=False)
+    assert any(
+        e["source"] == "A" and e["target"] == "C" for e in full["edges"]
+    )

--- a/ui/graph/index.js
+++ b/ui/graph/index.js
@@ -1,0 +1,18 @@
+let reduced = true;
+
+async function fetchGraph(seed, hops = 1) {
+  const res = await fetch(
+    `/subgraph?seed=${encodeURIComponent(seed)}&hops=${hops}&reduced=${reduced}`
+  );
+  return res.json();
+}
+
+export async function loadGraph(seed, hops) {
+  const data = await fetchGraph(seed, hops);
+  renderGraph(data); // assume global renderer
+}
+
+export function toggleReduction(seed, hops) {
+  reduced = !reduced;
+  return loadGraph(seed, hops);
+}


### PR DESCRIPTION
## Summary
- add NetworkX-based serializer that can perform transitive reduction
- expose reduced-or-full subgraph via API and simple frontend toggle
- test that removed edges return when reduction is disabled

## Testing
- `PYTHONPATH=. pytest tests/graph/test_transitive_reduction.py` *(fails: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_689d834566a48322b4642386615815bd