### PR TITLE
Add Hansard ingestion with SQLite persistence

### DIFF
--- a/src/ingestion/dispatcher.py
+++ b/src/ingestion/dispatcher.py
@@ -1,4 +1,5 @@
 import json
+import sqlite3
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -6,7 +7,7 @@ from typing import Any, Dict, List, Optional
 # Local adapters used by the dispatcher.  They are lightweight and avoid
 # third‑party dependencies so that unit tests can exercise the dispatch
 # logic without requiring network access.
-from . import frl, hca
+from . import frl, hca, hansard
 
 try:  # pragma: no cover - optional dependency
     from ..austlii_client import AustLIIClient
@@ -37,6 +38,31 @@ def fetch_official_register(source: Dict[str, Any]) -> str:
     """Placeholder fetcher for official register HTML sources."""
 
     return "official"
+
+
+def _persist_graph(nodes: List[Dict[str, Any]], edges: List[Dict[str, Any]], path: Path) -> None:
+    """Persist ``nodes`` and ``edges`` into a simple SQLite schema."""
+
+    conn = sqlite3.connect(path)
+    with conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS nodes (id TEXT PRIMARY KEY, type TEXT, data TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS edges (id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT, target TEXT, type TEXT)"
+        )
+        for n in nodes:
+            data = json.dumps({k: v for k, v in n.items() if k not in {"id", "type"}})
+            conn.execute(
+                "INSERT OR REPLACE INTO nodes(id, type, data) VALUES (?, ?, ?)",
+                (n.get("id"), n.get("type"), data),
+            )
+        for e in edges:
+            conn.execute(
+                "INSERT INTO edges(source, target, type) VALUES (?, ?, ?)",
+                (e.get("from"), e.get("to"), e.get("type")),
+            )
+    conn.close()
 
 
 class SourceDispatcher:
@@ -112,6 +138,24 @@ class SourceDispatcher:
                         "nodes": nodes,
                         "edges": edges,
                         "fetchers": fetchers,
+                    }
+                )
+                continue
+
+            if source.get("adapter") == "hansard" or source["name"].lower() == "hansard":
+                debates = source.get("debates", [])
+                try:
+                    nodes, edges = hansard.fetch_debates(debates)
+                except Exception:  # pragma: no cover - parsing errors
+                    nodes, edges = [], []
+                db_path = Path(source.get("db_path", "hansard.db"))
+                _persist_graph(nodes, edges, db_path)
+                results.append(
+                    {
+                        "name": source["name"],
+                        "nodes": nodes,
+                        "edges": edges,
+                        "db_path": str(db_path),
                     }
                 )
                 continue

