### PR TITLE
feat: allow multiple nodes for graph subgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Generates a DOT-format subgraph around seed nodes within the knowledge graph.
 *Required files*: pre-built graph data (e.g., ontology and case sources under `data/`).
 
 ```bash
-sensiblaw graph subgraph --seeds Concept#TerraNullius Case#Mabo1992 --hops 2 --dot
+sensiblaw graph subgraph --node Concept#TerraNullius --node Case#Mabo1992 --hops 2 --dot
 ```
 
 Sample output:
@@ -207,7 +207,7 @@ The command writes a JSON representation of the Native Title Act 1993 to
 `data/frl/nta1993.json`.
 
 ```bash
-python -m src.cli graph subgraph --graph-file data/frl/nta1993.json --seeds Provision#NTA:s223 --hops 1 --dot
+python -m src.cli graph subgraph --graph-file data/frl/nta1993.json --node Provision#NTA:s223 --hops 1 --dot
 ```
 
 This prints a DOT description of the one-hop neighbourhood around
@@ -237,7 +237,7 @@ The result includes the test name, evaluated factors, and whether the test
 Extract a portion of the legal knowledge graph:
 
 ```bash
-sensiblaw graph subgraph --seed case123 --hops 2
+sensiblaw graph subgraph --node case123 --hops 2
 ```
 
 This returns a JSON object with arrays of `"nodes"` and `"edges"` representing

--- a/tests/test_cli_frl_graph.py
+++ b/tests/test_cli_frl_graph.py
@@ -36,7 +36,7 @@ def test_extract_frl_to_graph(tmp_path: Path) -> None:
         "cli",
         "graph",
         "subgraph",
-        "--seed",
+        "--node",
         "NTA1993",
         "--graph-file",
         "-",

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -53,7 +53,7 @@ def test_graph_subgraph_unreadable_graph_file(tmp_path: Path):
         "subgraph",
         "--graph-file",
         str(graph_file),
-        "--seed",
+        "--node",
         "seed",
     )
     assert completed.returncode != 0


### PR DESCRIPTION
## Summary
- allow repeating `--node` in `graph subgraph`
- document and test new multi-node interface

## Testing
- `pytest tests/test_cli_frl_graph.py tests/test_cli_smoke.py -q`
- `pre-commit run --files cli/__main__.py tests/test_cli_frl_graph.py tests/test_cli_smoke.py README.md` *(fails: unable to access 'https://github.com/astral-sh/ruff-pre-commit/' CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af014a85908322b27d106bf35cb4ed