### PR TITLE
Refine atom metadata propagation and lint coverage

### DIFF
--- a/src/pdf_ingest.py
+++ b/src/pdf_ingest.py
@@ -98,60 +98,64 @@ def download_pdf(url: str, cache: HTTPCache, dest: Path) -> Path:
 def _rules_to_atoms(rules) -> List[Atom]:
     atoms: List[Atom] = []
     for r in rules:
-        who = getattr(r, "party", None) or UNKNOWN_PARTY
-        who_text = getattr(r, "who_text", None) or getattr(r, "actor", None)
-        text = f"{r.actor} {r.modality} {r.action}".strip()
-        if r.conditions:
-            text += f" {r.conditions}"
-        if r.scope:
-            text += f" {r.scope}"
-        atoms.append(
-            Atom(
-                type="rule",
-                role="principle",
-                party=r.actor or None,
-                who=who,
-                who_text=r.actor or None,
-                conditions=r.conditions,
-                text=text.strip() or None,
-                gloss=who_text or None,
-            )
-        )
+        actor = getattr(r, "actor", None)
+        who = getattr(r, "party", UNKNOWN_PARTY) or UNKNOWN_PARTY
+        who_text = getattr(r, "who_text", None) or actor or None
+        parts = [getattr(r, "actor", None), getattr(r, "modality", None), getattr(r, "action", None)]
+        if getattr(r, "conditions", None):
+            parts.append(r.conditions)
+        if getattr(r, "scope", None):
+            parts.append(r.scope)
+        text = " ".join(part.strip() for part in parts if part)
+
+        rule_atom_kwargs = {
+            "type": "rule",
+            "role": "principle",
+            "party": who,
+            "who": who,
+            "who_text": who_text,
+            "conditions": r.conditions,
+            "text": text or None,
+            "gloss": who_text or actor or None,
+        }
+        atoms.append(Atom(**rule_atom_kwargs))
 
         for role, fragments in (r.elements or {}).items():
             for fragment in fragments:
+                if not fragment:
+                    continue
                 gloss_entry = lookup_gloss(fragment)
-                atoms.append(
-                    Atom(
-                        type="element",
-                        role=role,
-                        party=r.actor or None,
-                        who=who,
-                        who_text=r.actor or None,
-                        conditions=r.conditions if role == "circumstance" else None,
-                        gloss=gloss_entry.text if gloss_entry else None,
-                        text=fragment,
-                        gloss=(gloss_entry.text if gloss_entry else None),
-                        gloss=(
-                            gloss_entry.text if gloss_entry else who_text or None
-                        ),
-                        gloss_metadata=(
-                            dict(gloss_entry.metadata)
-                            if gloss_entry and gloss_entry.metadata is not None
-                            else None
-                        ),
-                    )
-                )
+                gloss_text = who_text or fragment
+                gloss_metadata = None
+                if gloss_entry:
+                    gloss_text = gloss_entry.text
+                    if gloss_entry.metadata is not None:
+                        gloss_metadata = dict(gloss_entry.metadata)
+
+                element_atom_kwargs = {
+                    "type": "element",
+                    "role": role,
+                    "party": who,
+                    "who": who,
+                    "who_text": who_text,
+                    "conditions": r.conditions if role == "circumstance" else None,
+                    "text": fragment,
+                    "gloss": gloss_text,
+                    "gloss_metadata": gloss_metadata,
+                }
+                atoms.append(Atom(**element_atom_kwargs))
+
         if who == UNKNOWN_PARTY:
-            atoms.append(
-                Atom(
-                    type="lint",
-                    role="unknown_party",
-                    text=f"Unclassified actor: {r.actor}".strip(),
-                    who=UNKNOWN_PARTY,
-                    gloss=who_text or None,
-                )
-            )
+            lint_atom_kwargs = {
+                "type": "lint",
+                "role": "unknown_party",
+                "text": f"Unclassified actor: {actor}".strip(),
+                "party": UNKNOWN_PARTY,
+                "who": UNKNOWN_PARTY,
+                "who_text": who_text or actor or None,
+                "gloss": who_text or actor or None,
+            }
+            atoms.append(Atom(**lint_atom_kwargs))
     return atoms
 
 
@@ -248,9 +252,9 @@ def parse_sections(text: str) -> List[Provision]:
     if not text.strip():
         return []
 
