### PR TITLE
Ensure deterministic treatment aggregation

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -212,7 +212,8 @@ def fetch_case_treatment(case_id: str) -> Dict[str, Any]:
             }
         )
 
-    records.sort(key=lambda r: r["total"], reverse=True)
+    # Sort by total descending and treatment name for deterministic order
+    records.sort(key=lambda r: (-r["total"], r["treatment"]))
     return {"case_id": case_id, "treatments": records}
 
 


### PR DESCRIPTION
## Summary
- Sort case treatment records by score then name for stable ordering
- Verify aggregation and ordering with new tests

## Testing
- `pytest tests/api/test_treatment.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*
- `pip install hypothesis` *(fails: Could not find a version that satisfies the requirement hypothesis; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5923611c832294dbbc879aaa0998