### PR TITLE
Add definition graph with SCC-based expansion and CLI

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -120,6 +120,12 @@ def main() -> None:
         "--story-file", type=Path, required=True, help="Story JSON file"
     )
 
+    definitions_parser = sub.add_parser("definitions", help="Definition operations")
+    definitions_sub = definitions_parser.add_subparsers(dest="definitions_command")
+    definitions_expand = definitions_sub.add_parser("expand", help="Expand term definitions")
+    definitions_expand.add_argument("--term", required=True, help="Term identifier")
+    definitions_expand.add_argument("--depth", type=int, default=1, help="Expansion depth")
+
     cases_parser = sub.add_parser("cases", help="Case operations")
     cases_sub = cases_parser.add_subparsers(dest="cases_command")
     cases_treat = cases_sub.add_parser("treatment", help="Fetch case treatment")
@@ -369,6 +375,16 @@ def main() -> None:
             tags = set(story.get("tags", []))
             result = evaluate(checklist, tags)
             print(json.dumps(result))
+        else:
+            parser.print_help()
+    elif args.command == "definitions":
+        if args.definitions_command == "expand":
+            from .definitions.graph import DefinitionGraph, load_default_definitions
+
+            defs = load_default_definitions()
+            graph = DefinitionGraph(defs)
+            scoped = graph.expand(args.term, depth=args.depth)
+            print(json.dumps(scoped))
         else:
             parser.print_help()
     elif args.command == "cases":

--- a/src/definitions/__init__.py
+++ b/src/definitions/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for working with term definitions."""
+
+from .graph import DefinitionGraph, load_default_definitions
+
+__all__ = ["DefinitionGraph", "load_default_definitions"]

--- a/src/definitions/graph.py
+++ b/src/definitions/graph.py
@@ -1,0 +1,118 @@
+"""Directed graph utilities for term definitions.
+
+This module builds a graph of term identifiers linked by the terms used in
+their definitions.  Tarjan's algorithm is used to compute strongly connected
+components which are then used to break cycles when expanding definitions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Set, DefaultDict
+from collections import defaultdict
+import json
+from pathlib import Path
+
+
+@dataclass
+class Definition:
+    """A simple term definition."""
+
+    term: str
+    refers: List[str]
+
+
+class DefinitionGraph:
+    """Graph of term definitions with SCC detection."""
+
+    def __init__(self, definitions: Dict[str, List[str]]):
+        # Normalise graph ensuring all referenced nodes exist
+        self.graph: DefaultDict[str, List[str]] = defaultdict(list)
+        for term, refs in definitions.items():
+            self.graph[term].extend(refs)
+            for ref in refs:
+                self.graph.setdefault(ref, [])
+        # Pre-compute strongly connected components
+        self._build_scc()
+
+    # Tarjan's algorithm implementation
+    def _build_scc(self) -> None:
+        index = 0
+        stack: List[str] = []
+        indices: Dict[str, int] = {}
+        lowlinks: Dict[str, int] = {}
+        on_stack: Set[str] = set()
+        self._components: List[List[str]] = []
+        self._comp_index: Dict[str, int] = {}
+
+        def strongconnect(node: str) -> None:
+            nonlocal index
+            indices[node] = index
+            lowlinks[node] = index
+            index += 1
+            stack.append(node)
+            on_stack.add(node)
+
+            for neigh in self.graph.get(node, []):
+                if neigh not in indices:
+                    strongconnect(neigh)
+                    lowlinks[node] = min(lowlinks[node], lowlinks[neigh])
+                elif neigh in on_stack:
+                    lowlinks[node] = min(lowlinks[node], indices[neigh])
+
+            if lowlinks[node] == indices[node]:
+                comp: List[str] = []
+                while True:
+                    w = stack.pop()
+                    on_stack.remove(w)
+                    comp.append(w)
+                    if w == node:
+                        break
+                comp_id = len(self._components)
+                for n in comp:
+                    self._comp_index[n] = comp_id
+                self._components.append(comp)
+
+        for node in list(self.graph.keys()):
+            if node not in indices:
+                strongconnect(node)
+
+    def expand(self, term: str, depth: int = 1) -> Dict[str, List[str]]:
+        """Expand ``term`` definitions up to ``depth`` hops.
+
+        Expansion respects strongly connected components so that nodes within
+        the same component are expanded together and only once, preventing
+        infinite recursion on cyclic definitions.
+        """
+
+        result: Dict[str, List[str]] = {}
+        visited: Set[int] = set()
+
+        def _expand_comp(comp_id: int, d: int) -> None:
+            if comp_id in visited:
+                return
+            visited.add(comp_id)
+            nodes = self._components[comp_id]
+            for node in nodes:
+                result[node] = self.graph.get(node, [])
+            if d > 0:
+                for node in nodes:
+                    for dep in self.graph.get(node, []):
+                        dep_comp = self._comp_index[dep]
+                        if dep_comp not in visited:
+                            _expand_comp(dep_comp, d - 1)
+
+        start_comp = self._comp_index.get(term)
+        if start_comp is None:
+            return {}
+        _expand_comp(start_comp, depth)
+        return result
+
+
+def load_default_definitions() -> Dict[str, List[str]]:
+    """Load bundled definitions from ``definitions.json`` if present."""
+
+    path = Path(__file__).with_name("definitions.json")
+    if path.exists():
+        return json.loads(path.read_text())
+    return {}

--- a/tests/definitions/test_graph.py
+++ b/tests/definitions/test_graph.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+
+from src.definitions import DefinitionGraph
+
+
+def test_cyclic_definitions_do_not_loop():
+    defs = {
+        "a": ["b"],
+        "b": ["c"],
+        "c": ["a"],
+    }
+    graph = DefinitionGraph(defs)
+    result = graph.expand("a", depth=10)
+    assert result == {
+        "a": ["b"],
+        "b": ["c"],
+        "c": ["a"],
+    }
+
+
+def test_expansion_is_deterministic():
+    defs = {
+        "a": ["b"],
+        "b": ["c"],
+        "c": ["a"],
+    }
+    graph = DefinitionGraph(defs)
+    first = graph.expand("a", depth=5)
+    second = graph.expand("a", depth=5)
+    assert first == second


### PR DESCRIPTION
## Summary
- implement DefinitionGraph with Tarjan SCC computation and depth-limited expansion
- add `sensiblaw definitions expand` CLI for scoped definition expansion
- test cyclic definition handling and deterministic expansions

## Testing
- `pytest tests/definitions/test_graph.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d8321de588322a21bbb633303f1da