### PR TITLE
Add hierarchical section parsing and provision builders

### DIFF
--- a/src/ingestion/section_parser.py
+++ b/src/ingestion/section_parser.py
@@ -1,9 +1,19 @@
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 # Precompiled regex to capture leading numbering/heading from a block of text
 HEADING_RE = re.compile(r"^(?P<number>\d+(?:\.\d+)*)\s+(?P<heading>.+)$")
+
+PART_RE = re.compile(
+    r"^Part\s+(?P<number>[A-Z0-9IVXLC]+)(?:\s*(?:[-–:]\s*)?(?P<heading>.+))?$",
+    re.IGNORECASE,
+)
+DIVISION_RE = re.compile(
+    r"^Division\s+(?P<number>[A-Za-z0-9]+)(?:\s*(?:[-–:]\s*)?(?P<heading>.+))?$",
+    re.IGNORECASE,
+)
+SUBSECTION_RE = re.compile(r"^\((?P<number>\d+)\)\s*(?P<text>.+)$")
 
 # Single-pass combined regex mimicking an Aho–Corasick matcher for keywords
 TOKEN_RE = re.compile(
@@ -17,6 +27,55 @@ TOKEN_RE = re.compile(
 def _strip_tags(html: str) -> str:
     """Remove simple HTML tags, returning the text content."""
     return re.sub(r"<[^>]+>", "", html).strip()
+
+
+def _extract_rule_tokens(text: str) -> Dict[str, object]:
+    modality: Optional[str] = None
+    conditions: List[str] = []
+    references: List[str] = []
+
+    for match in TOKEN_RE.finditer(text):
+        token = match.group().strip()
+        group = match.lastgroup
+        if group == "modality" and modality is None:
+            modality = token.lower()
+        elif group == "condition":
+            conditions.append(token.lower())
+        elif group == "xref":
+            references.append(token)
+
+    return {"modality": modality, "conditions": conditions, "references": references}
+
+
+def _empty_tokens() -> Dict[str, object]:
+    return {"modality": None, "conditions": [], "references": []}
+
+
+@dataclass
+class ParsedNode:
+    """Structured representation of a legislative unit."""
+
+    node_type: str
+    identifier: Optional[str]
+    heading: Optional[str] = None
+    text: str = ""
+    rule_tokens: Dict[str, object] = field(default_factory=_empty_tokens)
+    children: List["ParsedNode"] = field(default_factory=list)
+    _buffer: List[str] = field(default_factory=list, repr=False)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "type": self.node_type,
+            "identifier": self.identifier,
+            "heading": self.heading,
+            "text": self.text,
+            "rule_tokens": {
+                "modality": self.rule_tokens.get("modality"),
+                "conditions": list(self.rule_tokens.get("conditions", [])),
+                "references": list(self.rule_tokens.get("references", [])),
+            },
+            "children": [child.to_dict() for child in self.children],
+        }
 
 
 @dataclass
@@ -61,27 +120,15 @@ def parse_html_section(html: str) -> Section:
         number = heading_match.group("number")
         heading = heading_match.group("heading")
 
-    modality: Optional[str] = None
-    conditions: List[str] = []
-    references: List[str] = []
-
-    for match in TOKEN_RE.finditer(text):
-        token = match.group().strip()
-        group = match.lastgroup
-        if group == "modality" and modality is None:
-            modality = token.lower()
-        elif group == "condition":
-            conditions.append(token.lower())
-        elif group == "xref":
-            references.append(token)
+    tokens = _extract_rule_tokens(text)
 
     return Section(
         number=number,
         heading=heading,
         text=text,
-        modality=modality,
-        conditions=conditions,
-        references=references,
+        modality=tokens["modality"],
+        conditions=tokens["conditions"],
+        references=tokens["references"],
     )
 
 
@@ -89,3 +136,103 @@ def fetch_section(html: str) -> Dict[str, object]:
     """Parse *html* and return raw text together with extracted rule metadata."""
     section = parse_html_section(html)
     return section.to_dict()
+
+
+def _finalize_node(node: ParsedNode) -> None:
+    node.text = " ".join(part for part in node._buffer if part).strip()
+    node.rule_tokens = _extract_rule_tokens(node.text)
+    node._buffer.clear()
+    for child in node.children:
+        _finalize_node(child)
+
+
+def _attach_node(
+    collection: List[ParsedNode],
+    parent: Optional[ParsedNode],
+    node: ParsedNode,
+) -> ParsedNode:
+    target = parent.children if parent else collection
+    target.append(node)
+    return node
+
+
+def parse_sections(text: str) -> List[ParsedNode]:
+    """Parse free-form text into a hierarchy of structured nodes."""
+
+    nodes: List[ParsedNode] = []
+    current_part: Optional[ParsedNode] = None
+    current_division: Optional[ParsedNode] = None
+    current_section: Optional[ParsedNode] = None
+    current_subsection: Optional[ParsedNode] = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        part_match = PART_RE.match(line)
+        if part_match:
+            current_part = ParsedNode(
+                node_type="part",
+                identifier=part_match.group("number"),
+                heading=part_match.group("heading"),
+            )
+            _attach_node(nodes, None, current_part)
+            current_division = None
+            current_section = None
+            current_subsection = None
+            continue
+
+        division_match = DIVISION_RE.match(line)
+        if division_match:
+            parent = current_part
+            current_division = ParsedNode(
+                node_type="division",
+                identifier=division_match.group("number"),
+                heading=division_match.group("heading"),
+            )
+            _attach_node(nodes, parent, current_division)
+            current_section = None
+            current_subsection = None
+            continue
+
+        section_match = HEADING_RE.match(line)
+        if section_match:
+            parent = current_division or current_part
+            current_section = ParsedNode(
+                node_type="section",
+                identifier=section_match.group("number"),
+                heading=section_match.group("heading"),
+            )
+            _attach_node(nodes, parent, current_section)
+            current_subsection = None
+            continue
+
+        subsection_match = SUBSECTION_RE.match(line)
+        if subsection_match and current_section:
+            current_subsection = ParsedNode(
+                node_type="subsection",
+                identifier=f"({subsection_match.group('number')})",
+            )
+            current_subsection._buffer.append(subsection_match.group("text"))
+            _attach_node(nodes, current_section, current_subsection)
+            continue
+
+        target = current_subsection or current_section or current_division or current_part
+        if target is None:
+            target = ParsedNode(node_type="section", identifier=None)
+            _attach_node(nodes, None, target)
+            current_part = None
+            current_division = None
+            current_section = target
+            current_subsection = None
+
+        target._buffer.append(line)
+
+    for node in nodes:
+        _finalize_node(node)
+
+    return nodes
+
+
+__all__ = ["ParsedNode", "parse_sections", "parse_html_section", "fetch_section"]

--- a/src/models/provision.py
+++ b/src/models/provision.py
@@ -10,6 +10,9 @@ class Provision:
 
     text: str
     identifier: Optional[str] = None
+    heading: Optional[str] = None
+    node_type: Optional[str] = None
+    rule_tokens: Dict[str, Any] = field(default_factory=dict)
     children: List["Provision"] = field(default_factory=list)
     principles: List[str] = field(default_factory=list)
     customs: List[str] = field(default_factory=list)
@@ -19,6 +22,9 @@ class Provision:
         return {
             "text": self.text,
             "identifier": self.identifier,
+            "heading": self.heading,
+            "node_type": self.node_type,
+            "rule_tokens": dict(self.rule_tokens),
             "children": [c.to_dict() for c in self.children],
             "principles": list(self.principles),
             "customs": list(self.customs),
@@ -30,6 +36,9 @@ class Provision:
         return cls(
             text=data["text"],
             identifier=data.get("identifier"),
+            heading=data.get("heading"),
+            node_type=data.get("node_type"),
+            rule_tokens=dict(data.get("rule_tokens", {})),
             children=[cls.from_dict(c) for c in data.get("children", [])],
             principles=list(data.get("principles", [])),
             customs=list(data.get("customs", [])),

--- a/tests/pdf_ingest/fixtures.py
+++ b/tests/pdf_ingest/fixtures.py
@@ -1,0 +1,9 @@
+MULTI_LEVEL_STATUTE = """Part 1 Preliminary Matters
+Division 1 Introductory
+1 Short title
+(1) This Act may be cited as the Sample Act.
+(2) Regulations must set required forms.
+
+2 Application of Act
+The Minister must not delay action if urgent circumstances exist.
+"""

--- a/tests/pdf_ingest/test_provision_hierarchy.py
+++ b/tests/pdf_ingest/test_provision_hierarchy.py
@@ -1,0 +1,54 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+root = Path(__file__).resolve().parents[2]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+fixtures_path = Path(__file__).with_name("fixtures.py")
+spec = importlib.util.spec_from_file_location("pdf_ingest_fixtures", fixtures_path)
+fixtures = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(fixtures)
+MULTI_LEVEL_STATUTE = fixtures.MULTI_LEVEL_STATUTE
+
+from src.ingestion.section_parser import parse_sections
+from src.pdf_ingest import _build_provisions_from_nodes
+
+
+def test_multi_level_provision_hierarchy():
+    nodes = parse_sections(MULTI_LEVEL_STATUTE)
+    provisions = _build_provisions_from_nodes(nodes)
+
+    assert len(provisions) == 1
+
+    part = provisions[0]
+    assert part.node_type == "part"
+    assert part.identifier == "1"
+    assert part.heading == "Preliminary Matters"
+
+    assert len(part.children) == 1
+    division = part.children[0]
+    assert division.node_type == "division"
+    assert division.identifier == "1"
+    assert division.heading == "Introductory"
+
+    assert len(division.children) == 2
+    section_one, section_two = division.children
+
+    assert section_one.node_type == "section"
+    assert section_one.identifier == "1"
+    assert section_one.heading == "Short title"
+    assert len(section_one.children) == 2
+    sub_one, sub_two = section_one.children
+    assert sub_one.identifier == "(1)"
+    assert "may be cited" in sub_one.text
+    assert sub_one.rule_tokens["modality"] == "may"
+    assert sub_two.rule_tokens["modality"] == "must"
+
+    assert section_two.node_type == "section"
+    assert section_two.identifier == "2"
+    assert section_two.rule_tokens["modality"] == "must not"
+    assert not section_two.children

--- a/tests/pdf_ingest/test_rule_extraction.py
+++ b/tests/pdf_ingest/test_rule_extraction.py
@@ -21,7 +21,15 @@ def test_rule_extraction(monkeypatch, tmp_path):
 
     def fake_parse_sections(text):
         body = text.split("\n", 1)[1] if "\n" in text else text
-        return [Provision(text=body)]
+        node = types.SimpleNamespace(
+            text=body,
+            identifier="1",
+            heading="Heading",
+            node_type="section",
+            rule_tokens={"modality": "must", "conditions": [], "references": []},
+            children=[],
+        )
+        return [node]
 
     monkeypatch.setattr(
         pdf_ingest,


### PR DESCRIPTION
## Summary
- extend the section parser to emit structured nodes for parts, divisions, sections, and subsections with extracted rule tokens
- enrich provision models and PDF ingestion with helpers that build nested provisions from parser output
- add multi-level statute fixtures and regression tests ensuring identifiers and hierarchy are preserved

## Testing
- pytest tests/pdf_ingest -q

------
https://chatgpt.com/codex/tasks/task_e_68d640f51dbc8322a76d3a73c2f0bc14