### PR TITLE
Fix atom metadata propagation in PDF ingest

### DIFF
--- a/src/pdf_ingest.py
+++ b/src/pdf_ingest.py
@@ -98,60 +98,59 @@ def download_pdf(url: str, cache: HTTPCache, dest: Path) -> Path:
 def _rules_to_atoms(rules) -> List[Atom]:
     atoms: List[Atom] = []
     for r in rules:
+        actor = getattr(r, "actor", None)
         who = getattr(r, "party", None) or UNKNOWN_PARTY
-        who_text = getattr(r, "who_text", None) or getattr(r, "actor", None)
+        who_text = getattr(r, "who_text", None) or actor or None
         text = f"{r.actor} {r.modality} {r.action}".strip()
         if r.conditions:
             text += f" {r.conditions}"
         if r.scope:
             text += f" {r.scope}"
-        atoms.append(
-            Atom(
-                type="rule",
-                role="principle",
-                party=r.actor or None,
-                who=who,
-                who_text=r.actor or None,
-                conditions=r.conditions,
-                text=text.strip() or None,
-                gloss=who_text or None,
-            )
-        )
+
+        rule_atom_kwargs = {
+            "type": "rule",
+            "role": "principle",
+            "party": who,
+            "who": who,
+            "who_text": who_text,
+            "conditions": r.conditions,
+            "text": text.strip() or None,
+            "gloss": who_text,
+        }
+        atoms.append(Atom(**rule_atom_kwargs))
 
         for role, fragments in (r.elements or {}).items():
             for fragment in fragments:
                 gloss_entry = lookup_gloss(fragment)
-                atoms.append(
-                    Atom(
-                        type="element",
-                        role=role,
-                        party=r.actor or None,
-                        who=who,
-                        who_text=r.actor or None,
-                        conditions=r.conditions if role == "circumstance" else None,
-                        gloss=gloss_entry.text if gloss_entry else None,
-                        text=fragment,
-                        gloss=(gloss_entry.text if gloss_entry else None),
-                        gloss=(
-                            gloss_entry.text if gloss_entry else who_text or None
-                        ),
-                        gloss_metadata=(
-                            dict(gloss_entry.metadata)
-                            if gloss_entry and gloss_entry.metadata is not None
-                            else None
-                        ),
-                    )
-                )
+                gloss_text = who_text
+                gloss_metadata = None
+                if gloss_entry:
+                    gloss_text = gloss_entry.text
+                    if gloss_entry.metadata is not None:
+                        gloss_metadata = dict(gloss_entry.metadata)
+
+                element_atom_kwargs = {
+                    "type": "element",
+                    "role": role,
+                    "party": who,
+                    "who": who,
+                    "who_text": who_text,
+                    "conditions": r.conditions if role == "circumstance" else None,
+                    "text": fragment,
+                    "gloss": gloss_text,
+                    "gloss_metadata": gloss_metadata,
+                }
+                atoms.append(Atom(**element_atom_kwargs))
+
         if who == UNKNOWN_PARTY:
-            atoms.append(
-                Atom(
-                    type="lint",
-                    role="unknown_party",
-                    text=f"Unclassified actor: {r.actor}".strip(),
-                    who=UNKNOWN_PARTY,
-                    gloss=who_text or None,
-                )
-            )
+            lint_atom_kwargs = {
+                "type": "lint",
+                "role": "unknown_party",
+                "text": f"Unclassified actor: {actor}".strip(),
+                "who": UNKNOWN_PARTY,
+                "gloss": who_text,
+            }
+            atoms.append(Atom(**lint_atom_kwargs))
     return atoms
 
 
@@ -248,9 +247,9 @@ def parse_sections(text: str) -> List[Provision]:
     if not text.strip():
         return []
 
-    if section_parser and hasattr(section_parser, "parse_sections"):
-
     parser_available = _has_section_parser()
+    if section_parser and hasattr(section_parser, "parse_sections"):
+        pass
 
     if parser_available and section_parser and hasattr(
         section_parser, "parse_sections"

--- a/tests/pdf_ingest/test_rules_to_atoms_metadata.py
+++ b/tests/pdf_ingest/test_rules_to_atoms_metadata.py
@@ -1,8 +1,22 @@
+from src.glossary.service import GlossEntry
 from src.pdf_ingest import _rules_to_atoms
 from src.rules import Rule
 
 
-def test_rules_to_atoms_includes_who_and_conditions_metadata():
+def test_rules_to_atoms_includes_party_who_text_and_gloss(monkeypatch):
+    metadata = {"source": "curated", "category": "example"}
+
+    def fake_lookup(term: str):
+        if term == "if requested":
+            return GlossEntry(
+                phrase=term,
+                text="Request condition",
+                metadata=metadata,
+            )
+        return None
+
+    monkeypatch.setattr("src.pdf_ingest.lookup_gloss", fake_lookup)
+
     rule = Rule(
         actor="The court",
         modality="must",
@@ -17,8 +31,9 @@ def test_rules_to_atoms_includes_who_and_conditions_metadata():
     atoms = _rules_to_atoms([rule])
 
     rule_atom = next(atom for atom in atoms if atom.type == "rule")
+    assert rule_atom.party == "court"
     assert rule_atom.who == "court"
-    assert rule_atom.party == "The court"
+    assert rule_atom.who_text == "the court"
     assert rule_atom.conditions == "if requested"
     assert rule_atom.gloss == "the court"
     assert rule_atom.text == "The court must consider the evidence if requested"
@@ -26,7 +41,29 @@ def test_rules_to_atoms_includes_who_and_conditions_metadata():
     element_atom = next(atom for atom in atoms if atom.type == "element")
     assert element_atom.role == "circumstance"
     assert element_atom.text == "if requested"
+    assert element_atom.party == "court"
     assert element_atom.who == "court"
+    assert element_atom.who_text == "the court"
     assert element_atom.conditions == "if requested"
-    assert element_atom.gloss is None
+    assert element_atom.gloss == "Request condition"
+    assert element_atom.gloss_metadata == metadata
+    assert element_atom.gloss_metadata is not metadata
+
+
+def test_element_atoms_fall_back_to_who_text_when_no_gloss(monkeypatch):
+    monkeypatch.setattr("src.pdf_ingest.lookup_gloss", lambda term: None)
+
+    rule = Rule(
+        actor="The court",
+        modality="must",
+        action="consider the evidence",
+        elements={"circumstance": ["if requested"]},
+        party="court",
+        who_text="the court",
+    )
+
+    atoms = _rules_to_atoms([rule])
+
+    element_atom = next(atom for atom in atoms if atom.type == "element")
+    assert element_atom.gloss == "the court"
     assert element_atom.gloss_metadata is None


### PR DESCRIPTION
## Summary
- ensure `_rules_to_atoms` builds rule, element, and lint atoms with consistent party/who metadata while copying glossary metadata once
- add unit tests exercising party, who_text, gloss, and metadata propagation along with the fallback when no gloss entry exists
- make `parse_sections` importable by giving the placeholder `section_parser` branch an explicit body

## Testing
- `PYTHONPATH=. pytest tests/pdf_ingest/test_rules_to_atoms_metadata.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d6695a19cc8322ae06626d413e2618