### PR TITLE
Use CulturalFlags enum in policy tests and consent check

### DIFF
--- a/src/policy/engine.py
+++ b/src/policy/engine.py
@@ -191,7 +191,7 @@ class PolicyEngine:
             return None
 
         metadata = node.metadata
-        if transform:
+        if transform and phase != "export":
             metadata = {
                 k: self._transform_value(v, transform) for k, v in metadata.items()
             }


### PR DESCRIPTION
## Summary
- import `CulturalFlags` in policy engine tests and replace hard-coded flag strings
- skip policy value transforms during export phase when consent is given
- always consult OPA gateway in `check_consent` for missing consent errors

## Testing
- `pytest tests/policy -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad593cb19c832296d5f846f65d0e08