### PR TITLE
Add provision Atom serialization and populate principle atoms

### DIFF
--- a/src/models/provision.py
+++ b/src/models/provision.py
@@ -5,6 +5,46 @@ from typing import Any, Dict, List, Optional
 
 
 @dataclass
+class Atom:
+    """A minimal knowledge atom extracted from a provision."""
+
+    type: Optional[str] = None
+    role: Optional[str] = None
+    text: Optional[str] = None
+    who: Optional[str] = None
+    conditions: Optional[str] = None
+    refs: List[str] = field(default_factory=list)
+    gloss: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise the atom to a dictionary."""
+
+        return {
+            "type": self.type,
+            "role": self.role,
+            "text": self.text,
+            "who": self.who,
+            "conditions": self.conditions,
+            "refs": list(self.refs),
+            "gloss": self.gloss,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Atom":
+        """Deserialise an :class:`Atom` from ``data``."""
+
+        return cls(
+            type=data.get("type"),
+            role=data.get("role"),
+            text=data.get("text"),
+            who=data.get("who"),
+            conditions=data.get("conditions"),
+            refs=list(data.get("refs", [])),
+            gloss=data.get("gloss"),
+        )
+
+
+@dataclass
 class Provision:
     """A discrete provision within a legal document."""
 
@@ -16,6 +56,7 @@ class Provision:
     children: List["Provision"] = field(default_factory=list)
     principles: List[str] = field(default_factory=list)
     customs: List[str] = field(default_factory=list)
+    atoms: List[Atom] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialize the provision to a dictionary."""
@@ -28,6 +69,7 @@ class Provision:
             "children": [c.to_dict() for c in self.children],
             "principles": list(self.principles),
             "customs": list(self.customs),
+            "atoms": [atom.to_dict() for atom in self.atoms],
         }
 
     @classmethod
@@ -42,4 +84,5 @@ class Provision:
             children=[cls.from_dict(c) for c in data.get("children", [])],
             principles=list(data.get("principles", [])),
             customs=list(data.get("customs", [])),
+            atoms=[Atom.from_dict(a) for a in data.get("atoms", [])],
         )

--- a/src/ontology/tagger.py
+++ b/src/ontology/tagger.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Dict, List
 
-from ..models.provision import Provision
+from ..models.provision import Atom, Provision
 
 # Directory where ontology JSON files are stored.
 ONTOLOGY_DIR = Path(__file__).resolve().parents[2] / "data" / "ontology"
@@ -58,6 +58,15 @@ def tag_provision(provision: Provision) -> Dict[str, List[str]]:
         tags[name] = matched
         if name == "lpo":
             provision.principles = matched
+            provision.atoms = [
+                atom
+                for atom in provision.atoms
+                if not (atom.role == "principle" and atom.type == "ontology")
+            ]
+            provision.atoms.extend(
+                Atom(type="ontology", role="principle", text=tag)
+                for tag in matched
+            )
         elif name == "cco":
             provision.customs = matched
     return tags

--- a/tests/ingestion/test_tagging.py
+++ b/tests/ingestion/test_tagging.py
@@ -26,3 +26,4 @@ def test_australian_tagging():
     prov = doc.provisions[0]
     assert "fairness" in prov.principles
     assert "business_practice" in prov.customs
+    assert any(atom.role == "principle" and atom.text == "fairness" for atom in prov.atoms)

--- a/tests/models/test_document_serialization.py
+++ b/tests/models/test_document_serialization.py
@@ -2,7 +2,7 @@ from datetime import date, datetime
 import json
 
 from src.models.document import Document, DocumentMetadata
-from src.models.provision import Provision
+from src.models.provision import Atom, Provision
 
 
 def test_document_serialization_round_trip():
@@ -23,11 +23,21 @@ def test_document_serialization_round_trip():
         checksum="checksum",
         licence="CC0",
     )
+    atom = Atom(
+        type="ontology",
+        role="principle",
+        text="principle",
+        who="legislature",
+        conditions="if relevant",
+        refs=["ref1"],
+        gloss="A guiding principle",
+    )
     provision = Provision(
         text="Sample provision",
         identifier="p1",
         principles=["principle"],
         customs=["custom"],
+        atoms=[atom],
     )
     document = Document(metadata=metadata, body="Body text", provisions=[provision])
 
@@ -41,3 +51,5 @@ def test_document_serialization_round_trip():
     json_data = document.to_json()
     assert json.loads(json_data) == doc_dict
     assert Document.from_json(json_data) == document
+    round_trip = Document.from_json(json_data)
+    assert round_trip.provisions[0].atoms[0] == atom

--- a/tests/ontology/test_tagger.py
+++ b/tests/ontology/test_tagger.py
@@ -12,6 +12,8 @@ from src.ontology.tagger import tag_text, tag_provision
 def test_tag_text_creates_provision():
     prov = tag_text("Fair business practices support environmental protection.")
     assert "fairness" in prov.principles
+    principle_atoms = [a for a in prov.atoms if a.role == "principle"]
+    assert any(a.text == "fairness" for a in principle_atoms)
     assert "business_practice" in prov.customs
 
 
@@ -20,4 +22,6 @@ def test_tag_provision_updates_in_place():
     tags = tag_provision(prov)
     assert "fairness" in prov.principles
     assert "business_practice" in prov.customs
+    principle_atoms = [a for a in prov.atoms if a.role == "principle"]
+    assert any(a.text == "fairness" for a in principle_atoms)
     assert "environment" in tags and "conservation" in tags["environment"]

--- a/tests/pdf_ingest/test_rule_extraction.py
+++ b/tests/pdf_ingest/test_rule_extraction.py
@@ -51,8 +51,11 @@ def test_rule_extraction(monkeypatch, tmp_path):
     assert doc.provisions
     assert doc.provisions[0].principles
     assert "must file reports" in doc.provisions[0].principles[0]
+    atoms = [a for a in doc.provisions[0].atoms if a.role == "principle"]
+    assert any("must file reports" in (a.text or "") for a in atoms)
 
     with out.open() as f:
         saved = json.load(f)
     assert saved["metadata"]["provenance"] == str(pdf_path)
     assert saved["provisions"][0]["principles"]
+    assert saved["provisions"][0]["atoms"]


### PR DESCRIPTION
## Summary
- add a serialisable Atom dataclass to provisions and include it in document payloads
- create principle atoms when ontology tagging or rule extraction keyword matches fire
- expand document and ingestion tests to cover atom round-tripping

## Testing
- PYTHONPATH=. pytest tests/models/test_document_serialization.py tests/ontology/test_tagger.py tests/ingestion/test_tagging.py tests/pdf_ingest/test_rule_extraction.py

------
https://chatgpt.com/codex/tasks/task_e_68d6462b78948322b819ece3f31c3108