### PR TITLE
Ensure postponed annotations imports are first

### DIFF
--- a/src/concepts/matcher.py
+++ b/src/concepts/matcher.py
@@ -1,7 +1,6 @@
-"""Concept matching using an Aho-Corasick automaton."""
-
-
 from __future__ import annotations
+
+"""Concept matching using an Aho-Corasick automaton."""
 
 import json
 from dataclasses import dataclass
@@ -27,8 +26,6 @@ class ConceptHit:
 Provides a :func:`match` function that uses the Aho-Corasick algorithm
 (if available) to locate multiple phrases within a body of text.
 """
-
-from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Iterable, List, Optional, Tuple
@@ -261,7 +258,6 @@ Provides :class:`ConceptMatcher` which loads phrase→concept mappings and
 returns deterministic hit spans when matching against text.  The matcher is
 case-insensitive and orders results by appearance in the input string.
 """
-from __future__ import annotations
 
 import json
 import re

--- a/src/graph/ingest.py
+++ b/src/graph/ingest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Graph ingestion utilities for legal documents.
 
 This module provides a very small in-memory graph representation along with
@@ -18,8 +20,6 @@ edge types are currently emitted:
 ``CITES``
     Connects a case document to another case that it cites.
 """
-
-from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Dict, List, Iterable
@@ -133,7 +133,6 @@ def ingest_document(doc: Document, graph: Graph) -> None:
 
 
 __all__ = ["Graph", "Node", "Edge", "ingest_document"]
-from __future__ import annotations
 
 from typing import Any, Dict, Optional
 

--- a/src/ingestion/cache.py
+++ b/src/ingestion/cache.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import time
 import hashlib
@@ -108,8 +110,6 @@ more than 30 requests per minute to any single host. This keeps the project
 polite when it needs to talk to real services but still remains deterministic
 for tests.
 """
-
-from __future__ import annotations
 
 import hashlib
 import json

--- a/src/repro/ledger.py
+++ b/src/repro/ledger.py
@@ -65,7 +65,6 @@ class CorrectionLedger:
 
 This module provides a minimal API for storing correction entries.
 """
-from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import List

--- a/src/tests/evaluator.py
+++ b/src/tests/evaluator.py
@@ -1,6 +1,6 @@
-"""Evaluation of legal test factors against provided facts."""
-
 from __future__ import annotations
+
+"""Evaluation of legal test factors against provided facts."""
 
 from dataclasses import dataclass, asdict
 from typing import Dict, Iterable, List, Mapping, Sequence
@@ -67,8 +67,6 @@ def evaluate(template: Mapping[str, Sequence[Mapping[str, object]]], facts: Mapp
         rows.append(ResultRow(factor=identifier, status=status, evidence=evidence))
     return ResultTable(rows)
 
-
-from __future__ import annotations
 
 """Evaluation utilities for declarative concept tests."""
 


### PR DESCRIPTION
## Summary
- place `from __future__ import annotations` as the first statement in several modules
- remove duplicate postponed-annotation imports

## Testing
- `pytest -q` *(fails: unmatched parentheses, missing dependencies, enum definition errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a836679af08322833c077541050e2e