### PR TITLE
Deduplicate node and edge enums in legal graph models

### DIFF
--- a/src/graph/models.py
+++ b/src/graph/models.py
@@ -16,9 +16,6 @@ class NodeType(Enum):
     CASE = "case"
     CONCEPT = "concept"
 
-    CONCEPT = "concept"
-    CASE = "case"
-
 
 class EdgeType(Enum):
     """Enumeration of supported edge types within a legal graph."""
@@ -33,10 +30,8 @@ class EdgeType(Enum):
     FOLLOWS = "follows"
     DISTINGUISHES = "distinguishes"
     REJECTS = "rejects"
-    FOLLOWS = "follows"
     APPLIES = "applies"
     CONSIDERS = "considers"
-    DISTINGUISHES = "distinguishes"
     OVERRULES = "overrules"
 
 


### PR DESCRIPTION
## Summary
- Remove duplicate `NodeType` and `EdgeType` entries in graph models

## Testing
- `pytest tests/graph/test_enums.py -q` *(fails: SyntaxError in src/graph/proof_tree.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a83934bfbc8322bc7f74986ff6f0d3