### PR TITLE
docs: mention test extras with hypothesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ Like coleslaw, it just makes sense.
 
 ## Installation
 
-Install the project and its development dependencies:
+Install the project along with the development and test dependencies:
 
 ```bash
-pip install -e .[dev]
+pip install -e .[dev,test]
 ```
 
 ## Testing
 
-Run the test suite:
+Install the test extras (which include Hypothesis) and run the suite:
 
 ```bash
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dev = [
     "ruff",
     "mypy",
     "pre-commit",
-    "hypothesis",
 ]
 test = [
     "pytest",


### PR DESCRIPTION
## Summary
- remove hypothesis from dev extras and keep it in test extras
- document installing `[dev,test]` to pull in Hypothesis

## Testing
- `pre-commit run --files pyproject.toml README.md` *(fails: command not found)*
- `pytest tests/storage/test_core_props.py::test_node_round_trip -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68a83935ed248322857bdc325abcd937