### PR TITLE
Add offence element classification and document atoms

### DIFF
--- a/src/pdf_ingest.py
+++ b/src/pdf_ingest.py
@@ -90,6 +90,18 @@ def _rules_to_atoms(rules) -> List[Atom]:
                 conditions=r.conditions,
             )
         )
+
+        for role, fragments in (r.elements or {}).items():
+            for fragment in fragments:
+                atoms.append(
+                    Atom(
+                        type="element",
+                        role=role,
+                        text=fragment,
+                        who=r.actor or None,
+                        conditions=r.conditions if role == "circumstance" else None,
+                    )
+                )
     return atoms
 
 

--- a/src/rules/__init__.py
+++ b/src/rules/__init__.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
 
 
 @dataclass
@@ -11,4 +11,5 @@ class Rule:
     action: str
     conditions: Optional[str] = None
     scope: Optional[str] = None
+    elements: Dict[str, List[str]] = field(default_factory=dict)
 

--- a/src/rules/extractor.py
+++ b/src/rules/extractor.py
@@ -1,25 +1,185 @@
 """Rule extraction utilities."""
 
+from __future__ import annotations
+
 import re
-from typing import List
+from collections import defaultdict
+from typing import Dict, List
 
 from . import Rule
 
-# Include the most common English legal modalities.  The pattern is fairly
-# permissive – it captures everything before the modality as the ``actor`` and
-# the remainder as the ``rest`` of the sentence which we later split into the
-# ``action`` and optional ``conditions``/``scope``.  Support for ``shall not``
-# was added to cover provisions expressed using the more formal "shall"
-# language often found in legislation.
-_PATTERN = re.compile(
+# Include the most common English legal modalities.  The patterns capture
+# normative "must/may" statements as well as offence formulations such as
+# "commits murder if".  The offence patterns normalise the modality to include
+# the offence label so downstream consumers can still reason about the actor's
+# behaviour.
+_NORMATIVE_PATTERN = re.compile(
     r"(?P<actor>.+?)\s+(?P<modality>must not|may not|shall not|must|shall|may)\s+(?P<rest>.+)",
     re.IGNORECASE,
 )
 
+_OFFENCE_PATTERN = re.compile(
+    r"(?P<actor>.+?)\s+(?P<modality>commits(?: the offence of)?|is guilty of)\s+"
+    r"(?P<offence>[^,.;]+?)\s+(?P<trigger>if|when|where|by)\s+(?P<rest>.+)",
+    re.IGNORECASE,
+)
+
+_PATTERNS = [_NORMATIVE_PATTERN, _OFFENCE_PATTERN]
+
+_FAULT_PATTERNS = [
+    re.compile(pat, re.IGNORECASE)
+    for pat in [
+        r"\bintentionally\b",
+        r"\bknowingly\b",
+        r"\brecklessly\b",
+        r"\bnegligently\b",
+        r"\bwilfully\b",
+        r"\bmaliciously\b",
+        r"\bdeliberately\b",
+        r"\bwith intent(?:ion)? to\b[^,;]+",
+        r"\bwith the intention of\b[^,;]+",
+    ]
+]
+
+_RESULT_PATTERNS = [
+    re.compile(pat, re.IGNORECASE)
+    for pat in [
+        r"\bresult(?:s|ing)? in\b[^,;]+",
+        r"\bso as to\b[^,;]+",
+        r"\bso that\b[^,;]+",
+        r"\bthereby\s+(?:causing|resulting in)\b[^,;]+",
+        r"\bleading to\b[^,;]+",
+    ]
+]
+
+_EXCEPTION_PATTERNS = [
+    re.compile(pat, re.IGNORECASE)
+    for pat in [
+        r"\bunless\b[^.]+",
+        r"\bexcept(?: where| that| as)?\b[^.]+",
+    ]
+]
+
+_CIRCUMSTANCE_PATTERNS = [
+    re.compile(pat, re.IGNORECASE)
+    for pat in [
+        r"\bin\s+(?:a|an|the)?[^,;.]+",
+        r"\bon\s+(?:a|an|the)?[^,;.]+",
+        r"\bat\s+(?:a|an|the)?[^,;.]+",
+        r"\bwithin\s+[^,;.]+",
+        r"\bunder\s+[^,;.]+",
+        r"\bwhile\s+[^,;.]+",
+        r"\bduring\s+[^,;.]+",
+        r"\bwithout\s+[^,;.]+",
+        r"\bby\s+[^,;.]+",
+        r"\busing\s+[^,;.]+",
+        r"\bwith\s+(?!intent(?:ion)?\b)[^,;.]+",
+    ]
+]
+
 
 def _split_sentences(text: str) -> List[str]:
     parts = re.split(r"[.;]\s*", text)
-    return [p.strip() for p in parts if p.strip()]
+    sentences: List[str] = []
+    for part in parts:
+        for line in part.splitlines():
+            candidate = line.strip()
+            if candidate:
+                sentences.append(candidate)
+    return sentences
+
+
+def _clean_fragment(fragment: str) -> str:
+    fragment = re.sub(r"\s+", " ", fragment)
+    return fragment.strip(" ,.;:")
+
+
+def _extract_patterns(text: str, patterns: List[re.Pattern[str]]) -> tuple[List[str], str]:
+    """Extract ``patterns`` from ``text`` returning matches and remainder."""
+
+    matches: List[str] = []
+    remainder = text
+
+    for pattern in patterns:
+        if not remainder:
+            break
+
+        def _repl(match: re.Match[str]) -> str:
+            fragment = _clean_fragment(match.group(0))
+            if fragment and fragment.lower() not in {m.lower() for m in matches}:
+                matches.append(fragment)
+            return " "
+
+        remainder = pattern.sub(_repl, remainder)
+
+    return matches, remainder
+
+
+def _classify_fragments(action: str, conditions: str | None, scope: str | None) -> Dict[str, List[str]]:
+    """Classify clause fragments into offence element roles."""
+
+    roles: Dict[str, List[str]] = defaultdict(list)
+
+    working_action = action or ""
+
+    if working_action:
+        leading_cond = re.match(r"\b(if|when|where)\b\s+(?P<body>.+)", working_action, re.IGNORECASE)
+        if leading_cond:
+            fragment = _clean_fragment(leading_cond.group(0))
+            if fragment:
+                roles["circumstance"].append(fragment)
+            working_action = leading_cond.group("body")
+
+    action_exceptions, working_action = _extract_patterns(working_action, _EXCEPTION_PATTERNS)
+    if action_exceptions:
+        roles["exception"].extend(action_exceptions)
+
+    faults, working_action = _extract_patterns(working_action, _FAULT_PATTERNS)
+    if faults:
+        roles["fault"].extend(faults)
+
+    results, working_action = _extract_patterns(working_action, _RESULT_PATTERNS)
+    if results:
+        roles["result"].extend(results)
+
+    circumstances, working_action = _extract_patterns(working_action, _CIRCUMSTANCE_PATTERNS)
+    if circumstances:
+        roles["circumstance"].extend(circumstances)
+
+    cond_text = conditions or ""
+    if cond_text:
+        cond_exceptions, cond_text = _extract_patterns(cond_text, _EXCEPTION_PATTERNS)
+        if cond_exceptions:
+            roles["exception"].extend(cond_exceptions)
+
+        for part in re.split(r"\b(?:and|or|;|,)\b", cond_text):
+            fragment = _clean_fragment(part)
+            if fragment:
+                roles["circumstance"].append(fragment)
+
+    if scope:
+        fragment = _clean_fragment(scope)
+        if fragment:
+            roles["circumstance"].append(fragment)
+
+    conduct = _clean_fragment(working_action)
+    if conduct:
+        roles["conduct"].append(conduct)
+
+    for role, fragments in list(roles.items()):
+        seen: set[str] = set()
+        unique: List[str] = []
+        for fragment in fragments:
+            key = fragment.lower()
+            if key not in seen and fragment:
+                seen.add(key)
+                unique.append(fragment)
+        if unique:
+            roles[role] = unique
+        else:
+            roles.pop(role, None)
+
+    return dict(roles)
 
 
 def extract_rules(text: str) -> List[Rule]:
@@ -27,19 +187,31 @@ def extract_rules(text: str) -> List[Rule]:
 
     rules: List[Rule] = []
     for sent in _split_sentences(text):
-        m = _PATTERN.match(sent)
-        if not m:
+        match = None
+        pattern_used = None
+        for pattern in _PATTERNS:
+            match = pattern.match(sent)
+            if match:
+                pattern_used = pattern
+                break
+        if not match or not pattern_used:
             continue
-        actor = m.group("actor").strip()
-        modality = m.group("modality").lower()
-        rest = m.group("rest").strip()
+
+        if pattern_used is _OFFENCE_PATTERN:
+            actor = match.group("actor").strip()
+            modality = f"{match.group('modality').strip()} {match.group('offence').strip()}".lower()
+            rest = f"{match.group('trigger').strip()} {match.group('rest').strip()}"
+        else:
+            actor = match.group("actor").strip()
+            modality = match.group("modality").lower()
+            rest = match.group("rest").strip()
 
         conditions = None
         scope = None
         action = rest
 
         cond_match = re.search(r"\b(if|when|unless)\b(.*)", rest, re.IGNORECASE)
-        if cond_match:
+        if cond_match and cond_match.start() > 0:
             action = rest[: cond_match.start()].strip()
             conditions = cond_match.group(0).strip()
 
@@ -48,14 +220,16 @@ def extract_rules(text: str) -> List[Rule]:
             scope = scope_match.group(0).strip()
             action = action[: scope_match.start()].strip()
 
+        elements = _classify_fragments(action, conditions, scope)
+
         rules.append(
             Rule(
                 actor=actor,
                 modality=modality,
-                action=action,
+                action=action.strip(),
                 conditions=conditions,
                 scope=scope,
+                elements=elements,
             )
         )
     return rules
-

--- a/tests/rules/test_element_extraction.py
+++ b/tests/rules/test_element_extraction.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+import pytest
+
+from src.pdf_ingest import build_document
+from src.rules.extractor import extract_rules
+
+
+@pytest.fixture
+def murder_clause() -> str:
+    return (
+        "A person commits murder if the person intentionally causes serious injury to "
+        "another resulting in the death of that person with intent to kill."
+    )
+
+
+@pytest.fixture
+def graffiti_clause() -> str:
+    return (
+        "A person commits the offence of graffiti if the person intentionally marks "
+        "property without the consent of the owner unless the marking is authorised."
+    )
+
+
+def test_murder_elements_are_classified(murder_clause: str) -> None:
+    rules = extract_rules(murder_clause)
+    assert len(rules) == 1
+
+    elements = rules[0].elements
+    assert "conduct" in elements
+    assert any(
+        frag.startswith("the person causes serious injury") for frag in elements["conduct"]
+    )
+    assert "fault" in elements
+    assert any(frag.lower() == "intentionally" for frag in elements["fault"])
+    assert any("intent to kill" in frag.lower() for frag in elements["fault"])
+    assert "result" in elements
+    assert any("resulting in the death" in frag.lower() for frag in elements["result"])
+    assert any("if the person" in frag.lower() for frag in elements.get("circumstance", []))
+
+
+def test_graffiti_elements_are_classified(graffiti_clause: str) -> None:
+    rules = extract_rules(graffiti_clause)
+    assert len(rules) == 1
+
+    elements = rules[0].elements
+    assert any(frag.startswith("the person marks property") for frag in elements["conduct"])
+    assert any(frag.lower() == "intentionally" for frag in elements["fault"])
+    assert any(
+        "without the consent of the owner" in frag.lower()
+        for frag in elements.get("circumstance", [])
+    )
+    assert any(
+        "unless the marking is authorised" in frag.lower()
+        for frag in elements.get("exception", [])
+    )
+
+
+def test_document_atoms_include_element_roles(
+    murder_clause: str, graffiti_clause: str
+) -> None:
+    pages = [
+        {
+            "page": 1,
+            "heading": "Sample Offences",
+            "text": f"{murder_clause} {graffiti_clause}",
+        }
+    ]
+
+    document = build_document(pages, Path("dummy.pdf"))
+    assert document.provisions
+    provision = document.provisions[0]
+
+    element_atoms = [atom for atom in provision.atoms if atom.type == "element"]
+    assert element_atoms, "expected element atoms from rule extraction"
+
+    def _atoms_for(role: str) -> list[str]:
+        return [atom.text for atom in element_atoms if atom.role == role]
+
+    assert any("serious injury" in (text or "").lower() for text in _atoms_for("conduct"))
+    assert any("intentionally" == (text or "").lower() for text in _atoms_for("fault"))
+    assert any("resulting in the death" in (text or "").lower() for text in _atoms_for("result"))
+    assert any("without the consent" in (text or "").lower() for text in _atoms_for("circumstance"))
+    assert any("unless the marking" in (text or "").lower() for text in _atoms_for("exception"))


### PR DESCRIPTION
## Summary
- expand the rule extractor with offence-form clauses and heuristics that label conduct, circumstance, fault, result, and exception fragments
- store classified fragments on rules and emit corresponding element atoms when building documents
- add tests that exercise murder and graffiti samples and assert the extracted checklist roles

## Testing
- PYTHONPATH=. pytest tests/rules/test_element_extraction.py
- PYTHONPATH=. pytest tests/rules/test_rules.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d6470b6bc08322b459182dc1e0127d