### PR TITLE
ci: install test extras before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[test]
-
+          pip install -e .[test] coverage[toml] pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest
       - name: Test and CLI smoke
         run: |
           set -e
@@ -101,8 +99,6 @@ PY
           python scripts/generate_sample_corpus.py
           python examples/distinguish_glj/demo.py
           python -m src.pdf_ingest --help
-
-          pip install pytest coverage[toml] pytest-cov hypothesis
       - name: Test
         run: pytest --cov=src --cov-report=xml
       - name: Evaluate gold set

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pre-commit run --all-files
 Install the package in editable mode along with development dependencies to develop locally:
 
 ```bash
-pip install -e .[dev]
+pip install -e .[dev,test]
 pre-commit install
 pre-commit run --all-files
 ```
@@ -48,7 +48,7 @@ dependencies:
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -e .[dev]
+pip install -e .[dev,test]
 ```
 
 Run the test suite and pre-commit hooks:
@@ -167,7 +167,7 @@ Sample output:
 Install development dependencies:
 
 ```bash
-pip install -e .[dev]
+pip install -e .[dev,test]
 ```
 
 Run tests:

--- a/docs/ci_acceptance.md
+++ b/docs/ci_acceptance.md
@@ -3,6 +3,12 @@
 The CI workflow runs a small acceptance suite after unit tests to ensure
 that command-line entry points are wired correctly.
 
+Install the test extras before running the suite:
+
+```bash
+pip install -e .[test]
+```
+
 The following commands are executed:
 
 ```bash


### PR DESCRIPTION
## Summary
- install test extras in CI before running tests
- document installing `[dev,test]` extras prior to invoking pytest
- note test extras for CI acceptance suite

## Testing
- `pip install -e .[test]` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*
- `pre-commit run --files README.md docs/ci_acceptance.md .github/workflows/ci.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad55f6d4d083228365231d639d6d02