### PR TITLE
ci: use explicit ruff check command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install ruff
       - name: Lint
-        run: ruff src tests
+        run: ruff check src tests
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- use `ruff check` explicitly in lint workflow

## Testing
- `ruff check src tests` *(fails: F401/E402 and other errors; 48 issues)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68a7da1c38088322a9dff83329fc174d