### PR TITLE
refactor: split sample API routes

### DIFF
--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,11 +1,14 @@
-"""API package providing FastAPI application and route definitions."""
-
-from .sample_routes import app
+"""API package providing FastAPI route definitions."""
 
 try:  # pragma: no cover - optional dependency
     from .routes import router
 except Exception:  # ImportError if FastAPI is missing
     router = None  # type: ignore
 
-__all__ = ["app", "router"]
+try:  # pragma: no cover - optional dependency
+    from .sample_routes import router as sample_router
+except Exception:  # ImportError if FastAPI is missing
+    sample_router = None  # type: ignore
+
+__all__ = ["router", "sample_router"]
 

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import json
 import subprocess
 from collections import defaultdict
 from dataclasses import asdict
 from typing import Any, Dict, List
 
 try:  # pragma: no cover - FastAPI is optional for CLI tests
-    from fastapi import APIRouter, HTTPException, Query
+    from fastapi import APIRouter, HTTPException
 except Exception:  # pragma: no cover
     class HTTPException(Exception):
         def __init__(self, status_code: int, detail: str) -> None:
@@ -27,9 +26,6 @@ except Exception:  # pragma: no cover
                 return func
             return decorator
 
-    def Query(*args, **kwargs):
-        return None
-
 try:  # pragma: no cover
     from pydantic import BaseModel, Field
 except Exception:  # pragma: no cover
@@ -39,77 +35,11 @@ except Exception:  # pragma: no cover
     def Field(*args, **kwargs):  # type: ignore[misc]
         return None
 
-from ..ontology.tagger import tag_text
-from ..pipeline import build_cloud, match_concepts, normalise
-from ..rules.extractor import extract_rules
 from ..graph.models import LegalGraph, GraphEdge
 from ..tests.templates import TEMPLATE_REGISTRY
 from ..policy.engine import PolicyEngine
 
 router = APIRouter()
-
-
-def _cloud_to_dot(cloud: Dict[str, int]) -> str:
-    lines = ["digraph G {"]
-    for node, count in cloud.items():
-        lines.append(f'  "{node}" [label="{node} ({count})"]')
-    lines.append("}")
-    return "\n".join(lines)
-
-
-def _rules_to_dot(rules: List[Dict[str, str]]) -> str:
-    lines = ["digraph G {"]
-    for i, rule in enumerate(rules):
-        label = f"{rule['actor']} {rule['modality']} {rule['action']}"
-        lines.append(f'  r{i} [label="{label}"]')
-    lines.append("}")
-    return "\n".join(lines)
-
-
-def _provision_to_dot(provision: Dict[str, Any]) -> str:
-    lines = ["digraph G {", '  prov [label="Provision"]']
-    for p in provision.get("principles", []):
-        lines.append(f'  "{p}" [shape=box]')
-        lines.append(f'  prov -> "{p}" [label="principle"]')
-    for c in provision.get("customs", []):
-        lines.append(f'  "{c}" [shape=ellipse]')
-        lines.append(f'  prov -> "{c}" [label="custom"]')
-    lines.append("}")
-    return "\n".join(lines)
-
-
-@router.get("/subgraph")
-def get_subgraph(text: str = Query(..., description="Query text"), *, dot: bool = False) -> Dict[str, Any]:
-    """Return a simple concept cloud for ``text``."""
-    normalised = normalise(text)
-    concepts = match_concepts(normalised)
-    cloud = build_cloud(concepts)
-    result: Dict[str, Any] = {"cloud": cloud}
-    if dot:
-        result["dot"] = _cloud_to_dot(cloud)
-    return result
-
-
-@router.get("/treatment")
-def get_treatment(text: str = Query(..., description="Provision text"), *, dot: bool = False) -> Dict[str, Any]:
-    """Extract rules from provision ``text``."""
-    rules = [r.__dict__ for r in extract_rules(text)]
-    result: Dict[str, Any] = {"rules": rules}
-    if dot:
-        result["dot"] = _rules_to_dot(rules)
-    return result
-
-
-@router.get("/provision")
-def parse_provision(
-    text: str = Query(..., description="Provision text"), *, dot: bool = False
-) -> Dict[str, Any]:
-    """Tag a provision of law and return structured data."""
-    provision = tag_text(text).to_dict()
-    result: Dict[str, Any] = {"provision": provision}
-    if dot:
-        result["dot"] = _provision_to_dot(provision)
-    return result
 
 
 @router.post("/tests/run")

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,24 +1,24 @@
 import sys
-import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
 
 from src.api.sample_routes import api_provision, api_subgraph, api_treatment
 
 
 def test_subgraph_endpoint():
-    data = api_subgraph(["doc1", "doc2"], limit=10, offset=0)
-    assert len(data["nodes"]) == 2
-    assert any(e["target"] == "doc2" for e in data["edges"])
+    data = api_subgraph("example text")
+    assert "cloud" in data
 
 
 def test_treatment_endpoint():
-    data = api_treatment(doc="doc1", limit=10, offset=0)
-    assert any(e["target"] == "doc2" for e in data["treatments"])
+    data = api_treatment("a person shall act")
+    assert "rules" in data
 
 
 def test_provision_endpoint():
-    data = api_provision(doc="doc1", id="prov1")
-    assert data["identifier"] == "prov1"
+    data = api_provision("Sample provision text")
+    assert "provision" in data
+


### PR DESCRIPTION
## Summary
- extract demo endpoints into `sample_routes` module
- keep production endpoints in `routes.py` with a single docstring
- update API package exports and tests to use new module

## Testing
- `pytest tests/test_api_routes.py -q`
- `pytest -q` *(fails: No module named 'hypothesis')*


------
https://chatgpt.com/codex/tasks/task_e_68ad5e4449d88322abe93691846f7902