### PR TITLE
Add who and conditions metadata to provision atoms

### DIFF
--- a/src/models/provision.py
+++ b/src/models/provision.py
@@ -11,7 +11,9 @@ class Atom:
     type: Optional[str] = None
     role: Optional[str] = None
     party: Optional[str] = None
+    who: Optional[str] = None
     who_text: Optional[str] = None
+    conditions: Optional[str] = None
     text: Optional[str] = None
     refs: List[str] = field(default_factory=list)
     gloss: Optional[str] = None
@@ -24,7 +26,9 @@ class Atom:
             "type": self.type,
             "role": self.role,
             "party": self.party,
+            "who": self.who,
             "who_text": self.who_text,
+            "conditions": self.conditions,
             "text": self.text,
             "refs": list(self.refs),
             "gloss": self.gloss,
@@ -43,7 +47,9 @@ class Atom:
             type=data.get("type"),
             role=data.get("role"),
             party=data.get("party"),
+            who=data.get("who"),
             who_text=data.get("who_text"),
+            conditions=data.get("conditions"),
             text=data.get("text"),
             refs=list(data.get("refs", [])),
             gloss=data.get("gloss"),

--- a/src/pdf_ingest.py
+++ b/src/pdf_ingest.py
@@ -110,10 +110,10 @@ def _rules_to_atoms(rules) -> List[Atom]:
                 type="rule",
                 role="principle",
                 party=r.actor or None,
-                who_text=r.actor or None,
-                text=text.strip() or None,
                 who=who,
+                who_text=r.actor or None,
                 conditions=r.conditions,
+                text=text.strip() or None,
                 gloss=who_text or None,
             )
         )
@@ -126,14 +126,11 @@ def _rules_to_atoms(rules) -> List[Atom]:
                         type="element",
                         role=role,
                         party=r.actor or None,
-                        who_text=r.actor or None,
-                        text=fragment,
                         who=who,
+                        who_text=r.actor or None,
                         conditions=r.conditions if role == "circumstance" else None,
-                        gloss=(
-                            gloss_entry.text if gloss_entry else who_text or None
-                        ),
-                        gloss=gloss_entry.text if gloss_entry else None,
+                        text=fragment,
+                        gloss=(gloss_entry.text if gloss_entry else None),
                         gloss_metadata=(
                             dict(gloss_entry.metadata)
                             if gloss_entry and gloss_entry.metadata is not None
@@ -249,8 +246,9 @@ def parse_sections(text: str) -> List[Provision]:
 
     parser_available = _has_section_parser()
 
-    if parser_available:
-    if section_parser and hasattr(section_parser, "parse_sections"):
+    if parser_available and section_parser and hasattr(
+        section_parser, "parse_sections"
+    ):
         nodes = section_parser.parse_sections(text)  # type: ignore[attr-defined]
         structured = _build_provisions_from_nodes(nodes)
         sections = list(_iter_section_provisions(structured))

--- a/tests/models/test_provision_atoms.py
+++ b/tests/models/test_provision_atoms.py
@@ -6,7 +6,9 @@ def test_provision_atom_round_trip_preserves_party_and_who_text():
         type="rule",
         role="obligation",
         party="respondent",
+        who="defence",
         who_text="The respondent",
+        conditions="if ordered",
         text="must pay damages",
         refs=["s 10"],
         gloss="Obligation to compensate",
@@ -15,7 +17,9 @@ def test_provision_atom_round_trip_preserves_party_and_who_text():
 
     data = provision.to_dict()
     assert data["atoms"][0]["party"] == "respondent"
+    assert data["atoms"][0]["who"] == "defence"
     assert data["atoms"][0]["who_text"] == "The respondent"
+    assert data["atoms"][0]["conditions"] == "if ordered"
 
     round_tripped = Provision.from_dict(data)
     assert round_tripped.atoms == [atom]

--- a/tests/pdf_ingest/test_rules_to_atoms_metadata.py
+++ b/tests/pdf_ingest/test_rules_to_atoms_metadata.py
@@ -1,0 +1,32 @@
+from src.pdf_ingest import _rules_to_atoms
+from src.rules import Rule
+
+
+def test_rules_to_atoms_includes_who_and_conditions_metadata():
+    rule = Rule(
+        actor="The court",
+        modality="must",
+        action="consider the evidence",
+        conditions="if requested",
+        elements={"circumstance": ["if requested"]},
+        party="court",
+        role="decision_maker",
+        who_text="the court",
+    )
+
+    atoms = _rules_to_atoms([rule])
+
+    rule_atom = next(atom for atom in atoms if atom.type == "rule")
+    assert rule_atom.who == "court"
+    assert rule_atom.party == "The court"
+    assert rule_atom.conditions == "if requested"
+    assert rule_atom.gloss == "the court"
+    assert rule_atom.text == "The court must consider the evidence if requested"
+
+    element_atom = next(atom for atom in atoms if atom.type == "element")
+    assert element_atom.role == "circumstance"
+    assert element_atom.text == "if requested"
+    assert element_atom.who == "court"
+    assert element_atom.conditions == "if requested"
+    assert element_atom.gloss is None
+    assert element_atom.gloss_metadata is None


### PR DESCRIPTION
## Summary
- extend the Atom dataclass with canonical who and conditions fields and include them in serialisation
- update _rules_to_atoms to populate the new metadata and remove the duplicated gloss argument
- cover the new behaviour with provision serialisation and atom metadata unit tests

## Testing
- pytest tests/pdf_ingest/test_rule_party_classification.py tests/glossary/test_offence_glossary.py tests/models/test_provision_atoms.py tests/pdf_ingest/test_rules_to_atoms_metadata.py

------
https://chatgpt.com/codex/tasks/task_e_68d662e79f048322ac429bcade3d19c4