### PR TITLE
Fix storage exports

### DIFF
--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -1,7 +1,7 @@
 from .versioned_store import VersionedStore
 from .fts import TextIndex
 
+# Public objects re-exported when ``from src.storage import *`` is used. Having a
+# single ``__all__`` definition avoids accidental overwrites and makes the
+# intent explicit.
 __all__ = ["VersionedStore", "TextIndex"]
-
-
-__all__ = ["VersionedStore"]


### PR DESCRIPTION
## Summary
- define storage package `__all__` once for clearer exports

## Testing
- `python - <<'PY'
import types, sys
# stub out modules
models_module = types.ModuleType('src.graph.models')
for name in ['GraphNode','LegalGraph','NodeType','GraphEdge']:
    setattr(models_module, name, type(name, (), {}))

graph_module = types.ModuleType('src.graph')
setattr(graph_module, 'models', models_module)

concepts_module = types.ModuleType('src.concepts')
cloud_module = types.ModuleType('src.concepts.cloud')
setattr(cloud_module, 'build_cloud', lambda *args, **kwargs: None)
setattr(concepts_module, 'cloud', cloud_module)

sys.modules['src.graph'] = graph_module
sys.modules['src.graph.models'] = models_module
sys.modules['src.concepts'] = concepts_module
sys.modules['src.concepts.cloud'] = cloud_module

from src.storage import VersionedStore, TextIndex
print(VersionedStore.__name__, TextIndex.__name__)
PY`
- `pytest` *(fails: 'CONCEPT' already defined as 'concept'; missing 'hypothesis'; circular import in cli; SyntaxError in tests.templates)*

------
https://chatgpt.com/codex/tasks/task_e_68a83939c3048322ac2618764b20b987