### PR TITLE
Add bitemporal storage and as-at queries

### DIFF
--- a/src/storage/core.py
+++ b/src/storage/core.py
@@ -12,6 +12,10 @@ class Node:
     id: Optional[int]
     type: str
     data: Dict[str, Any]
+    valid_from: str | None = None
+    valid_to: str | None = None
+    recorded_from: str | None = None
+    recorded_to: str | None = None
 
 
 @dataclass
@@ -21,6 +25,10 @@ class Edge:
     target: int
     type: str
     data: Optional[Dict[str, Any]] = None
+    valid_from: str | None = None
+    valid_to: str | None = None
+    recorded_from: str | None = None
+    recorded_to: str | None = None
 
 
 @dataclass
@@ -81,40 +89,108 @@ class Storage:
     # ------------------------------------------------------------------
     # Nodes
     # ------------------------------------------------------------------
-    def insert_node(self, type: str, data: Dict[str, Any]) -> int:
+    def insert_node(
+        self,
+        type: str,
+        data: Dict[str, Any],
+        *,
+        valid_from: str | None = None,
+        valid_to: str | None = None,
+        recorded_from: str | None = None,
+        recorded_to: str | None = None,
+    ) -> int:
+        valid_from = valid_from or "1970-01-01"
+        recorded_from = recorded_from or valid_from
         with self.conn:
             cur = self.conn.execute(
-                "INSERT INTO nodes(type, data) VALUES (?, ?)",
-                (type, json.dumps(data)),
+                "INSERT INTO nodes(type, data, valid_from, valid_to, recorded_from, recorded_to) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    type,
+                    json.dumps(data),
+                    valid_from,
+                    valid_to,
+                    recorded_from,
+                    recorded_to,
+                ),
             )
             return cur.lastrowid
 
     def get_node(self, node_id: int) -> Optional[Node]:
         row = self.conn.execute(
-            "SELECT id, type, data FROM nodes WHERE id = ?",
+            "SELECT id, type, data, valid_from, valid_to, recorded_from, recorded_to FROM nodes WHERE id = ?",
             (node_id,),
         ).fetchone()
         if row is None:
             return None
-        return Node(id=row["id"], type=row["type"], data=json.loads(row["data"]))
+        return Node(
+            id=row["id"],
+            type=row["type"],
+            data=json.loads(row["data"]),
+            valid_from=row["valid_from"],
+            valid_to=row["valid_to"],
+            recorded_from=row["recorded_from"],
+            recorded_to=row["recorded_to"],
+        )
 
     def update_node(
-        self, node_id: int, *, type: Optional[str] = None, data: Optional[Dict[str, Any]] = None
+        self,
+        node_id: int,
+        *,
+        type: Optional[str] = None,
+        data: Optional[Dict[str, Any]] = None,
+        valid_from: Optional[str] = None,
+        valid_to: Optional[str] = None,
+        recorded_from: Optional[str] = None,
+        recorded_to: Optional[str] = None,
     ) -> None:
         node = self.get_node(node_id)
         if node is None:
             raise KeyError(node_id)
         type = type if type is not None else node.type
         data = data if data is not None else node.data
+        valid_from = valid_from if valid_from is not None else node.valid_from
+        valid_to = valid_to if valid_to is not None else node.valid_to
+        recorded_from = recorded_from if recorded_from is not None else node.recorded_from
+        recorded_to = recorded_to if recorded_to is not None else node.recorded_to
         with self.conn:
             self.conn.execute(
-                "UPDATE nodes SET type = ?, data = ? WHERE id = ?",
-                (type, json.dumps(data), node_id),
+                "UPDATE nodes SET type = ?, data = ?, valid_from = ?, valid_to = ?, recorded_from = ?, recorded_to = ? WHERE id = ?",
+                (
+                    type,
+                    json.dumps(data),
+                    valid_from,
+                    valid_to,
+                    recorded_from,
+                    recorded_to,
+                    node_id,
+                ),
             )
 
     def delete_node(self, node_id: int) -> None:
         with self.conn:
             self.conn.execute("DELETE FROM nodes WHERE id = ?", (node_id,))
