### PR TITLE
Ensure build_document fallback returns Provision objects

### DIFF
--- a/tests/pdf_ingest/test_build_document_multiple_provisions_regression.py
+++ b/tests/pdf_ingest/test_build_document_multiple_provisions_regression.py
@@ -5,6 +5,9 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from types import SimpleNamespace
+from unittest.mock import patch
+
 from src.pdf_ingest import build_document
 
 
@@ -25,3 +28,48 @@ def test_build_document_preserves_multiple_provisions():
         "Preliminary",
         "Application",
     ]
+
+
+def test_build_document_section_parser_fallback_returns_provisions_with_atoms():
+    pages = [
+        {
+            "page": 1,
+            "heading": "Preface",
+            "text": "Section 1 text\n\nMore text in section 2",
+        }
+    ]
+
+    nodes = [
+        SimpleNamespace(
+            text="Section 1 text",
+            identifier="1",
+            heading="Intro",
+            node_type="section",
+            children=[],
+            rule_tokens={},
+            references=[],
+        ),
+        SimpleNamespace(
+            text="More text in section 2",
+            identifier="2",
+            heading="Scope",
+            node_type="section",
+            children=[],
+            rule_tokens={},
+            references=[],
+        ),
+    ]
+
+    class DummyParser:
+        def parse_sections(self, _text):
+            return nodes
+
+    with patch("src.pdf_ingest.parse_sections", return_value=[]), patch(
+        "src.pdf_ingest.section_parser",
+        DummyParser(),
+    ):
+        document = build_document(pages, Path("dummy.pdf"))
+
+    assert [prov.identifier for prov in document.provisions] == ["1", "2"]
+    assert all(isinstance(prov.atoms, list) for prov in document.provisions)
+    assert all(isinstance(prov.principles, list) for prov in document.provisions)


### PR DESCRIPTION
## Summary
- ensure `parse_sections` converts optional parser output into provision objects before falling back
- update `build_document` fallback to reuse structured parser output and only collapse to a single provision as a last resort
- add regression coverage verifying fallback provisions expose atoms and principles

## Testing
- pytest tests/pdf_ingest/test_build_document_multiple_provisions_regression.py

------
https://chatgpt.com/codex/tasks/task_e_68d66b6f9ecc8322937d30bfb6d16750