--- a/src/ingestion/hansard.py
+++ b/src/ingestion/hansard.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Tuple, Iterable
+
+
+@dataclass
+class Debate:
+    """Simple representation of a parliamentary debate."""
+
+    identifier: str
+    text: str
+    date: str | None = None
+
+
+_CITATION_RE = re.compile(r"([A-Z][a-z]*(?: [A-Z][a-z]*)* Act \d{4})")
+
+
+def normalize_text(text: str) -> str:
+    """Return ``text`` normalised for spacing.
+
+    Multiple whitespace characters are collapsed to a single space and
+    leading/trailing whitespace is stripped.  This is intentionally simple
+    but sufficient for unit tests where stable hashing across runs is
+    important.
+    """
+
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def extract_citations(text: str) -> List[str]:
+    """Extract crude Act citations from ``text``.
+
+    The implementation uses a lightweight regular expression that matches
+    phrases such as ``"Crimes Act 1914"``.  It is not intended to be
+    exhaustive but provides deterministic behaviour for the tests.
+    """
+
+    return _CITATION_RE.findall(text)
+
+
+def fetch_debates(raw_debates: Iterable[Dict[str, str]]) -> Tuple[List[Dict[str, object]], List[Dict[str, object]]]:
+    """Convert raw debate data into graph ``nodes`` and ``edges``.
+
+    Parameters
+    ----------
+    raw_debates:
+        Iterable of dictionaries each containing at least ``id`` and ``text``
+        keys.  Optional metadata such as ``date`` may also be supplied.
+
+    Returns
+    -------
+    ``(nodes, edges)``
+        ``nodes`` contains a node for each debate and any cited Acts while
+        ``edges`` expresses the ``"cites"`` relationship between debates and
+        Acts.
+    """
+
+    nodes: List[Dict[str, object]] = []
+    edges: List[Dict[str, object]] = []
+    seen_citations: set[str] = set()
+
+    for item in raw_debates:
+        ident = item.get("id") or item.get("identifier")
+        if ident is None:
+            continue
+        body = normalize_text(item.get("text", ""))
+        citations = extract_citations(body)
+        sha = hashlib.sha256(body.encode("utf-8")).hexdigest()
+        metadata = {
+            "date": item.get("date"),
+            "hash": sha,
+            "citations": citations,
+        }
+        nodes.append({
+            "id": ident,
+            "type": "debate",
+            "body": body,
+            "metadata": metadata,
+        })
+        for cit in citations:
+            if cit not in seen_citations:
+                nodes.append({"id": cit, "type": "act"})
+                seen_citations.add(cit)
+            edges.append({"from": ident, "to": cit, "type": "cites"})
+    return nodes, edges
+
+
+__all__ = ["Debate", "normalize_text", "extract_citations", "fetch_debates"]

--- a/tests/ingestion/test_hansard.py
+++ b/tests/ingestion/test_hansard.py
@@ -1,0 +1,61 @@
+import sys
+from pathlib import Path
+import json
+import sqlite3
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+from src.ingestion import hansard
+from src.ingestion.dispatcher import SourceDispatcher
+
+
+def test_normalization_and_citation_extraction():
+    text = "\n  This references the Crimes Act 1914  and   Another Act 2000.\n"
+    norm = hansard.normalize_text(text)
+    assert norm == "This references the Crimes Act 1914 and Another Act 2000."
+    citations = hansard.extract_citations(norm)
+    assert citations == ["Crimes Act 1914", "Another Act 2000"]
+
+
+def test_hash_stability_and_graph_generation():
+    debates = [
+        {
+            "id": "deb1",
+            "text": "Debate on the Crimes Act 1914",
+            "date": "2023-01-01",
+        }
+    ]
+    nodes1, edges1 = hansard.fetch_debates(debates)
+    nodes2, edges2 = hansard.fetch_debates(debates)
+    hash1 = nodes1[0]["metadata"]["hash"]
+    hash2 = nodes2[0]["metadata"]["hash"]
+    assert hash1 == hash2
+    # Ensure citation and edge captured
+    assert nodes1[1]["id"] == "Crimes Act 1914"
+    assert edges1[0]["to"] == "Crimes Act 1914"
+
+
+def test_dispatch_persists_hansard(tmp_path):
+    db_path = tmp_path / "hansard.db"
+    config = {
+        "sources": [
+            {
+                "name": "Hansard",
+                "adapter": "hansard",
+                "debates": [
+                    {"id": "d1", "text": "Discussion of the Crimes Act 1914"}
+                ],
+                "db_path": str(db_path),
+            }
+        ]
+    }
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps(config))
+    dispatcher = SourceDispatcher(cfg)
+    dispatcher.dispatch()
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT id, type FROM nodes").fetchall()
+    conn.close()
+    assert ("d1", "debate") in [(r[0], r[1]) for r in rows]


### PR DESCRIPTION
## Summary
- add Hansard ingestion module that normalises debate text, extracts citations and stores SHA-256 hashes
- extend SourceDispatcher to handle Hansard jobs and persist graph nodes and edges to SQLite
- test Hansard normalisation, citation extraction, hashing stability and dispatcher persistence

## Testing
- `pytest tests/ingestion/test_hansard.py tests/ingestion/test_dispatcher.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689d85f6b6d8832298119c5b42874184