+
+    def fetch_node_as_at(self, node_id: int, as_at: str) -> Optional[Node]:
+        row = self.conn.execute(
+            """
+            SELECT id, type, data, valid_from, valid_to, recorded_from, recorded_to
+            FROM nodes
+            WHERE id = ? AND valid_from <= ? AND (valid_to IS NULL OR valid_to > ?)
+            """,
+            (node_id, as_at, as_at),
+        ).fetchone()
+        if row is None:
+            return None
+        return Node(
+            id=row["id"],
+            type=row["type"],
+            data=json.loads(row["data"]),
+            valid_from=row["valid_from"],
+            valid_to=row["valid_to"],
+            recorded_from=row["recorded_from"],
+            recorded_to=row["recorded_to"],
+        )
 
     # ------------------------------------------------------------------
     # Edges
@@ -125,17 +201,34 @@ class Storage:
         target: int,
         type: str,
         data: Optional[Dict[str, Any]] = None,
+        *,
+        valid_from: str | None = None,
+        valid_to: str | None = None,
+        recorded_from: str | None = None,
+        recorded_to: str | None = None,
     ) -> int:
+        valid_from = valid_from or "1970-01-01"
+        recorded_from = recorded_from or valid_from
         with self.conn:
             cur = self.conn.execute(
-                "INSERT INTO edges(source, target, type, data) VALUES (?, ?, ?, ?)",
-                (source, target, type, json.dumps(data) if data is not None else None),
+                "INSERT INTO edges(source, target, type, data, valid_from, valid_to, recorded_from, recorded_to) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    source,
+                    target,
+                    type,
+                    json.dumps(data) if data is not None else None,
+                    valid_from,
+                    valid_to,
+                    recorded_from,
+                    recorded_to,
+                ),
             )
             return cur.lastrowid
 
     def get_edge(self, edge_id: int) -> Optional[Edge]:
         row = self.conn.execute(
-            "SELECT id, source, target, type, data FROM edges WHERE id = ?",
+            "SELECT id, source, target, type, data, valid_from, valid_to, recorded_from, recorded_to FROM edges WHERE id = ?",
             (edge_id,),
         ).fetchone()
         if row is None:
@@ -147,6 +240,10 @@ class Storage:
             target=row["target"],
             type=row["type"],
             data=data,
+            valid_from=row["valid_from"],
+            valid_to=row["valid_to"],
+            recorded_from=row["recorded_from"],
+            recorded_to=row["recorded_to"],
         )
 
     def update_edge(
@@ -157,6 +254,10 @@ class Storage:
         target: Optional[int] = None,
         type: Optional[str] = None,
         data: Optional[Dict[str, Any]] = None,
+        valid_from: Optional[str] = None,
+        valid_to: Optional[str] = None,
+        recorded_from: Optional[str] = None,
+        recorded_to: Optional[str] = None,
     ) -> None:
         edge = self.get_edge(edge_id)
         if edge is None:
@@ -165,15 +266,62 @@ class Storage:
         target = target if target is not None else edge.target
         type = type if type is not None else edge.type
         data = data if data is not None else edge.data
+        valid_from = valid_from if valid_from is not None else edge.valid_from
+        valid_to = valid_to if valid_to is not None else edge.valid_to
+        recorded_from = recorded_from if recorded_from is not None else edge.recorded_from
+        recorded_to = recorded_to if recorded_to is not None else edge.recorded_to
         with self.conn:
             self.conn.execute(
-                "UPDATE edges SET source = ?, target = ?, type = ?, data = ? WHERE id = ?",
-                (source, target, type, json.dumps(data) if data is not None else None, edge_id),
+                """
+                UPDATE edges
+                SET source = ?, target = ?, type = ?, data = ?,
+                    valid_from = ?, valid_to = ?, recorded_from = ?, recorded_to = ?
+                WHERE id = ?
+                """,
+                (
+                    source,
+                    target,
+                    type,
+                    json.dumps(data) if data is not None else None,
+                    valid_from,
+                    valid_to,
+                    recorded_from,
+                    recorded_to,
+                    edge_id,
+                ),
             )
 
     def delete_edge(self, edge_id: int) -> None:
         with self.conn:
             self.conn.execute("DELETE FROM edges WHERE id = ?", (edge_id,))
