### PR TITLE
Align consent check with separate storage/inference flags

### DIFF
--- a/src/ingestion/consent_gate.py
+++ b/src/ingestion/consent_gate.py
@@ -42,6 +42,7 @@ def check_consent(record: Dict[str, Any]) -> None:
 
     storage_consent = record.get("storage_consent", record.get("consent", False))
     inference_consent = record.get("inference_consent", record.get("consent", False))
+    record["consent"] = storage_consent and inference_consent
     citation = record.get("metadata", {}).get("citation")
 
     if record.get("consent_required") and not (storage_consent and inference_consent):
@@ -72,9 +73,16 @@ def check_consent(record: Dict[str, Any]) -> None:
         )
         raise ConsentError("Consent required for records with cultural flags")
 
-    if record.get("consent"):
-        logger.info(
-            "Consent receipt for record %s: %s",
-            citation,
-            record.get("consent_receipt", "consent granted"),
-        )
+    if storage_consent and inference_consent:
+        receipt = record.get("consent_receipt")
+        if receipt:
+            logger.info(
+                "Consent receipt for record %s: %s",
+                citation,
+                receipt,
+            )
+        else:
+            logger.info(
+                "Consent receipt for record %s: consent granted",
+                citation,
+            )


### PR DESCRIPTION
## Summary
- Log consent receipts only when both storage and inference consents are granted
- Emit explicit consent flag for policy evaluation and include receipt details in logs

## Testing
- `pytest tests/ingestion/test_consent_gate.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ad5e594d2c8322b1d3d2c2ede49124