### PR TITLE
Refactor PDF ingestion and add CLI test for pdf-fetch

### DIFF
--- a/tests/pdf_ingest/test_rule_extraction.py
+++ b/tests/pdf_ingest/test_rule_extraction.py
@@ -11,8 +11,11 @@ def test_rule_extraction(monkeypatch, tmp_path):
     def fake_extract_text(path):
         return "Heading\nThe agent must file reports."
 
-    sys.modules["pdfminer.high_level"] = types.SimpleNamespace(extract_text=fake_extract_text)
+    sys.modules["pdfminer.high_level"] = types.SimpleNamespace(
+        extract_text=fake_extract_text
+    )
 
+    sys.modules.pop("src.pdf_ingest", None)
     from src.models.provision import Provision
     import src.pdf_ingest as pdf_ingest
 

--- a/tests/test_cli_pdf_fetch.py
+++ b/tests/test_cli_pdf_fetch.py
@@ -1,0 +1,40 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_pdf_fetch_cli(tmp_path):
+    # Create stub pdfminer module so pdf_ingest uses predictable text
+    stub_pkg = tmp_path / "stubs"
+    (stub_pkg / "pdfminer").mkdir(parents=True)
+    (stub_pkg / "pdfminer" / "__init__.py").write_text("")
+    (stub_pkg / "pdfminer" / "high_level.py").write_text(
+        "def extract_text(path):\n    return 'Heading 1\\nHello\\nWorld\\fHeading2\\nSecond Page'\n"
+    )
+
+    pdf_path = tmp_path / "sample.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4")
+    out_path = tmp_path / "out.json"
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{stub_pkg}:{env.get('PYTHONPATH', '')}"
+    cmd = [
+        "python",
+        "-m",
+        "cli",
+        "pdf-fetch",
+        str(pdf_path),
+        "--output",
+        str(out_path),
+        "--jurisdiction",
+        "US",
+        "--citation",
+        "CIT",
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True, env=env)
+    data = json.loads(completed.stdout)
+    assert data["metadata"]["jurisdiction"] == "US"
+    assert out_path.exists()
+    saved = json.loads(out_path.read_text())
+    assert saved["metadata"]["citation"] == "CIT"


### PR DESCRIPTION
## Summary
- consolidate duplicate PDF text extraction and JSON helpers
- wire up pdf-ingest CLI entry to processing helpers
- test pdf-fetch command through CLI

## Testing
- `black src/pdf_ingest.py tests/test_pdf_ingest.py tests/test_cli_pdf_fetch.py tests/pdf_ingest/test_rule_extraction.py`
- `pytest tests/test_pdf_ingest.py tests/pdf_ingest/test_rule_extraction.py tests/test_cli_pdf_fetch.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad5e5c1acc8322a2a0a9955bbdedad