### PR TITLE
chore: remove stray assertions from CLI tests

### DIFF
--- a/tests/test_distinguish_cli.py
+++ b/tests/test_distinguish_cli.py
@@ -71,7 +71,3 @@ def test_distinguish_cli_bad_story():
     completed = subprocess.run(cmd, capture_output=True, text=True)
     assert completed.returncode != 0
     assert "error" in completed.stderr.lower()
-
-    assert "overlaps" in data
-    missing_ids = {m["id"] for m in data["missing"]}
-    assert "delay" in missing_ids


### PR DESCRIPTION
## Summary
- remove stray assertions after `test_distinguish_cli_bad_story`
- ensure no code executes at import time

## Testing
- `pytest tests/test_distinguish_cli.py` *(fails: CalledProcessError: Command '['python', '-m', 'src.cli', 'distinguish', '--case', '[2002] HCA 14', '--story', 'tests/fixtures/glj_permanent_stay_story.json']' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5e6a38888322976cb54c556fd2d4