### PR TITLE
Include Hypothesis dev extra and document property-based tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ pip install -e .[dev,test]
 
 ## Testing
 
-Install the test extras (which include Hypothesis) and run the suite:
+Install the test extras and run the suite. The extras include
+[Hypothesis](https://hypothesis.readthedocs.io/), which powers the
+project's property-based tests:
 
 ```bash
+pip install -e .[test]
 pytest
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "ruff",
     "mypy",
     "pre-commit",
+    "hypothesis",
 ]
 test = [
     "pytest",


### PR DESCRIPTION
## Summary
- note that Hypothesis is required for property-based tests
- include Hypothesis in the `dev` optional dependency set

## Testing
- `pip install -e .[dev,test]` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `pytest tests/storage/test_core_props.py::test_node_round_trip -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a841ac1ba48322be0ef84265ab7163