### PR TITLE
Add email intake parsing and stub generation

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -137,6 +137,23 @@ def main() -> None:
         help="Directory to save claim files",
     )
 
+    intake_parser = sub.add_parser("intake", help="Email intake operations")
+    intake_sub = intake_parser.add_subparsers(dest="intake_command")
+    intake_parse = intake_sub.add_parser(
+        "parse", help="Parse an email mailbox into claim stubs"
+    )
+    intake_parse.add_argument(
+        "--mailbox",
+        required=True,
+        help="IMAP URL or directory containing .eml files",
+    )
+    intake_parse.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="Directory for generated claim stubs",
+    )
+
     args = parser.parse_args()
     if args.command == "get":
         store = VersionedStore(args.db)
@@ -377,6 +394,17 @@ def main() -> None:
 
             result = fetch_case_treatment(args.case_id)
             print(json.dumps(result))
+        else:
+            parser.print_help()
+    elif args.command == "intake":
+        if args.intake_command == "parse":
+            from .intake.email_parser import fetch_messages, parse_email
+            from .intake.stub_builder import build_stub
+
+            messages = fetch_messages(str(args.mailbox))
+            for msg in messages:
+                data = parse_email(msg)
+                build_stub(data, args.out)
         else:
             parser.print_help()
     elif args.command == "tools":

--- a/src/intake/email_parser.py
+++ b/src/intake/email_parser.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import imaplib
+import re
+from email import policy
+from email.message import EmailMessage
+from email.parser import BytesParser
+from pathlib import Path
+from typing import Dict, List
+from urllib.parse import urlparse
+
+
+def fetch_messages(mailbox: str) -> List[EmailMessage]:
+    """Fetch email messages from an IMAP server or local directory.
+
+    The *mailbox* argument may be one of:
+    - an ``imap://`` URL pointing to an IMAP server.  The URL may include
+      username, password and mailbox path, e.g.
+      ``imap://user:pass@host/INBOX``.
+    - a filesystem path or ``file://`` URL pointing to a directory containing
+      ``.eml`` files.  This mode is primarily used for tests.
+    """
+
+    parsed = urlparse(mailbox)
+    scheme = parsed.scheme
+    # Local directory mode for tests / offline use
+    if scheme in {"", "file"}:
+        directory = Path(parsed.path)
+        messages: List[EmailMessage] = []
+        for eml in sorted(directory.glob("*.eml")):
+            with eml.open("rb") as f:
+                msg = BytesParser(policy=policy.default).parse(f)
+                messages.append(msg)
+        return messages
+
+    if scheme != "imap":
+        raise ValueError(f"Unsupported mailbox scheme: {scheme}")
+
+    host = parsed.hostname or "localhost"
+    username = parsed.username or ""
+    password = parsed.password or ""
+    mailbox_name = parsed.path.lstrip("/") or "INBOX"
+
+    with imaplib.IMAP4_SSL(host) as imap:
+        if username:
+            imap.login(username, password)
+        imap.select(mailbox_name)
+        typ, data = imap.search(None, "ALL")
+        messages: List[EmailMessage] = []
+        for num in data[0].split():
+            typ, msg_data = imap.fetch(num, "(RFC822)")
+            msg = BytesParser(policy=policy.default).parsebytes(msg_data[0][1])
+            messages.append(msg)
+        imap.logout()
+    return messages
+
+
+def _extract_fields(text: str, subject: str) -> Dict[str, str]:
+    combined = subject + "\n" + text
+
+    parties: List[str] = []
+    m = re.search(r"Parties:\s*(.+)", combined, re.IGNORECASE)
+    if m:
+        parties = [p.strip() for p in re.split(r"[;,]", m.group(1)) if p.strip()]
+    else:
+        m = re.search(r"Case:\s*(.+)", combined, re.IGNORECASE)
+        if m:
+            case_line = m.group(1)
+            m2 = re.search(r"(.+?)\s+v(?:s\.?|\.)?\s+(.+)", case_line, re.IGNORECASE)
+            if m2:
+                parties = [m2.group(1).strip(), m2.group(2).strip()]
+    if not parties:
+        m = re.search(r"(.+?)\s+v(?:s\.?|\.)?\s+(.+)", combined, re.IGNORECASE)
+        if m:
+            parties = [m.group(1).strip(), m.group(2).strip()]
+
+    jurisdiction = ""
+    m = re.search(r"Jurisdiction:\s*(.+)", combined, re.IGNORECASE)
+    if m:
+        jurisdiction = m.group(1).strip()
+    else:
+        m = re.search(r"\b(NSW|VIC|QLD|SA|WA|TAS|NT|ACT)\b", subject)
+        if m:
+            jurisdiction = m.group(1)
+
+    summary = ""
+    m = re.search(r"Summary:\s*(.+)", combined, re.IGNORECASE | re.DOTALL)
+    if m:
+        summary = m.group(1).strip()
+    else:
+        # Use first non-empty line as summary fallback
+        for line in text.splitlines():
+            line = line.strip()
+            if line:
+                summary = line
+                break
+
+    return {
+        "parties": parties,
+        "jurisdiction": jurisdiction,
+        "summary": summary,
+    }
+
+
+def parse_email(msg: EmailMessage) -> Dict[str, str]:
+    """Parse an ``EmailMessage`` into structured data."""
+    if msg.is_multipart():
+        parts: List[str] = []
+        for part in msg.walk():
+            if part.get_content_type() == "text/plain":
+                payload = part.get_payload(decode=True)
+                charset = part.get_content_charset() or "utf-8"
+                parts.append(payload.decode(charset, errors="ignore"))
+        body = "\n".join(parts)
+    else:
+        payload = msg.get_payload(decode=True)
+        charset = msg.get_content_charset() or "utf-8"
+        body = payload.decode(charset, errors="ignore") if payload else ""
+
+    subject = msg.get("Subject", "")
+    return _extract_fields(body, subject)

