### PR TITLE
Fix section parsing regression and add regression test

### DIFF
--- a/src/pdf_ingest.py
+++ b/src/pdf_ingest.py
@@ -133,7 +133,6 @@ def _rules_to_atoms(rules) -> List[Atom]:
                         gloss=(
                             gloss_entry.text if gloss_entry else who_text or None
                         ),
-                        gloss=gloss_entry.text if gloss_entry else None,
                         gloss_metadata=(
                             dict(gloss_entry.metadata)
                             if gloss_entry and gloss_entry.metadata is not None
@@ -180,24 +179,18 @@ def _collect_section_provisions(provision: Provision, bucket: List[Provision]) -
         _collect_section_provisions(child, bucket)
 
 
+def _iter_section_provisions(provisions: List[Provision]):
+    """Yield every section provision from a list of provisions."""
+
+    for provision in provisions:
+        if provision.node_type == "section":
+            yield provision
+        if provision.children:
+            yield from _iter_section_provisions(provision.children)
+
+
 def _has_section_parser() -> bool:
     return bool(section_parser and hasattr(section_parser, "parse_sections"))
-
-
-    if not text.strip():
-        return []
-
-    if section_parser and hasattr(section_parser, "parse_sections"):
-        nodes = section_parser.parse_sections(text)  # type: ignore[attr-defined]
-        structured = _build_provisions_from_nodes(nodes)
-        sections = list(_iter_section_provisions(structured))
-        if sections:
-            return sections
-        if structured:
-            return structured
-
-    return _fallback_parse_sections(text)
-
 
 
 _SECTION_HEADING_RE = re.compile(
@@ -250,14 +243,14 @@ def parse_sections(text: str) -> List[Provision]:
     parser_available = _has_section_parser()
 
     if parser_available:
-    if section_parser and hasattr(section_parser, "parse_sections"):
-        nodes = section_parser.parse_sections(text)  # type: ignore[attr-defined]
-        structured = _build_provisions_from_nodes(nodes)
-        sections = list(_iter_section_provisions(structured))
-        if sections:
-            return sections
-        if structured:
-            return structured
+        if section_parser and hasattr(section_parser, "parse_sections"):
+            nodes = section_parser.parse_sections(text)  # type: ignore[attr-defined]
+            structured = _build_provisions_from_nodes(nodes)
+            sections = list(_iter_section_provisions(structured))
+            if sections:
+                return sections
+            if structured:
+                return structured
 
     logger.debug(
         "Falling back to regex-based section parsing (section_parser_available=%s, "

--- a/tests/pdf_ingest/test_parse_sections_regression.py
+++ b/tests/pdf_ingest/test_parse_sections_regression.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import src.pdf_ingest as pdf_ingest
+from src.pdf_ingest import build_document, parse_sections
+
+
+def test_parse_sections_structured_and_regex_fallback(monkeypatch):
+    text = "1 Heading\nBody of the section."
+
+    section_node = SimpleNamespace(
+        text="Heading\nBody of the section.",
+        identifier="1",
+        heading="Heading",
+        node_type="section",
+        children=[],
+        rule_tokens={},
+        references=[],
+    )
+
+    fake_parser = SimpleNamespace(parse_sections=lambda _: [section_node])
+    monkeypatch.setattr(pdf_ingest, "section_parser", fake_parser, raising=False)
+
+    structured_sections = parse_sections(text)
+    assert [section.identifier for section in structured_sections] == ["1"]
+
+    monkeypatch.setattr(pdf_ingest, "section_parser", None, raising=False)
+
+    fallback_sections = parse_sections(text)
+    assert fallback_sections
+    assert fallback_sections[0].identifier == "1"
+
+    pages = [{"heading": "1 Heading", "text": "Body of the section."}]
+    document = build_document(pages, Path("dummy.pdf"))
+    assert document.provisions


### PR DESCRIPTION
## Summary
- restore the section provision iterator and clean up the optional parser invocation in `parse_sections`
- resolve the duplicate `gloss` keyword in atom construction to avoid syntax errors
- add a regression test that exercises both structured parsing and the regex fallback via `build_document`

## Testing
- pytest tests/pdf_ingest/test_parse_sections_regression.py

------
https://chatgpt.com/codex/tasks/task_e_68d662e63978832281a952efc45de848