### PR TITLE
Add case timeline query

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -83,6 +83,19 @@ def main() -> None:
     case_q.add_argument("--id", required=True, help="Case identifier")
     case_q.add_argument("--year", type=int, default=1992, help="Year of judgment")
 
+    timeline_q = query_sub.add_parser("timeline", help="Generate timeline for a case")
+    timeline_q.add_argument("--case", required=True, help="Case identifier")
+    timeline_q.add_argument(
+        "--graph-file",
+        type=Path,
+        help="Graph JSON file (use '-' for stdin)",
+    )
+    timeline_q.add_argument(
+        "--svg",
+        action="store_true",
+        help="Output SVG instead of JSON",
+    )
+
     graph_parser = sub.add_parser("graph", help="Graph operations")
     graph_sub = graph_parser.add_subparsers(dest="graph_command")
     subgraph_parser = graph_sub.add_parser("subgraph", help="Extract subgraph")
@@ -231,6 +244,30 @@ def main() -> None:
                     "citations": cites,
                 }
                 print(json.dumps(result))
+        elif args.query_command == "timeline":
+            from dataclasses import asdict
+            from .reason.timeline import build_timeline, events_to_json, events_to_svg
+
+            if args.graph_file:
+                import sys
+
+                if str(args.graph_file) == "-":
+                    data = json.load(sys.stdin)
+                else:
+                    data = json.loads(args.graph_file.read_text())
+                nodes = data.get("nodes", [])
+                edges = data.get("edges", [])
+            else:
+                from .api import routes
+
+                nodes = [asdict(n) for n in routes._graph.nodes.values()]
+                edges = [asdict(e) for e in routes._graph.edges]
+
+            events = build_timeline(nodes, edges, args.case)
+            if args.svg:
+                print(events_to_svg(events))
+            else:
+                print(events_to_json(events))
         else:
             from .pipeline import build_cloud, match_concepts, normalise
             from .pipeline.input_handler import parse_input

--- a/src/reason/__init__.py
+++ b/src/reason/__init__.py
@@ -1,0 +1,1 @@
+"""Reasoning helpers for SensibLaw."""