-    if section_parser and hasattr(section_parser, "parse_sections"):
-
     parser_available = _has_section_parser()
+    if section_parser and hasattr(section_parser, "parse_sections"):
+        pass
 
     if parser_available and section_parser and hasattr(
         section_parser, "parse_sections"

--- a/tests/pdf_ingest/test_rules_to_atoms_metadata.py
+++ b/tests/pdf_ingest/test_rules_to_atoms_metadata.py
@@ -1,8 +1,22 @@
+from src.glossary.service import GlossEntry
 from src.pdf_ingest import _rules_to_atoms
-from src.rules import Rule
+from src.rules import Rule, UNKNOWN_PARTY
 
 
-def test_rules_to_atoms_includes_who_and_conditions_metadata():
+def test_rules_to_atoms_includes_party_who_text_and_gloss(monkeypatch):
+    metadata = {"source": "curated", "category": "example"}
+
+    def fake_lookup(term: str):
+        if term == "if requested":
+            return GlossEntry(
+                phrase=term,
+                text="Request condition",
+                metadata=metadata,
+            )
+        return None
+
+    monkeypatch.setattr("src.pdf_ingest.lookup_gloss", fake_lookup)
+
     rule = Rule(
         actor="The court",
         modality="must",
@@ -17,8 +31,9 @@ def test_rules_to_atoms_includes_who_and_conditions_metadata():
     atoms = _rules_to_atoms([rule])
 
     rule_atom = next(atom for atom in atoms if atom.type == "rule")
+    assert rule_atom.party == "court"
     assert rule_atom.who == "court"
-    assert rule_atom.party == "The court"
+    assert rule_atom.who_text == "the court"
     assert rule_atom.conditions == "if requested"
     assert rule_atom.gloss == "the court"
     assert rule_atom.text == "The court must consider the evidence if requested"
@@ -26,7 +41,49 @@ def test_rules_to_atoms_includes_who_and_conditions_metadata():
     element_atom = next(atom for atom in atoms if atom.type == "element")
     assert element_atom.role == "circumstance"
     assert element_atom.text == "if requested"
+    assert element_atom.party == "court"
     assert element_atom.who == "court"
+    assert element_atom.who_text == "the court"
     assert element_atom.conditions == "if requested"
-    assert element_atom.gloss is None
+    assert element_atom.gloss == "Request condition"
+    assert element_atom.gloss_metadata == metadata
+    assert element_atom.gloss_metadata is not metadata
+
+
+def test_element_atoms_fall_back_to_who_text_when_no_gloss(monkeypatch):
+    monkeypatch.setattr("src.pdf_ingest.lookup_gloss", lambda term: None)
+
+    rule = Rule(
+        actor="The court",
+        modality="must",
+        action="consider the evidence",
+        elements={"circumstance": ["if requested"]},
+        party="court",
+        who_text="the court",
+    )
+
+    atoms = _rules_to_atoms([rule])
+
+    element_atom = next(atom for atom in atoms if atom.type == "element")
+    assert element_atom.gloss == "the court"
     assert element_atom.gloss_metadata is None
+
+
+def test_unknown_party_lint_atom_inherits_party_metadata(monkeypatch):
+    monkeypatch.setattr("src.pdf_ingest.lookup_gloss", lambda term: None)
+
+    rule = Rule(
+        actor="The spaceship",
+        modality="must",
+        action="register with the ministry",
+        party=UNKNOWN_PARTY,
+        who_text="The spaceship",
+    )
+
+    atoms = _rules_to_atoms([rule])
+
+    lint_atom = next(atom for atom in atoms if atom.type == "lint")
+    assert lint_atom.party == UNKNOWN_PARTY
+    assert lint_atom.who == UNKNOWN_PARTY
+    assert lint_atom.who_text == "The spaceship"
+    assert lint_atom.gloss == "The spaceship"


### PR DESCRIPTION
## Summary
- normalise rule atom text assembly and ensure lint atoms carry party, who, and gloss fields
- skip empty element fragments while preserving gloss fallbacks and copying metadata safely
- extend pdf ingest metadata tests to cover lint atom metadata propagation

## Testing
- `PYTHONPATH=. pytest tests/pdf_ingest/test_rules_to_atoms_metadata.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d6695a19cc8322ae06626d413e2618