### PR TITLE
refactor: lazily import CLI main wrapper

### DIFF
--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -3,9 +3,6 @@ import json
 from datetime import datetime, date
 from pathlib import Path
 
-from src.storage import VersionedStore
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(prog="sensiblaw")
     sub = parser.add_subparsers(dest="command")
@@ -102,6 +99,8 @@ def main() -> None:
         args.func(args)
         return
     if args.command == "get":
+        from src.storage import VersionedStore
+
         store = VersionedStore(args.db)
         if args.as_at:
             as_at = datetime.fromisoformat(args.as_at).date()

--- a/src/cli.py
+++ b/src/cli.py
@@ -7,7 +7,12 @@ interface now lives in the top-level :mod:`cli` package.
 
 from __future__ import annotations
 
-from cli import main
+def main() -> None:
+    """Entry point that defers loading the heavy ``cli`` package."""
+    from cli import main as real_main
+
+    real_main()
+
 
 __all__ = ["main"]
 

--- a/src/graph/models.py
+++ b/src/graph/models.py
@@ -16,9 +16,6 @@ class NodeType(Enum):
     CASE = "case"
     CONCEPT = "concept"
 
-    CONCEPT = "concept"
-    CASE = "case"
-
 
 class EdgeType(Enum):
     """Enumeration of supported edge types within a legal graph."""
@@ -33,10 +30,8 @@ class EdgeType(Enum):
     FOLLOWS = "follows"
     DISTINGUISHES = "distinguishes"
     REJECTS = "rejects"
-    FOLLOWS = "follows"
     APPLIES = "applies"
     CONSIDERS = "considers"
-    DISTINGUISHES = "distinguishes"
     OVERRULES = "overrules"
 
 


### PR DESCRIPTION
## Summary
- load the CLI entry point lazily through a small `src.cli.main` shim
- defer heavy storage import in the CLI and clean up duplicate graph enums

## Testing
- `pre-commit run --files src/cli.py src/graph/models.py` *(fails: command not found)*
- `python -m src.cli --help`


------
https://chatgpt.com/codex/tasks/task_e_68a839352d308322b54c9cbc05bd46b0