### PR TITLE
Add statute redline utility

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -41,6 +41,15 @@ def main() -> None:
         "--cultural-flags", nargs="*", help="List of cultural sensitivity flags"
     )
 
+    law_parser = sub.add_parser("law", help="Law document utilities")
+    law_sub = law_parser.add_subparsers(dest="law_command")
+    law_redline = law_sub.add_parser(
+        "redline", help="Generate HTML diff between two statute versions"
+    )
+    law_redline.add_argument("--old", type=Path, required=True, help="Path to old version")
+    law_redline.add_argument("--new", type=Path, required=True, help="Path to new version")
+    law_redline.add_argument("--out", type=Path, required=True, help="Output HTML file")
+
     dist_parser = sub.add_parser(
         "distinguish", help="Compare a story against a case silhouette"
     )
@@ -183,6 +192,16 @@ def main() -> None:
             cultural_flags=args.cultural_flags,
         )
         print(doc.to_json())
+    elif args.command == "law":
+        if args.law_command == "redline":
+            from .versioning.section_diff import redline
+
+            old_text = args.old.read_text()
+            new_text = args.new.read_text()
+            html = redline(old_text, new_text, old_ref=str(args.old), new_ref=str(args.new))
+            args.out.write_text(html)
+        else:
+            parser.print_help()
     elif args.command == "distinguish":
         from .distinguish.loader import load_case_silhouette
         from .distinguish.engine import compare_story_to_case

