### PR TITLE
refactor: split sample API routes

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,14 +1,11 @@
-"""API package providing FastAPI application."""
+"""API package providing FastAPI application and route definitions."""
 
-from .routes import app
-
-__all__ = ["app"]
-"""API package providing route definitions."""
+from .sample_routes import app
 
 try:  # pragma: no cover - optional dependency
     from .routes import router
-
-    __all__ = ["router"]
 except Exception:  # ImportError if FastAPI is missing
     router = None  # type: ignore
-    __all__ = ["router"]
+
+__all__ = ["app", "router"]
+

--- a/src/api/sample_routes.py
+++ b/src/api/sample_routes.py
@@ -1,0 +1,66 @@
+"""HTTP routes exposing sample data via FastAPI."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+try:  # pragma: no cover - fallback when FastAPI isn't available
+    from fastapi import FastAPI, HTTPException, Query
+except Exception:  # pragma: no cover
+    # Minimal shims so the module can be imported without FastAPI installed.
+    class HTTPException(Exception):
+        def __init__(self, status_code: int, detail: str) -> None:
+            self.status_code = status_code
+            self.detail = detail
+
+    class Query:  # type: ignore[misc]
+        def __init__(self, default=None, **_: object) -> None:
+            self.default = default
+
+    class FastAPI:  # type: ignore[misc]
+        def __init__(self) -> None:
+            pass
+
+        def get(self, _path: str):
+            def decorator(func):
+                return func
+
+            return decorator
+
+from ..sample_data import build_subgraph, get_provision, treatments_for
+
+app = FastAPI()
+
+
+@app.get("/subgraph")
+def api_subgraph(
+    node: Optional[List[str]] = Query(None),
+    limit: int = Query(50, ge=1),
+    offset: int = Query(0, ge=0),
+):
+    """Return a subgraph of the sample graph."""
+    return build_subgraph(node, limit, offset)
+
+
+@app.get("/treatment")
+def api_treatment(
+    doc: str = Query(..., description="Document identifier"),
+    limit: int = Query(50, ge=1),
+    offset: int = Query(0, ge=0),
+):
+    """Return edges involving a document."""
+    edges = treatments_for(doc, limit, offset)
+    return {"treatments": edges}
+
+
+@app.get("/provision")
+def api_provision(doc: str = Query(...), id: str = Query(...)):
+    """Return a provision from the sample documents."""
+    prov = get_provision(doc, id)
+    if prov is None:
+        raise HTTPException(status_code=404, detail="Provision not found")
+    return prov
+
+
+__all__ = ["app", "api_subgraph", "api_treatment", "api_provision"]
+

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -5,7 +5,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from src.api.routes import api_provision, api_subgraph, api_treatment
+from src.api.sample_routes import api_provision, api_subgraph, api_treatment
 
 
 def test_subgraph_endpoint():


### PR DESCRIPTION
## Summary
- separate sample-data FastAPI endpoints into `sample_routes`
- keep production API routes and utilities in streamlined `routes`
- adjust package init and tests for new module layout

## Testing
- `pytest -q` *(fails: No module named 'hypothesis')*
- `pip install hypothesis` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5603d2f88322b8c4cd2f005b021d