### PR TITLE
Normalize provision metadata

### DIFF
--- a/src/section_parser.py
+++ b/src/section_parser.py
@@ -36,6 +36,8 @@ def _extract_rule_tokens(text: str) -> Dict[str, object]:
     modality: Optional[str] = None
     conditions: List[str] = []
     references: List[str] = []
+    seen_conditions: set[str] = set()
+    seen_refs: set[str] = set()
 
     for match in TOKEN_RE.finditer(text):
         token = match.group().strip()
@@ -43,8 +45,15 @@ def _extract_rule_tokens(text: str) -> Dict[str, object]:
         if group == "modality" and modality is None:
             modality = token.lower()
         elif group == "condition":
-            conditions.append(token.lower())
+            lowered = token.lower()
+            if lowered not in seen_conditions:
+                seen_conditions.add(lowered)
+                conditions.append(lowered)
         elif group == "xref":
+            lowered = token.lower()
+            if lowered in seen_refs:
+                continue
+            seen_refs.add(lowered)
             references.append(token)
 
     return {"modality": modality, "conditions": conditions, "references": references}


### PR DESCRIPTION
## Summary
- deduplicate extracted rule token conditions and references in both section parsers
- normalise provision principle text and remove structural numbering artifacts
- ensure document building derives principles from normalised, de-duplicated rule atoms

## Testing
- pytest tests/pdf_ingest -q

------
https://chatgpt.com/codex/tasks/task_e_68d68e5cd47083229a2c8b9667a76365