### PR TITLE
Add provision atom checklist UI and API endpoint

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -99,6 +99,81 @@ class TestRunRequest(BaseModel):
     story: Dict[str, Any] = Field(..., description="Story data for evaluation")
 
 
+_PROVISION_ATOMS: Dict[str, Dict[str, Any]] = {
+    "Provision#NTA:s223": {
+        "provision_id": "Provision#NTA:s223",
+        "title": "Native Title Act 1993 (Cth) s 223",
+        "atoms": [
+            {
+                "id": "nta-s223-principle",
+                "label": "Native title is recognised if laws and customs are acknowledged",
+                "role": "principle",
+                "proof": {"status": "proven", "confidence": 0.91, "evidenceCount": 3},
+                "principle": {
+                    "id": "nta-principle-1",
+                    "title": "Continuity of traditional laws",
+                    "summary": "Claimants must show continued acknowledgment of traditional laws and customs since sovereignty.",
+                    "citation": "#/proof-tree/statute/Provision#NTA:s223",
+                    "tags": ["continuity", "custom"],
+                },
+                "children": [
+                    {
+                        "id": "nta-s223-fact-1",
+                        "label": "Elders gave testimony about ongoing ceremonies",
+                        "role": "fact",
+                        "proof": {"status": "proven", "confidence": 0.87},
+                    },
+                    {
+                        "id": "nta-s223-fact-2",
+                        "label": "Anthropological report contested on methodology",
+                        "role": "fact",
+                        "proof": {"status": "contested", "evidenceCount": 1},
+                        "notes": "The opposing expert challenges the time depth of the survey interviews.",
+                    },
+                ],
+            },
+            {
+                "id": "nta-s223-principle-2",
+                "label": "The society must have a normative system",
+                "role": "principle",
+                "proof": {"status": "pending", "evidenceCount": 0},
+                "principle": {
+                    "id": "nta-principle-2",
+                    "title": "Normative society",
+                    "summary": "Proof requires demonstrating a body of rules that binds the claim group.",
+                    "tags": ["society", "normative"],
+                },
+            },
+        ],
+    },
+    "Provision#NTA:s225": {
+        "provision_id": "Provision#NTA:s225",
+        "title": "Native Title Act 1993 (Cth) s 225",
+        "atoms": [
+            {
+                "id": "nta-s225-principle",
+                "label": "Determinations must describe the nature and extent of native title rights",
+                "role": "principle",
+                "proof": {"status": "proven", "confidence": 0.78, "evidenceCount": 2},
+                "principle": {
+                    "id": "nta-principle-3",
+                    "title": "Determination particulars",
+                    "summary": "Orders identify rights, interests, and relationship to other interests in the determination area.",
+                    "tags": ["determination", "interests"],
+                },
+            },
+            {
+                "id": "nta-s225-fact",
+                "label": "Overlap with pastoral lease requires clarification",
+                "role": "fact",
+                "proof": {"status": "contested", "evidenceCount": 2},
+                "notes": "Negotiations with the leaseholder are ongoing and unresolved.",
+            },
+        ],
+    },
+}
+
+
 def execute_tests(ids: List[str], story: Dict[str, Any]) -> Dict[str, Any]:
     results: Dict[str, Any] = {}
     for test_id in ids:
@@ -112,6 +187,15 @@ def execute_tests(ids: List[str], story: Dict[str, Any]) -> Dict[str, Any]:
             "passed": all(factors.values()),
         }
     return {"results": results}
+
+
+def fetch_provision_atoms(provision_id: str) -> Dict[str, Any]:
+    """Return provision atoms ready for checklist rendering."""
+
+    provision = _PROVISION_ATOMS.get(provision_id)
+    if not provision:
+        raise HTTPException(status_code=404, detail="Provision not found")
+    return provision
 
 
 def fetch_case_treatment(case_id: str) -> Dict[str, Any]:
@@ -154,11 +238,17 @@ def case_treatment_endpoint(case_id: str) -> Dict[str, Any]:
     return fetch_case_treatment(case_id)
 
 
