### PR TITLE
Document versioning docs and pdf-fetch CLI guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,28 @@ sensiblaw query treatment --case case123
 See [docs/versioning.md](docs/versioning.md) for details on the versioned
 storage layer and available provenance metadata.
 
+#### Ingest PDF documents
+
+Extract provisions and atoms from a PDF while writing the structured
+[`Document`](src/models/document.py) payload into the SQLite store:
+
+```bash
+sensiblaw pdf-fetch data/example.pdf --jurisdiction "NSW" --citation "Act 1994" \
+  --db data/store.db
+```
+
+To reuse an existing document identifier when appending a new revision:
+
+```bash
+sensiblaw pdf-fetch data/amendment.pdf --jurisdiction "NSW" --citation "Act 1994" \
+  --db data/store.db --doc-id 42
+```
+
+Both commands emit the parsed structure to stdout (and optionally `--output`)
+so that downstream tooling can inspect the [`Provision`](src/models/provision.py)
+hierarchy, while the `--db/--doc-id` options persist the same structure in the
+versioned store.
+
 ## Development
 
 Optionally install [pre-commit](https://pre-commit.com/) to run linters and

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -9,6 +9,9 @@ queries.
 
 - `documents` – identity table used to generate IDs.
 - `revisions` – holds each revision with its effective date, metadata and body.
+- `revisions.document_json` – JSON column containing the full
+  [`Document`](../src/models/document.py) structure, including nested
+  [`Provision`](../src/models/provision.py) entries and their atoms.
 - `revisions_fts` – FTS5 index over revision text and metadata for search.
 
 Each revision also records provenance fields:
@@ -17,6 +20,13 @@ Each revision also records provenance fields:
 - `retrieved_at` – timestamp when it was fetched.
 - `checksum` – optional hash of the retrieved content.
 - `licence` – the licence governing the text.
+
+## Writing revisions
+
+`VersionedStore.add_revision` serialises the entire `Document` instance into
+`document_json`.  Consumers can therefore rely on snapshots reflecting the
+structured metadata, provision hierarchy, and extracted atoms produced at
+ingest time.
 
 ## Snapshots
 
@@ -28,7 +38,10 @@ sensiblaw get --id 1 --as-at 2023-01-01
 ```
 
 The returned JSON includes the provenance metadata captured for the selected
-revision.
+revision and the full [`Document`](../src/models/document.py) payload stored in
+`document_json`.  Consumers should expect the same schema as defined in the
+data models, with provision and atom structures matching
+[`Provision`](../src/models/provision.py).
 
 ## Diffs
 


### PR DESCRIPTION
## Summary
- document the `document_json` payload written by VersionedStore revisions and clarify snapshot expectations
- link versioning notes to the Document and Provision data model implementations
- expand CLI docs with pdf-fetch usage examples covering the new --db/--doc-id options and persistence behaviour

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d6878e3de483228d5526b0ee761e1f