--- a/src/reason/timeline.py
+++ b/src/reason/timeline.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+"""Utilities for generating chronological event sequences.
+
+This module builds simple timelines from graph data where nodes and edges
+may carry ISO formatted ``date`` strings.  Events are derived from the case
+node itself and from any edges connected to that case.  Each event retains
+any ``citation`` metadata when present.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, date
+from typing import Any, Dict, Iterable, List, Optional
+
+
+@dataclass
+class TimelineEvent:
+    """Representation of a single timeline entry."""
+
+    date: date
+    text: str
+    citation: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_date(value: Any) -> Optional[date]:
+    """Best effort conversion of ``value`` to :class:`~datetime.date`.
+
+    ``value`` may be ``None``, a :class:`date`, :class:`datetime` or an ISO
+    formatted string.  Invalid strings return ``None``.
+    """
+
+    if value is None:
+        return None
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value).date()
+        except ValueError:
+            return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def build_timeline(
+    nodes: Iterable[Dict[str, Any]],
+    edges: Iterable[Dict[str, Any]],
+    case_id: str,
+) -> List[TimelineEvent]:
+    """Derive a chronological list of events for ``case_id``.
+
+    Parameters
+    ----------
+    nodes, edges:
+        Iterable collections describing the graph.  Nodes must provide an
+        ``id`` and may include ``title``, ``citation`` and ``date`` fields.
+        Edges are expected to provide ``from``/``to`` (or ``source``/``target``),
+        ``type`` and optional ``date`` and ``citation`` fields.
+    case_id:
+        Identifier of the case to build the timeline for.
+    """
+
+    node_map: Dict[str, Dict[str, Any]] = {n.get("id"): n for n in nodes}
+    events: List[TimelineEvent] = []
+
+    case_node = node_map.get(case_id)
+    if case_node:
+        d = _parse_date(case_node.get("date"))
+        if d:
+            citation = case_node.get("citation") or case_node.get("metadata", {}).get(
+                "citation"
+            )
+            text = case_node.get("title") or case_node.get("id")
+            events.append(TimelineEvent(d, text, citation))
+
+    for edge in edges:
+        src = edge.get("from") or edge.get("source")
+        tgt = edge.get("to") or edge.get("target")
+        if case_id not in {src, tgt}:
+            continue
+        d = _parse_date(edge.get("date"))
+        if not d:
+            continue
+        other_id = tgt if src == case_id else src
+        other = node_map.get(other_id, {})
+        other_label = (
+            other.get("title")
+            or other.get("metadata", {}).get("label")
+            or other_id
+        )
+        label = edge.get("type", "")
+        text = f"{label} {other_label}".strip()
+        citation = edge.get("citation") or edge.get("metadata", {}).get("citation")
+        events.append(TimelineEvent(d, text, citation))
+
+    events.sort(key=lambda e: e.date)
+    return events
+
+
+def events_to_json(events: List[TimelineEvent]) -> str:
+    """Serialise ``events`` to a JSON string."""
+
+    import json
+
+    data = [
+        {"date": e.date.isoformat(), "text": e.text, **({"citation": e.citation} if e.citation else {})}
+        for e in events
+    ]
+    return json.dumps(data)
+
+
+def events_to_svg(events: List[TimelineEvent]) -> str:
+    """Render ``events`` as a simple SVG timeline."""
+
+    height = 20 + 20 * len(events)
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="800" height="{height}">'
+    ]
+    y = 15
+    for ev in events:
+        lines.append(
+            f'<text x="10" y="{y}">{ev.date.isoformat()} - {ev.text}</text>'
+        )
+        y += 20
+    lines.append("</svg>")
+    return "".join(lines)
+
+
+__all__ = ["TimelineEvent", "build_timeline", "events_to_json", "events_to_svg"]

--- a/tests/reason/test_timeline.py
+++ b/tests/reason/test_timeline.py
@@ -1,0 +1,63 @@
+import json
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from src.reason.timeline import build_timeline
+
+
+def _sample_graph():
+    nodes = [
+        {
+            "id": "A",
+            "title": "Case A",
+            "date": "2020-01-01",
+            "citation": "A v B [2020] HCA 1",
+        },
+        {
+            "id": "B",
+            "title": "Case B",
+            "date": "2021-01-01",
+            "citation": "B v C [2021] HCA 2",
+        },
+    ]
+    edges = [
+        {
+            "from": "A",
+            "to": "B",
+            "type": "cites",
+            "date": "2021-01-02",
+            "citation": "A [2]",
+        }
+    ]
+    return nodes, edges
+
+
+def test_timeline_sorted_with_citations(tmp_path: Path) -> None:
+    nodes, edges = _sample_graph()
+    events = build_timeline(nodes, edges, "A")
+    assert [e.date.isoformat() for e in events] == ["2020-01-01", "2021-01-02"]
+    assert all(e.citation for e in events)
+
+    graph = {"nodes": nodes, "edges": edges}
+    gfile = tmp_path / "graph.json"
+    gfile.write_text(json.dumps(graph))
+    cmd = [
+        sys.executable,
+        "-m",
+        "src.cli",
+        "query",
+        "timeline",
+        "--case",
+        "A",
+        "--graph-file",
+        str(gfile),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    data = json.loads(completed.stdout)
+    assert [e["date"] for e in data] == ["2020-01-01", "2021-01-02"]
+    assert data[0]["citation"] == "A v B [2020] HCA 1"
+    assert data[1]["citation"] == "A [2]"


### PR DESCRIPTION
## Summary
- derive chronological case timelines from graph node and edge dates
- add CLI `query timeline` outputting events in JSON or SVG
- test timeline ordering and citation inclusion

## Testing
- `pytest tests/reason/test_timeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d860590fc8322ae7a9665f63c07e3