### PR TITLE
Enhance CLI PDF fetch test coverage

### DIFF
--- a/tests/test_cli_pdf_fetch.py
+++ b/tests/test_cli_pdf_fetch.py
@@ -10,7 +10,8 @@ def test_pdf_fetch_cli(tmp_path):
     (stub_pkg / "pdfminer").mkdir(parents=True)
     (stub_pkg / "pdfminer" / "__init__.py").write_text("")
     (stub_pkg / "pdfminer" / "high_level.py").write_text(
-        "def extract_text(path):\n    return 'Heading 1\\nHello\\nWorld\\fHeading2\\nSecond Page'\n"
+        "def extract_text(path):\n"
+        "    return '1 Heading One\\nAgents must file reports.\\f2 Heading Two\\nDirectors may refuse permits.'\n"
     )
 
     pdf_path = tmp_path / "sample.pdf"
@@ -35,6 +36,22 @@ def test_pdf_fetch_cli(tmp_path):
     completed = subprocess.run(cmd, capture_output=True, text=True, check=True, env=env)
     data = json.loads(completed.stdout)
     assert data["metadata"]["jurisdiction"] == "US"
+    provisions = data["provisions"]
+    assert [prov["identifier"] for prov in provisions] == ["1", "2"]
+    assert [prov["heading"] for prov in provisions] == ["Heading One", "Heading Two"]
+    for provision in provisions:
+        assert provision["principles"], "expected non-empty principles from CLI output"
+        assert provision["atoms"], "expected non-empty atoms from CLI output"
+
     assert out_path.exists()
     saved = json.loads(out_path.read_text())
     assert saved["metadata"]["citation"] == "CIT"
+    saved_provisions = saved["provisions"]
+    assert [prov["identifier"] for prov in saved_provisions] == ["1", "2"]
+    assert [prov["heading"] for prov in saved_provisions] == [
+        "Heading One",
+        "Heading Two",
+    ]
+    for provision in saved_provisions:
+        assert provision["principles"], "expected principles persisted to disk"
+        assert provision["atoms"], "expected atoms persisted to disk"


### PR DESCRIPTION
## Summary
- update the pdfminer stub in the CLI PDF fetch test to emit two numbered sections with rule-like sentences
- assert that the CLI JSON output contains the expected provision identifiers and headings with populated principles and atoms
- verify the persisted JSON mirrors the CLI output, ensuring the end-to-end rule extraction is exercised

## Testing
- pytest tests/test_cli_pdf_fetch.py -q *(fails: src/pdf_ingest import raises IndentationError while checking for section parser)*

------
https://chatgpt.com/codex/tasks/task_e_68d65f657ea88322865dc0278ad4ba17