### PR TITLE
Include networkx in test extras and document test setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
 
-  pull_request:
-
-jobs:
   build:
     runs-on: ubuntu-latest
     steps:
@@ -34,15 +31,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,test]"
+          pip install -e .[test]
+          pip install -e .[dev]
       - name: Run pre-commit
         run: pre-commit run --all-files
       - name: Run tests
         run: pytest
-
-
-          pip install .[test]
-          pip install ruff
       - name: Lint
         run: ruff check src tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,10 @@
 
 Contributions to SensibLaw are welcome. For a high-level roadmap linking tools
 to implementation areas, see [todo.md](todo.md). To get started, install the
-development dependencies and run the test suite:
+test dependencies and run the suite:
 
 ```bash
-pip install -e .[dev,test]
+pip install -e .[test]
 pytest
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
 test = [
     "pytest",
     "hypothesis",
+    "networkx",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add networkx to optional test dependencies
- install test extras in CI before running tests
- document installing test extras before running the suite

## Testing
- `pip install -e .[test]` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `pre-commit run --files pyproject.toml .github/workflows/ci.yml CONTRIBUTING.md` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_68ad5e30bba48322b317b86e91d29fe1