### PR TITLE
Improve PDF ingestion fallback section parsing

### DIFF
--- a/src/pdf_ingest.py
+++ b/src/pdf_ingest.py
@@ -115,8 +115,6 @@ def _rules_to_atoms(rules) -> List[Atom]:
                         text=fragment,
                         who=who,
                         conditions=r.conditions if role == "circumstance" else None,
-                        gloss=who_text or None,
-
                         gloss=gloss_entry.text if gloss_entry else None,
                         gloss_metadata=(
                             dict(gloss_entry.metadata)
@@ -169,6 +167,19 @@ def parse_sections(text: str) -> List[Provision]:
 
     if not text.strip():
         return []
+
+    if section_parser and hasattr(section_parser, "parse_sections"):
+        nodes = section_parser.parse_sections(text)  # type: ignore[attr-defined]
+        structured = _build_provisions_from_nodes(nodes)
+        sections = list(_iter_section_provisions(structured))
+        if sections:
+            return sections
+        if structured:
+            return structured
+
+    return _fallback_parse_sections(text)
+
+
 _SECTION_HEADING_RE = re.compile(
     r"(?m)^(?P<identifier>\d+[A-Za-z0-9]*)\s+(?P<heading>[^\n]+)"
 )
@@ -218,28 +229,6 @@ def _fallback_parse_sections(text: str) -> List[Provision]:
     return sections
 
 
-def parse_sections(text: str) -> List[Provision]:
-    """Split ``text`` into individual section provisions."""
-
-    if section_parser and hasattr(section_parser, "parse_sections"):
-        nodes = section_parser.parse_sections(text)  # type: ignore[attr-defined]
-        structured = _build_provisions_from_nodes(nodes)
-        sections: List[Provision] = []
-        for prov in structured:
-            _collect_section_provisions(prov, sections)
-        if sections:
-            return sections
-        if structured:
-            return structured
-
-    return [Provision(text=text)]
-        sections = list(_iter_section_provisions(structured))
-        if sections:
-            return sections
-
-    return _fallback_parse_sections(text)
-
-
 def build_document(
     pages: List[dict],
     source: Path,
@@ -260,11 +249,6 @@ def build_document(
 
     provisions = parse_sections(body)
     if not provisions:
-    if hasattr(section_parser, "parse_sections"):
-        provisions = section_parser.parse_sections(body)
-        if not provisions:
-            provisions = [Provision(text=body)]
-    else:  # Fallback: single provision containing entire body
         provisions = [Provision(text=body)]
 
     for prov in provisions:

--- a/tests/pdf_ingest/test_section_splitting.py
+++ b/tests/pdf_ingest/test_section_splitting.py
@@ -1,11 +1,24 @@
+import importlib
+import sys
 from pathlib import Path
 
+import pytest
 
-def test_build_document_creates_multiple_sections(monkeypatch):
-    from src import pdf_ingest
 
-    monkeypatch.setattr(pdf_ingest, "section_parser", None, raising=False)
-    monkeypatch.setattr(pdf_ingest, "extract_rules", lambda text: [])
+@pytest.fixture(name="pdf_ingest")
+def _pdf_ingest(monkeypatch):
+    root = Path(__file__).resolve().parents[2]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+    sys.modules.pop("src.pdf_ingest", None)
+    module = importlib.import_module("src.pdf_ingest")
+    monkeypatch.setattr(module, "section_parser", None, raising=False)
+    monkeypatch.setattr(module, "extract_rules", lambda text: [])
+    return module
+
+
+def test_build_document_creates_multiple_sections(pdf_ingest):
 
     pages = [
         {"page": 1, "heading": "Part 1 Preliminary Matters", "text": ""},
@@ -33,3 +46,17 @@ def test_build_document_creates_multiple_sections(monkeypatch):
     assert "may be cited as the Sample Act" in first.text
     assert second.heading == "Application of Act"
     assert "must not delay action" in second.text
+
+
+def test_parse_sections_falls_back_to_regex(pdf_ingest):
+    text = (
+        "Introductory text.\n"
+        "1 Heading One\nBody of the first section.\n"
+        "2 Heading Two\nBody of the second section."
+    )
+
+    provisions = pdf_ingest.parse_sections(text)
+
+    assert [prov.identifier for prov in provisions] == ["1", "2"]
+    assert provisions[0].heading == "Heading One"
+    assert provisions[1].heading == "Heading Two"


### PR DESCRIPTION
## Summary
- ensure `parse_sections` walks structured parser output before falling back to regex splitting
- remove the duplicate gloss argument when building element atoms
- add tests that cover the regex fallback when `section_parser` is unavailable

## Testing
- pytest tests/pdf_ingest/test_section_splitting.py

------
https://chatgpt.com/codex/tasks/task_e_68d655dd677c8322a19df1bd885b3c85