### PR TITLE
refactor: tidy graph package exports

### DIFF
--- a/src/graph/__init__.py
+++ b/src/graph/__init__.py
@@ -1,27 +1,13 @@
-"""Simple in-memory graph structures and ingestion utilities."""
+"""Graph utilities and lightweight in-memory structures.
 
-from .ingest import Graph, ingest_document
+This package exposes a minimal set of data structures for representing legal
+graphs together with helpers to ingest documents, build proof trees and
+serialise the resulting graph structures.
+"""
 
-__all__ = ["Graph", "ingest_document"]
-
-"""Graph utilities."""
-
-"""Graph utilities for representing relationships between legal entities."""
-
-from .models import EdgeType, GraphEdge, GraphNode, LegalGraph, NodeType
-from .proof_tree import (
-    ProofTree,
-    ProofTreeEdge,
-    ProofTreeNode,
-    Provenance,
-    ResultNode,
-    ResultTable,
-)
-
-from .proof_tree import ProofTree, expand_proof_tree
-from .ingest import compute_weight, ingest_extrinsic
-from .models import EdgeType, ExtrinsicNode, GraphEdge, GraphNode, LegalGraph, NodeType
+from .api import serialize_graph
 from .hierarchy import COURT_RANKS, court_weight
+from .ingest import Graph, compute_weight, ingest_document, ingest_extrinsic
 from .models import (
     CaseNode,
     EdgeType,
@@ -31,9 +17,19 @@ from .models import (
     LegalGraph,
     NodeType,
 )
-from .api import serialize_graph
+from .proof_tree import (
+    ProofTree,
+    ProofTreeEdge,
+    ProofTreeNode,
+    Provenance,
+    ResultNode,
+    ResultTable,
+    expand_proof_tree,
+)
 
 __all__ = [
+    "Graph",
+    "ingest_document",
     "EdgeType",
     "GraphEdge",
     "GraphNode",
@@ -48,11 +44,10 @@ __all__ = [
     "expand_proof_tree",
     "ExtrinsicNode",
     "CaseNode",
-    "LegalGraph",
-    "NodeType",
     "serialize_graph",
     "ingest_extrinsic",
     "compute_weight",
     "court_weight",
     "COURT_RANKS",
 ]
+


### PR DESCRIPTION
## Summary
- clean up graph package __init__ by removing duplicated docstrings and consolidating imports
- define a single `__all__` exposing public graph utilities

## Testing
- `ruff check src/graph/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68ad55fb10a88322be82d15dc84f8d25