### PR TITLE
Normalize revision storage schema and add ingestion tests

### DIFF
--- a/src/models/provision.py
+++ b/src/models/provision.py
@@ -70,6 +70,7 @@ class Provision:
     heading: Optional[str] = None
     node_type: Optional[str] = None
     rule_tokens: Dict[str, Any] = field(default_factory=dict)
+    cultural_flags: List[str] = field(default_factory=list)
     references: List[Tuple[str, Optional[str], Optional[str], Optional[str], str]] = (
         field(default_factory=list)
     )
@@ -86,6 +87,7 @@ class Provision:
             "heading": self.heading,
             "node_type": self.node_type,
             "rule_tokens": dict(self.rule_tokens),
+            "cultural_flags": list(self.cultural_flags),
             "references": [tuple(ref) for ref in self.references],
             "children": [c.to_dict() for c in self.children],
             "principles": list(self.principles),
@@ -102,6 +104,7 @@ class Provision:
             heading=data.get("heading"),
             node_type=data.get("node_type"),
             rule_tokens=dict(data.get("rule_tokens", {})),
+            cultural_flags=list(data.get("cultural_flags", [])),
             references=[
                 tuple(ref) if isinstance(ref, (list, tuple)) else tuple(ref)
                 for ref in data.get("references", [])

--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -84,6 +84,50 @@ CREATE TABLE IF NOT EXISTS revisions (
     FOREIGN KEY (doc_id) REFERENCES documents(id)
 );
 
+CREATE TABLE IF NOT EXISTS provisions (
+    doc_id INTEGER NOT NULL,
+    rev_id INTEGER NOT NULL,
+    provision_id INTEGER NOT NULL,
+    parent_id INTEGER,
+    identifier TEXT,
+    heading TEXT,
+    node_type TEXT,
+    text TEXT,
+    rule_tokens TEXT,
+    references_json TEXT,
+    principles TEXT,
+    customs TEXT,
+    cultural_flags TEXT,
+    PRIMARY KEY (doc_id, rev_id, provision_id),
+    FOREIGN KEY (doc_id, rev_id) REFERENCES revisions(doc_id, rev_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_provisions_doc_rev
+ON provisions(doc_id, rev_id, provision_id);
+
+CREATE TABLE IF NOT EXISTS atoms (
+    doc_id INTEGER NOT NULL,
+    rev_id INTEGER NOT NULL,
+    provision_id INTEGER NOT NULL,
+    atom_id INTEGER NOT NULL,
+    type TEXT,
+    role TEXT,
+    party TEXT,
+    who TEXT,
+    who_text TEXT,
+    text TEXT,
+    conditions TEXT,
+    refs TEXT,
+    gloss TEXT,
+    gloss_metadata TEXT,
+    PRIMARY KEY (doc_id, rev_id, provision_id, atom_id),
+    FOREIGN KEY (doc_id, rev_id, provision_id)
+        REFERENCES provisions(doc_id, rev_id, provision_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_atoms_doc_rev
+ON atoms(doc_id, rev_id, provision_id);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS revisions_fts USING fts5(
     body, metadata, content='revisions', content_rowid='rowid'
 );


### PR DESCRIPTION
## Summary
- add normalized `provisions` and `atoms` tables to the SQLite schema used by the versioned store
- persist document revisions into the normalized tables (with cultural flag support) and rebuild snapshots from them when available
- cover the migration path by ingesting a sample PDF in tests and asserting normalized storage while keeping existing diff/snapshot behaviour

## Testing
- pytest tests/test_versioned_store.py

------
https://chatgpt.com/codex/tasks/task_e_68d68a92a53083229cfcdcc687171338