--- a/src/versioning/__init__.py
+++ b/src/versioning/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for document versioning and redlines."""
+
+from .section_diff import redline
+
+__all__ = ["redline"]

--- a/src/versioning/section_diff.py
+++ b/src/versioning/section_diff.py
@@ -1,0 +1,106 @@
+"""HTML section diffing utilities.
+
+This module provides a simple HTML redline generator that aligns sections
+between two statute versions and highlights textual changes. Sections are
+matched by normalised headings (stripping numbering and extra whitespace)
+before computing word-level diffs.
+"""
+from __future__ import annotations
+
+import html
+import re
+from difflib import SequenceMatcher
+from typing import Dict, List, Tuple
+
+
+_heading_re = re.compile(r"<h[1-6][^>]*>(.*?)</h[1-6]>", re.I | re.S)
+
+
+def _slugify(text: str) -> str:
+    text = re.sub(r"[^a-z0-9]+", "-", text.lower())
+    return text.strip("-")
+
+
+def _normalise_heading(text: str) -> str:
+    text = html.unescape(text)
+    # remove leading numbering like "1", "1.", "1A" etc
+    text = re.sub(r"^\s*\d+[A-Za-z]*[.)]?\s*", "", text)
+    return " ".join(text.split())
+
+
+def _split_sections(doc: str) -> Dict[str, Tuple[str, str]]:
+    """Split an HTML document into sections keyed by normalised heading.
+
+    Returns a mapping of section key to a tuple of (display heading, body).
+    """
+    sections: Dict[str, Tuple[str, str]] = {}
+    pattern = re.compile(r"(<h[1-6][^>]*>.*?</h[1-6]>)(.*?)(?=<h[1-6][^>]*>|$)", re.I | re.S)
+    for heading_html, body in pattern.findall(doc):
+        heading = _heading_re.search(heading_html)
+        if not heading:
+            continue
+        raw_heading = heading.group(1)
+        display_heading = html.unescape(re.sub(r"<[^>]+>", "", raw_heading)).strip()
+        key = _slugify(_normalise_heading(display_heading))
+        body_text = html.unescape(re.sub(r"<[^>]+>", "", body)).strip()
+        sections[key] = (display_heading, body_text)
+    return sections
+
+
+def _normalise_body(text: str) -> List[str]:
+    # strip numbering at line starts and collapse whitespace
+    lines = []
+    for line in html.unescape(text).splitlines():
+        line = re.sub(r"^\s*\d+[A-Za-z]*[.)]?\s*", "", line)
+        lines.append(line.strip())
+    normalised = " ".join(" ".join(lines).split())
+    return normalised.split()
+
+
+def _diff_words(old: str, new: str) -> str:
+    old_words = _normalise_body(old)
+    new_words = _normalise_body(new)
+    sm = SequenceMatcher(None, old_words, new_words)
+    parts: List[str] = []
+    for tag, i1, i2, j1, j2 in sm.get_opcodes():
+        if tag == "equal":
+            parts.append(" ".join(old_words[i1:i2]))
+        elif tag == "delete":
+            parts.append(f'<span class="del">{" ".join(old_words[i1:i2])}</span>')
+        elif tag == "insert":
+            parts.append(f'<span class="ins">{" ".join(new_words[j1:j2])}</span>')
+        elif tag == "replace":
+            parts.append(f'<span class="del">{" ".join(old_words[i1:i2])}</span>')
+            parts.append(f'<span class="ins">{" ".join(new_words[j1:j2])}</span>')
+    return " ".join(parts)
+
+
+def redline(old: str, new: str, old_ref: str = "old", new_ref: str = "new") -> str:
+    """Generate an HTML redline comparing two statute versions.
+
+    Parameters
+    ----------
+    old, new:
+        HTML strings for the old and new statute versions.
+    old_ref, new_ref:
+        Base URLs or paths used for section anchor links.
+    """
+    old_secs = _split_sections(old)
+    new_secs = _split_sections(new)
+    keys = sorted(set(old_secs) | set(new_secs))
+    out: List[str] = ["<html><body>"]
+    for key in keys:
+        old_sec = old_secs.get(key, ("", ""))
+        new_sec = new_secs.get(key, ("", ""))
+        heading = old_sec[0] or new_sec[0] or key
+        diff_html = _diff_words(old_sec[1], new_sec[1])
+        out.append(f'<section id="{key}">')
+        out.append(f"<h2>{heading}</h2>")
+        out.append(
+            f'<a href="{old_ref}#{key}">old</a> | <a href="{new_ref}#{key}">new</a>'
+        )
+        if diff_html:
+            out.append(f"<p>{diff_html}</p>")
+        out.append("</section>")
+    out.append("</body></html>")
+    return "\n".join(out)

--- a/tests/fixtures/statute_v1.html
+++ b/tests/fixtures/statute_v1.html
@@ -1,0 +1,4 @@
+<h2>Section 1 - Short title</h2>
+<p>This Act may be cited as the Test Act 2020.</p>
+<h2>Section 2 - Purpose</h2>
+<p>The purpose of this Act is to test diffing.</p>

--- a/tests/fixtures/statute_v2.html
+++ b/tests/fixtures/statute_v2.html
@@ -1,0 +1,4 @@
+<h2>Section 1 - Short title</h2>
+<p>This Act may be cited as the Test Act 2021.</p>
+<h2>Section 2 - Purpose</h2>
+<p>The purpose of this Act is to test diffing.</p>

--- a/tests/versioning/test_section_diff.py
+++ b/tests/versioning/test_section_diff.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+from src.versioning.section_diff import redline
+
+
+def test_only_changed_spans():
+    old = (ROOT / "tests/fixtures/statute_v1.html").read_text()
+    new = (ROOT / "tests/fixtures/statute_v2.html").read_text()
+
+    html = redline(old, new, old_ref="old.html", new_ref="new.html")
+
+    assert '<span class="del">2020' in html
+    assert '<span class="ins">2021' in html
+
+    match = re.search(
+        r"<h2>Section 2 - Purpose</h2>.*?<p>(.*?)</p>", html, re.S
+    )
+    assert match is not None
+    body = match.group(1)
+    assert "<span" not in body


### PR DESCRIPTION
## Summary
- add `section_diff` module to normalise headings and body text and highlight word changes in HTML
- extend CLI with `law redline` for diffing two statute versions
- include fixture-based test ensuring only modified spans are marked

## Testing
- `pytest tests/versioning/test_section_diff.py -q`
- `python -m src.cli law redline --old tests/fixtures/statute_v1.html --new tests/fixtures/statute_v2.html --out diff.html`


------
https://chatgpt.com/codex/tasks/task_e_689d830bea9c8322a322d76e4ec29f59