+@router.get("/provisions/{provision_id}/atoms")
+def provision_atoms_endpoint(provision_id: str) -> Dict[str, Any]:
+    return fetch_provision_atoms(provision_id)
+
+
 __all__ = [
     "router",
     "generate_subgraph",
     "execute_tests",
     "fetch_case_treatment",
+    "fetch_provision_atoms",
     "_graph",
     "WEIGHT",
     "RANK",

--- a/tests/api/test_provision_atoms.py
+++ b/tests/api/test_provision_atoms.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src.api.routes import fetch_provision_atoms, HTTPException
+
+
+def test_fetch_provision_atoms_structure():
+    payload = fetch_provision_atoms("Provision#NTA:s223")
+    assert payload["provision_id"] == "Provision#NTA:s223"
+    assert payload["atoms"], "expected atoms in payload"
+
+    first = payload["atoms"][0]
+    assert first["proof"]["status"] in {"proven", "pending", "contested"}
+    if "principle" in first:
+        card = first["principle"]
+        assert {"id", "title", "summary"}.issubset(card.keys())
+
+
+def test_fetch_provision_atoms_missing():
+    with pytest.raises(HTTPException) as excinfo:
+        fetch_provision_atoms("Provision#missing")
+    assert excinfo.value.status_code == 404

--- a/ui/components/PrincipleCard.tsx
+++ b/ui/components/PrincipleCard.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+
+export interface PrincipleCardProps {
+  id: string;
+  title: string;
+  summary: string;
+  citation?: string;
+  tags?: string[];
+}
+
+const cardStyle: React.CSSProperties = {
+  border: "1px solid #d0d7de",
+  borderRadius: "0.75rem",
+  boxShadow: "0 1px 2px rgba(15, 23, 42, 0.08)",
+  padding: "1rem",
+  backgroundColor: "#fff",
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: "0.95rem",
+  fontWeight: 600,
+  margin: "0 0 0.4rem 0",
+};
+
+const summaryStyle: React.CSSProperties = {
+  fontSize: "0.85rem",
+  margin: "0 0 0.6rem 0",
+  lineHeight: 1.4,
+};
+
+const badgeStyle: React.CSSProperties = {
+  backgroundColor: "#f1f5f9",
+  borderRadius: "999px",
+  color: "#334155",
+  display: "inline-flex",
+  fontSize: "0.7rem",
+  fontWeight: 600,
+  marginRight: "0.4rem",
+  padding: "0.2rem 0.6rem",
+};
+
+const PrincipleCard: React.FC<PrincipleCardProps> = ({
+  id,
+  title,
+  summary,
+  citation,
+  tags = [],
+}) => {
+  return (
+    <article style={cardStyle} data-principle-id={id}>
+      <header style={{ marginBottom: "0.5rem" }}>
+        <h4 style={titleStyle}>{title}</h4>
+        {citation ? (
+          <a
+            href={citation}
+            style={{ color: "#2563eb", fontSize: "0.75rem", textDecoration: "none" }}
+          >
+            View source
+          </a>
+        ) : null}
+      </header>
+      <p style={summaryStyle}>{summary}</p>
+      {tags.length ? (
+        <div aria-label="principle tags">
+          {tags.map((tag) => (
+            <span key={tag} style={badgeStyle}>
+              {tag}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  );
+};
+
+export default PrincipleCard;

--- a/ui/components/ProofStateBadge.tsx
+++ b/ui/components/ProofStateBadge.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+
+export type ProofStatus = "proven" | "contested" | "pending";
+
+export interface ProofState {
+  status: ProofStatus;
+  confidence?: number;
+  evidenceCount?: number;
+}
+
+interface ProofStateBadgeProps {
+  proof: ProofState;
+}
+
+const STATUS_LABELS: Record<ProofStatus, string> = {
+  proven: "Proven",
+  contested: "Contested",
+  pending: "Pending",
+};
+
+const STATUS_COLORS: Record<ProofStatus, string> = {
+  proven: "#2e7d32",
+  contested: "#f9a825",
+  pending: "#546e7a",
+};
+
+const ProofStateBadge: React.FC<ProofStateBadgeProps> = ({ proof }) => {
+  const { status, confidence, evidenceCount } = proof;
+  const label = STATUS_LABELS[status];
+  const color = STATUS_COLORS[status];
+  const extra: string[] = [];
+
+  if (typeof confidence === "number") {
+    extra.push(`${Math.round(confidence * 100)}% confidence`);
+  }
+
+  if (typeof evidenceCount === "number") {
+    const noun = evidenceCount === 1 ? "source" : "sources";
+    extra.push(`${evidenceCount} ${noun}`);
+  }
+
+  return (
+    <span
+      style={{
+        alignItems: "center",
+        borderRadius: "9999px",
+        border: `1px solid ${color}`,
+        color,
+        display: "inline-flex",
+        fontSize: "0.75rem",
+        fontWeight: 600,
+        gap: "0.4rem",
+        padding: "0.1rem 0.6rem",
+      }}
+      aria-label={extra.length ? `${label} (${extra.join(", ")})` : label}
+      data-status={status}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          backgroundColor: color,
+          borderRadius: "50%",
+          display: "inline-block",
+          height: "0.55rem",
+          width: "0.55rem",
+        }}
+      />
+      <span>{label}</span>
+      {extra.length ? <span style={{ color: "inherit" }}>· {extra.join(", ")}</span> : null}
+    </span>
+  );
+};
+
+export default ProofStateBadge;

--- a/ui/components/ProvisionAtomChecklist.stories.tsx
+++ b/ui/components/ProvisionAtomChecklist.stories.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import ProvisionAtomChecklist, {
+  ProvisionAtomNode,
+} from "./ProvisionAtomChecklist";
+
+const sampleAtoms: ProvisionAtomNode[] = [
+  {
+    id: "atom-1",
+    label: "Native title holders must authorise agreements",
+    role: "principle",
+    notes: "Derived from subsection 223(1)(a).",
+    proof: { status: "proven", confidence: 0.92, evidenceCount: 3 },
+    principle: {
+      id: "principle-1",
+      title: "Authorisation principle",
+      summary: "Agreements affecting native title require free, prior and informed consent from recognised holders.",
+      citation: "#/proof-tree/statute/Provision#NTA:s223",
+      tags: ["consent", "representation"],
+    },
+    children: [
+      {
+        id: "atom-1a",
+        label: "Meeting convened with notice to prescribed body corporate",
+        role: "fact",
+        proof: { status: "proven", confidence: 0.88 },
+      },
+      {
+        id: "atom-1b",
+        label: "Resolution passed with 75% majority",
+        role: "fact",
+        proof: { status: "contested", evidenceCount: 1 },
+        notes: "The minutes reference proxies that are under review.",
+      },
+    ],
+  },
+  {
+    id: "atom-2",
+    label: "Agreements must satisfy procedural fairness",
+    role: "principle",
+    proof: { status: "pending", evidenceCount: 0 },
+    principle: {
+      id: "principle-2",
+      title: "Procedural fairness",
+      summary: "Processes must provide affected parties an opportunity to be heard before approval.",
+      tags: ["procedure"],
+    },
+  },
+];
+
+export default {
+  title: "ProvisionAtoms/Checklist",
+  component: ProvisionAtomChecklist,
+};
+
+export const DefaultChecklist = () => (
+  <ProvisionAtomChecklist title="Section 223 atoms" atoms={sampleAtoms} />
+);
+
+export const DenseChecklist = () => (
+  <ProvisionAtomChecklist title="Compact view" atoms={sampleAtoms} dense />
+);

--- a/ui/components/ProvisionAtomChecklist.tsx
+++ b/ui/components/ProvisionAtomChecklist.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import PrincipleCard, { PrincipleCardProps } from "./PrincipleCard";
+import ProofStateBadge, { ProofState } from "./ProofStateBadge";
+
+export interface ProvisionAtomNode {
+  id: string;
+  label: string;
+  role?: string;
+  proof: ProofState;
+  principle?: PrincipleCardProps;
+  notes?: string;
+  children?: ProvisionAtomNode[];
+}
+
+export interface ProvisionAtomChecklistProps {
+  atoms: ProvisionAtomNode[];
+  title?: string;
+  dense?: boolean;
+}
+
+const listStyle: React.CSSProperties = {
+  display: "grid",
+  gap: "0.9rem",
+  margin: 0,
+  padding: 0,
+};
+
+const itemStyle: React.CSSProperties = {
+  backgroundColor: "#f8fafc",
+  border: "1px solid #e2e8f0",
+  borderRadius: "0.9rem",
+  listStyle: "none",
+  padding: "0.9rem",
+};
+
+const ProvisionAtomChecklist: React.FC<ProvisionAtomChecklistProps> = ({
+  atoms,
+  title,
+  dense = false,
+}) => {
+  const renderNode = (node: ProvisionAtomNode, depth = 0) => {
+    const hasChildren = Boolean(node.children?.length);
+    return (
+      <li key={node.id} style={{ ...itemStyle, paddingLeft: `${0.9 + depth * 0.6}rem` }}>
+        <div
+          style={{
+            alignItems: "flex-start",
+            display: "flex",
+            flexDirection: "column",
+            gap: dense ? "0.4rem" : "0.6rem",
+          }}
+        >
+          <div
+            style={{
+              alignItems: "flex-start",
+              display: "flex",
+              gap: "0.8rem",
+              width: "100%",
+            }}
+          >
+            <ProofStateBadge proof={node.proof} />
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: "0.95rem", fontWeight: 600 }}>{node.label}</div>
+              {node.role ? (
+                <div style={{ color: "#475569", fontSize: "0.75rem" }}>{node.role}</div>
+              ) : null}
+              {node.notes ? (
+                <p style={{ color: "#1e293b", fontSize: "0.8rem", margin: "0.4rem 0 0" }}>
+                  {node.notes}
+                </p>
+              ) : null}
+            </div>
+          </div>
+          {node.principle ? (
+            <PrincipleCard {...node.principle} />
+          ) : null}
+        </div>
+        {hasChildren ? (
+          <ul style={{ ...listStyle, marginTop: dense ? "0.6rem" : "0.9rem", paddingLeft: "0.6rem" }}>
+            {node.children!.map((child) => renderNode(child, depth + 1))}
+          </ul>
+        ) : null}
+      </li>
+    );
+  };
+
+  return (
+    <section aria-label={title ?? "Provision atom checklist"}>
+      {title ? (
+        <header style={{ marginBottom: "1rem" }}>
+          <h3 style={{ fontSize: "1.1rem", margin: 0 }}>{title}</h3>
+        </header>
+      ) : null}
+      <ul style={listStyle}>{atoms.map((atom) => renderNode(atom))}</ul>
+    </section>
+  );
+};
+
+export default ProvisionAtomChecklist;

--- a/ui/components/index.ts
+++ b/ui/components/index.ts
@@ -1,2 +1,9 @@
 export { default as TreatmentTable } from "./TreatmentTable";
 export { default as DistinguishPanel } from "./DistinguishPanel";
+export { default as ProvisionAtomChecklist } from "./ProvisionAtomChecklist";
+export { default as PrincipleCard } from "./PrincipleCard";
+export { default as ProofStateBadge } from "./ProofStateBadge";
+
+export type { ProvisionAtomNode, ProvisionAtomChecklistProps } from "./ProvisionAtomChecklist";
+export type { PrincipleCardProps } from "./PrincipleCard";
+export type { ProofState, ProofStatus } from "./ProofStateBadge";


### PR DESCRIPTION
## Summary
- add React checklist, principle card, and proof-state badge components for provision atoms
- expose a provisions/{id}/atoms endpoint that returns checklist-ready atom payloads
- include a Storybook harness and pytest coverage to validate provision atom structures

## Testing
- pytest tests/api/test_provision_atoms.py

------
https://chatgpt.com/codex/tasks/task_e_68d649ca52288322a0bc36fb051dc336