### PR TITLE
Rename provision route handler to avoid helper collision

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -101,7 +101,9 @@ def get_treatment(text: str = Query(..., description="Provision text"), *, dot: 
 
 
 @router.get("/provision")
-def get_provision(text: str = Query(..., description="Provision text"), *, dot: bool = False) -> Dict[str, Any]:
+def parse_provision(
+    text: str = Query(..., description="Provision text"), *, dot: bool = False
+) -> Dict[str, Any]:
     """Tag a provision of law and return structured data."""
     provision = tag_text(text).to_dict()
     result: Dict[str, Any] = {"provision": provision}


### PR DESCRIPTION
## Summary
- rename API route handler `get_provision` to `parse_provision`
- keep sample API `api_provision` using sample-data helper

## Testing
- `pytest tests/test_api_routes.py -q`
- ⚠️ `pre-commit run --files src/api/routes.py` *(pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad593a46fc8322962762bf39696b9d