### PR TITLE
Add Hypothesis development dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ pip install -e .[dev,test]
 pytest
 ```
 
+The test extras install [Hypothesis](https://hypothesis.readthedocs.io/) for property-based testing.
+
 ## Writing tests
 
 New features and fixes should include tests. A helper script is available to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "ruff",
     "mypy",
     "pre-commit",
+    "hypothesis",
 ]
 test = [
     "pytest",


### PR DESCRIPTION
## Summary
- include Hypothesis in development extras
- document installing Hypothesis for property-based tests

## Testing
- `pre-commit run --files pyproject.toml CONTRIBUTING.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pip install hypothesis` *(fails: Could not find a version that satisfies the requirement hypothesis)*
- `python - <<'PY'
import hypothesis
print('hypothesis available')
PY` *(fails: ModuleNotFoundError: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68a836696d708322897f4e9564076364