--- a/src/intake/stub_builder.py
+++ b/src/intake/stub_builder.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+def _slug(parties: List[str]) -> str:
+    if not parties:
+        return "case"
+    return "-".join(p.lower().replace(" ", "_") for p in parties)
+
+
+def build_stub(data: Dict[str, str], out_dir: Path) -> Path:
+    """Write a draft case record to ``out_dir``.
+
+    The filename is derived from the parties to allow deterministic output.
+    The record minimally contains the parties, jurisdiction and summary.
+    """
+
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    filename = f"{_slug(data.get('parties', []))}.json"
+    path = out / filename
+    payload = {
+        "parties": data.get("parties", []),
+        "jurisdiction": data.get("jurisdiction"),
+        "summary": data.get("summary"),
+    }
+    path.write_text(json.dumps(payload, indent=2))
+    return path

--- a/tests/fixtures/emails/email1.eml
+++ b/tests/fixtures/emails/email1.eml
@@ -1,0 +1,9 @@
+From: reporter1@example.com
+To: intake@sensiblaw.test
+Subject: Alice v Bob - NSW
+Date: Mon, 1 Jan 2024 10:00:00 +0000
+Content-Type: text/plain; charset="utf-8"
+
+Case: Alice v Bob
+Jurisdiction: NSW
+Summary: Alice alleges Bob breached contract.

--- a/tests/fixtures/emails/email2.eml
+++ b/tests/fixtures/emails/email2.eml
@@ -1,0 +1,9 @@
+From: reporter2@example.com
+To: intake@sensiblaw.test
+Subject: Charlie vs Delta (VIC)
+Date: Tue, 2 Feb 2024 11:00:00 +0000
+Content-Type: text/plain; charset="utf-8"
+
+Parties: Charlie; Delta
+Jurisdiction: VIC
+Summary: Land dispute between neighbours.

--- a/tests/test_intake_cli.py
+++ b/tests/test_intake_cli.py
@@ -1,0 +1,33 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_intake_parse_generates_stubs(tmp_path: Path):
+    mailbox = Path("tests/fixtures/emails")
+    out_dir = tmp_path / "claims"
+    cmd = [
+        "python",
+        "-m",
+        "src.cli",
+        "intake",
+        "parse",
+        "--mailbox",
+        str(mailbox),
+        "--out",
+        str(out_dir),
+    ]
+    subprocess.run(cmd, check=True)
+
+    data1 = json.loads((out_dir / "alice-bob.json").read_text())
+    assert data1 == {
+        "parties": ["Alice", "Bob"],
+        "jurisdiction": "NSW",
+        "summary": "Alice alleges Bob breached contract.",
+    }
+    data2 = json.loads((out_dir / "charlie-delta.json").read_text())
+    assert data2 == {
+        "parties": ["Charlie", "Delta"],
+        "jurisdiction": "VIC",
+        "summary": "Land dispute between neighbours.",
+    }


### PR DESCRIPTION
## Summary
- parse email mailboxes from IMAP or .eml directories and extract parties, jurisdiction, summary
- build deterministic claim stubs from parsed messages
- add `sensiblaw intake parse` CLI and tests for stub generation

## Testing
- `pytest tests/test_intake_cli.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi hypothesis -q` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_689d8301e8848322843dce73eb63ef7b