### PR TITLE
Annotate offence atoms with curated glossary metadata

### DIFF
--- a/cli/glossary.py
+++ b/cli/glossary.py
@@ -15,8 +15,11 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
 
 
 def _handle(args: argparse.Namespace) -> None:
-    definition = lookup(args.term)
-    print(definition)
+    entry = lookup(args.term)
+    if entry is None:
+        print(args.term)
+    else:
+        print(entry.text)
 
 
 __all__ = ["register"]

--- a/data/glossary/offence_gloss.yaml
+++ b/data/glossary/offence_gloss.yaml
@@ -1,0 +1,11 @@
+elements:
+  with intent to cause death:
+    text: "R v Smith [2001] HCA 12 confirmed that murder requires an intention to kill."
+    metadata:
+      case: "R v Smith"
+      citation: "[2001] HCA 12"
+  resulting in grievous bodily harm:
+    text: "Brown v R [1995] HCA 34 treated grievous bodily harm as a qualifying result for serious offences."
+    metadata:
+      case: "Brown v R"
+      citation: "[1995] HCA 34"

--- a/src/glossary/service.py
+++ b/src/glossary/service.py
@@ -2,13 +2,101 @@
 
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
 
-def lookup(term: str) -> str:
-    """Return a definition for *term*.
+import yaml
 
-    The current implementation is a placeholder that simply echoes the term.
-    """
-    return term
+_DATA_DIR = Path(__file__).resolve().parents[2] / "data" / "glossary"
+_DEFAULT_DATA_FILE = _DATA_DIR / "offence_gloss.yaml"
 
 
-__all__ = ["lookup"]
+def _normalise_key(term: str) -> str:
+    """Normalise a lookup *term* for matching against curated data."""
+
+    return " ".join(term.lower().strip(" \t\n,.!?;:'\"()").split())
+
+
+@dataclass(frozen=True)
+class GlossEntry:
+    """Curated gloss definition and optional metadata."""
+
+    phrase: str
+    text: str
+    metadata: Optional[Dict[str, Any]] = None
+
+    def __str__(self) -> str:  # pragma: no cover - exercised indirectly
+        return self.text
+
+
+def _coerce_metadata(meta: Any) -> Optional[Dict[str, Any]]:
+    if meta is None:
+        return None
+    if isinstance(meta, Mapping):
+        return dict(meta)
+    raise TypeError("Gloss metadata must be a mapping or null")
+
+
+def _coerce_entry(phrase: str, value: Any) -> Optional[GlossEntry]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        return GlossEntry(phrase=phrase, text=text)
+    if isinstance(value, Mapping):
+        text = str(value.get("text") or value.get("gloss") or "").strip()
+        if not text:
+            return None
+        metadata = _coerce_metadata(value.get("metadata"))
+        return GlossEntry(phrase=phrase, text=text, metadata=metadata)
+    raise TypeError(f"Unsupported glossary entry type for '{phrase}': {type(value)!r}")
+
+
+def _load_raw(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        if path.suffix.lower() == ".json":
+            data = json.load(handle)
+        elif path.suffix.lower() in {".yaml", ".yml"}:
+            data = yaml.safe_load(handle)
+        else:
+            raise ValueError(f"Unsupported glossary format: {path.suffix}")
+    if data is None:
+        return {}
+    if not isinstance(data, Mapping):
+        raise TypeError("Glossary file must contain a mapping of phrases to entries")
+    # Allow files to nest entries under an "elements" key for readability.
+    if "elements" in data and isinstance(data["elements"], Mapping):
+        return dict(data["elements"])
+    return dict(data)
+
+
+@lru_cache(maxsize=None)
+def _load_glossary(path: Path = _DEFAULT_DATA_FILE) -> Dict[str, GlossEntry]:
+    raw = _load_raw(path)
+    entries: Dict[str, GlossEntry] = {}
+    for phrase, value in raw.items():
+        normalised_phrase = " ".join(str(phrase).split())
+        entry = _coerce_entry(normalised_phrase, value)
+        if entry is None:
+            continue
+        entries[_normalise_key(normalised_phrase)] = entry
+    return entries
+
+
+def lookup(term: str, *, path: Optional[Path] = None) -> Optional[GlossEntry]:
+    """Return the curated gloss entry for *term* if available."""
+
+    if not term:
+        return None
+    glossary = _load_glossary(path or _DEFAULT_DATA_FILE)
+    return glossary.get(_normalise_key(term))
+
+
+__all__ = ["lookup", "GlossEntry"]

--- a/src/models/provision.py
+++ b/src/models/provision.py
@@ -15,6 +15,7 @@ class Atom:
     conditions: Optional[str] = None
     refs: List[str] = field(default_factory=list)
     gloss: Optional[str] = None
+    gloss_metadata: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Serialise the atom to a dictionary."""
@@ -27,6 +28,11 @@ class Atom:
             "conditions": self.conditions,
             "refs": list(self.refs),
             "gloss": self.gloss,
+            "gloss_metadata": (
+                dict(self.gloss_metadata)
+                if self.gloss_metadata is not None
+                else None
+            ),
         }
 
     @classmethod
@@ -41,6 +47,11 @@ class Atom:
             conditions=data.get("conditions"),
             refs=list(data.get("refs", [])),
             gloss=data.get("gloss"),
+            gloss_metadata=(
+                dict(data["gloss_metadata"])
+                if "gloss_metadata" in data and data["gloss_metadata"] is not None
+                else None
+            ),
         )
 
 

--- a/src/pdf_ingest.py
+++ b/src/pdf_ingest.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 
 from pdfminer.high_level import extract_text
 
+from .glossary.service import lookup as lookup_gloss
 from .ingestion.cache import HTTPCache
 from .models.document import Document, DocumentMetadata, Provision
 from .models.provision import Atom
@@ -93,6 +94,7 @@ def _rules_to_atoms(rules) -> List[Atom]:
 
         for role, fragments in (r.elements or {}).items():
             for fragment in fragments:
+                gloss_entry = lookup_gloss(fragment)
                 atoms.append(
                     Atom(
                         type="element",
@@ -100,6 +102,12 @@ def _rules_to_atoms(rules) -> List[Atom]:
                         text=fragment,
                         who=r.actor or None,
                         conditions=r.conditions if role == "circumstance" else None,
+                        gloss=gloss_entry.text if gloss_entry else None,
+                        gloss_metadata=(
+                            dict(gloss_entry.metadata)
+                            if gloss_entry and gloss_entry.metadata is not None
+                            else None
+                        ),
                     )
                 )
     return atoms

--- a/tests/glossary/test_offence_glossary.py
+++ b/tests/glossary/test_offence_glossary.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from src.pdf_ingest import _rules_to_atoms
+from src.rules.extractor import extract_rules
+
+
+def _build_atoms(text: str):
+    rules = extract_rules(text)
+    assert rules, "expected at least one rule from sample text"
+    return _rules_to_atoms(rules)
+
+
+def test_offence_elements_receive_curated_gloss():
+    text = (
+        "A person commits the offence of aggravated assault if the person, with intent "
+        "to cause death, causes an injury resulting in grievous bodily harm."
+    )
+    atoms = _build_atoms(text)
+    by_text = {atom.text: atom for atom in atoms if atom.type == "element"}
+
+    fault_atom = by_text["with intent to cause death"]
+    assert (
+        fault_atom.gloss
+        == "R v Smith [2001] HCA 12 confirmed that murder requires an intention to kill."
+    )
+    assert fault_atom.gloss_metadata == {"case": "R v Smith", "citation": "[2001] HCA 12"}
+
+    result_atom = by_text["resulting in grievous bodily harm"]
+    assert (
+        result_atom.gloss
+        == "Brown v R [1995] HCA 34 treated grievous bodily harm as a qualifying result for serious offences."
+    )
+    assert result_atom.gloss_metadata == {"case": "Brown v R", "citation": "[1995] HCA 34"}
+
+
+def test_offence_element_without_gloss_remains_unannotated():
+    text = (
+        "A person commits the offence of aggravated assault if the person causes an injury "
+        "without lawful excuse."
+    )
+    atoms = _build_atoms(text)
+    for atom in atoms:
+        if atom.type == "element":
+            assert atom.text != "with intent to cause death"
+            assert atom.gloss is None
+            assert atom.gloss_metadata is None

--- a/tests/models/test_document_serialization.py
+++ b/tests/models/test_document_serialization.py
@@ -31,6 +31,7 @@ def test_document_serialization_round_trip():
         conditions="if relevant",
         refs=["ref1"],
         gloss="A guiding principle",
+        gloss_metadata={"source": "example"},
     )
     provision = Provision(
         text="Sample provision",


### PR DESCRIPTION
## Summary
- load curated offence gloss definitions from the curated YAML dataset
- extend atoms to carry optional gloss metadata and fill it during PDF ingestion
- cover the new behaviour with offence scenario tests exercising curated gloss matches

## Testing
- PYTHONPATH=. pytest tests/models/test_document_serialization.py tests/glossary -vv

------
https://chatgpt.com/codex/tasks/task_e_68d649c9c7648322bd53c2c2442d0b15