### PR TITLE
Check DAG before transitive reduction

### DIFF
--- a/src/graph/api.py
+++ b/src/graph/api.py
@@ -36,7 +36,16 @@ def serialize_graph(graph: LegalGraph, reduced: bool = False) -> Dict[str, Any]:
         g.add_edge(edge.source, edge.target, obj=edge)
 
     if reduced:
-        g = nx.transitive_reduction(g)
+        if not nx.is_directed_acyclic_graph(g):
+            raise ValueError(
+                "Transitive reduction requires the graph to be a directed acyclic graph."
+            )
+        reduction = nx.transitive_reduction(g)
+        for node in reduction.nodes:
+            reduction.nodes[node]["obj"] = g.nodes[node]["obj"]
+        for u, v in reduction.edges:
+            reduction.edges[u, v]["obj"] = g.edges[u, v]["obj"]
+        g = reduction
 
     nodes = [asdict(data["obj"]) for _, data in g.nodes(data=True)]
     edges = [asdict(data["obj"]) for _, _, data in g.edges(data=True)]

--- a/tests/graph/test_transitive_reduction.py
+++ b/tests/graph/test_transitive_reduction.py
@@ -1,3 +1,12 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
 from src.graph.api import serialize_graph
 from src.graph.models import LegalGraph, GraphNode, GraphEdge, NodeType, EdgeType
 
@@ -10,6 +19,15 @@ def build_sample_graph() -> LegalGraph:
     g.add_edge(GraphEdge(type=EdgeType.CITES, source="A", target="B"))
     g.add_edge(GraphEdge(type=EdgeType.CITES, source="B", target="C"))
     g.add_edge(GraphEdge(type=EdgeType.CITES, source="A", target="C"))
+    return g
+
+
+def build_cyclic_graph() -> LegalGraph:
+    g = LegalGraph()
+    g.add_node(GraphNode(type=NodeType.CASE, identifier="A"))
+    g.add_node(GraphNode(type=NodeType.CASE, identifier="B"))
+    g.add_edge(GraphEdge(type=EdgeType.CITES, source="A", target="B"))
+    g.add_edge(GraphEdge(type=EdgeType.CITES, source="B", target="A"))
     return g
 
 
@@ -27,3 +45,9 @@ def test_edges_reappear_when_not_reduced():
     assert any(
         e["source"] == "A" and e["target"] == "C" for e in full["edges"]
     )
+
+
+def test_transitive_reduction_requires_acyclic_graph():
+    g = build_cyclic_graph()
+    with pytest.raises(ValueError):
+        serialize_graph(g, reduced=True)


### PR DESCRIPTION
## Summary
- validate graphs are acyclic before performing transitive reduction
- preserve node and edge attributes when reducing a graph
- test transitive reduction behaviour on cyclic and acyclic graphs

## Testing
- `pytest tests/graph/test_transitive_reduction.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad560058c08322a5afcca762849ee2