### PR TITLE
Improve PDF section parsing

### DIFF
--- a/src/pdf_ingest.py
+++ b/src/pdf_ingest.py
@@ -19,7 +19,7 @@ from .rules.extractor import extract_rules
 # available, a trivial fallback is used which treats the entire body as a single
 # provision.
 try:  # pragma: no cover - executed conditionally
-    from . import section_parser  # type: ignore
+    from .ingestion import section_parser  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     section_parser = None  # type: ignore
 
@@ -123,6 +123,68 @@ def _build_provisions_from_nodes(nodes) -> List[Provision]:
     return [_build_provision_from_node(node) for node in nodes]
 
 
+_SECTION_HEADING_RE = re.compile(
+    r"(?m)^(?P<identifier>\d+[A-Za-z0-9]*)\s+(?P<heading>[^\n]+)"
+)
+
+
+def _iter_section_provisions(provisions: List[Provision]):
+    for provision in provisions:
+        if provision.node_type == "section":
+            yield provision
+        for child in _iter_section_provisions(provision.children):
+            yield child
+
+
+def _fallback_parse_sections(text: str) -> List[Provision]:
+    matches = list(_SECTION_HEADING_RE.finditer(text))
+    if not matches:
+        return [Provision(text=text)]
+
+    sections: List[Provision] = []
+    prefix = text[: matches[0].start()].strip()
+
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        body = text[start:end].strip()
+
+        identifier = match.group("identifier").strip()
+        heading = match.group("heading").strip()
+
+        parts: List[str] = []
+        if index == 0 and prefix:
+            parts.append(prefix)
+        parts.append(heading)
+        if body:
+            parts.append(body)
+
+        section_text = "\n".join(parts).strip()
+        sections.append(
+            Provision(
+                text=section_text,
+                identifier=identifier or None,
+                heading=heading or None,
+                node_type="section",
+            )
+        )
+
+    return sections
+
+
+def parse_sections(text: str) -> List[Provision]:
+    """Split ``text`` into individual section provisions."""
+
+    if section_parser and hasattr(section_parser, "parse_sections"):
+        nodes = section_parser.parse_sections(text)  # type: ignore[attr-defined]
+        structured = _build_provisions_from_nodes(nodes)
+        sections = list(_iter_section_provisions(structured))
+        if sections:
+            return sections
+
+    return _fallback_parse_sections(text)
+
+
 def build_document(
     pages: List[dict],
     source: Path,
@@ -141,11 +203,7 @@ def build_document(
         provenance=str(source),
     )
 
-    if section_parser and hasattr(section_parser, "parse_sections"):
-        structured = section_parser.parse_sections(body)  # type: ignore[attr-defined]
-        provisions = _build_provisions_from_nodes(structured)
-    else:  # Fallback: single provision containing entire body
-        provisions = [Provision(text=body)]
+    provisions = parse_sections(body)
 
     for prov in provisions:
         rules = extract_rules(prov.text)

--- a/tests/pdf_ingest/test_section_splitting.py
+++ b/tests/pdf_ingest/test_section_splitting.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+def test_build_document_creates_multiple_sections(monkeypatch):
+    from src import pdf_ingest
+
+    monkeypatch.setattr(pdf_ingest, "section_parser", None, raising=False)
+    monkeypatch.setattr(pdf_ingest, "extract_rules", lambda text: [])
+
+    pages = [
+        {"page": 1, "heading": "Part 1 Preliminary Matters", "text": ""},
+        {"page": 2, "heading": "Division 1 Introductory", "text": ""},
+        {
+            "page": 3,
+            "heading": "1 Short title",
+            "text": "(1) This Act may be cited as the Sample Act.\n(2) Regulations must set required forms.",
+        },
+        {
+            "page": 4,
+            "heading": "2 Application of Act",
+            "text": "The Minister must not delay action if urgent circumstances exist.",
+        },
+    ]
+
+    document = pdf_ingest.build_document(pages, source=Path("sample.pdf"))
+
+    assert len(document.provisions) == 2
+    identifiers = [prov.identifier for prov in document.provisions]
+    assert identifiers == ["1", "2"]
+
+    first, second = document.provisions
+    assert first.heading == "Short title"
+    assert "may be cited as the Sample Act" in first.text
+    assert second.heading == "Application of Act"
+    assert "must not delay action" in second.text


### PR DESCRIPTION
## Summary
- import the ingestion section parser directly and add a helper that flattens parsed nodes into provisions
- fall back to a simple heading-based splitter when the section parser is unavailable so each section becomes its own provision
- add regression coverage ensuring multi-section PDFs yield separate provisions with the correct identifiers

## Testing
- pytest tests/pdf_ingest -q

------
https://chatgpt.com/codex/tasks/task_e_68d649d0680c83228468b9bdee92f30d