+
+    def fetch_edges_as_at(self, node_id: int, as_at: str) -> list[Edge]:
+        rows = self.conn.execute(
+            """
+            SELECT id, source, target, type, data, valid_from, valid_to, recorded_from, recorded_to
+            FROM edges
+            WHERE (source = ? OR target = ?)
+              AND valid_from <= ? AND (valid_to IS NULL OR valid_to > ?)
+            """,
+            (node_id, node_id, as_at, as_at),
+        ).fetchall()
+        edges: list[Edge] = []
+        for row in rows:
+            data = json.loads(row["data"]) if row["data"] is not None else None
+            edges.append(
+                Edge(
+                    id=row["id"],
+                    source=row["source"],
+                    target=row["target"],
+                    type=row["type"],
+                    data=data,
+                    valid_from=row["valid_from"],
+                    valid_to=row["valid_to"],
+                    recorded_from=row["recorded_from"],
+                    recorded_to=row["recorded_to"],
+                )
+            )
+        return edges
 
     # ------------------------------------------------------------------
     # Frames

--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -1,7 +1,11 @@
 CREATE TABLE IF NOT EXISTS nodes (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     type TEXT NOT NULL,
-    data TEXT NOT NULL
+    data TEXT NOT NULL,
+    valid_from TEXT NOT NULL DEFAULT '1970-01-01',
+    valid_to TEXT,
+    recorded_from TEXT NOT NULL DEFAULT '1970-01-01',
+    recorded_to TEXT
 );
 
 CREATE TABLE IF NOT EXISTS edges (
@@ -9,8 +13,17 @@ CREATE TABLE IF NOT EXISTS edges (
     source INTEGER NOT NULL REFERENCES nodes(id),
     target INTEGER NOT NULL REFERENCES nodes(id),
     type TEXT NOT NULL,
-    data TEXT
+    data TEXT,
+    valid_from TEXT NOT NULL DEFAULT '1970-01-01',
+    valid_to TEXT,
+    recorded_from TEXT NOT NULL DEFAULT '1970-01-01',
+    recorded_to TEXT
 );
+
+CREATE INDEX IF NOT EXISTS idx_nodes_valid ON nodes(valid_from, valid_to);
+CREATE INDEX IF NOT EXISTS idx_edges_valid ON edges(valid_from, valid_to);
+CREATE INDEX IF NOT EXISTS idx_nodes_recorded ON nodes(recorded_from, recorded_to);
+CREATE INDEX IF NOT EXISTS idx_edges_recorded ON edges(recorded_from, recorded_to);
 
 CREATE TABLE IF NOT EXISTS frames (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/storage/test_bitemporal.py
+++ b/tests/storage/test_bitemporal.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+
+from src.storage.core import Storage
+
+
+def test_as_at_queries(tmp_path):
+    db_path = tmp_path / "test.db"
+    store = Storage(db_path)
+
+    # create two nodes with finite validity
+    n1 = store.insert_node("entity", {}, valid_from="2020-01-01", valid_to="2020-12-31")
+    n2 = store.insert_node("entity", {}, valid_from="2020-01-01", valid_to="2020-12-31")
+
+    # two edges representing different valid periods
+    e1 = store.insert_edge(
+        n1,
+        n2,
+        "rel",
+        {},
+        valid_from="2020-01-01",
+        valid_to="2020-06-30",
+    )
+    e2 = store.insert_edge(
+        n1,
+        n2,
+        "rel",
+        {},
+        valid_from="2020-07-01",
+        valid_to="2020-12-31",
+    )
+
+    # as-at before edge swap
+    edges_may = store.fetch_edges_as_at(n1, "2020-05-01")
+    assert {e.id for e in edges_may} == {e1}
+
+    # as-at after edge swap
+    edges_aug = store.fetch_edges_as_at(n1, "2020-08-01")
+    assert {e.id for e in edges_aug} == {e2}
+
+    # node validity checks
+    assert store.fetch_node_as_at(n1, "2020-05-01") is not None
+    assert store.fetch_node_as_at(n1, "2021-01-01") is None
+
+    store.close()
+


### PR DESCRIPTION
## Summary
- support bitemporal intervals on `nodes` and `edges`
- add `fetch_node_as_at` and `fetch_edges_as_at` accessors
- test bitemporal snapshot queries

## Testing
- `pytest tests/storage/test_core_schema.py tests/storage/test_bitemporal.py -q`
- `pip install hypothesis -q` *(fails: Could not find a version that satisfies the requirement hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_689d832e0fa08322a8e1dbf7a43bbbf4