### PR TITLE
docs: fix linting section formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Execute all linting and type-check hooks:
 
 ```bash
 pre-commit run --all-files
-=======
+```
+
 Install the package in editable mode along with development dependencies to develop locally:
 
 ```bash


### PR DESCRIPTION
## Summary
- fix linting instructions in README

## Testing
- `python -m markdown README.md` *(fails: No module named markdown)*
- `pip install markdown` *(fails: Could not find a version that satisfies the requirement markdown)*
- `pre-commit run --files README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` *(fails: SyntaxError in src/graph/proof_tree.py and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a841ad462083228e5c9db3a62afa58