### PR TITLE
Normalize atom references storage

### DIFF
--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -128,6 +128,24 @@ CREATE TABLE IF NOT EXISTS atoms (
 CREATE INDEX IF NOT EXISTS idx_atoms_doc_rev
 ON atoms(doc_id, rev_id, provision_id);
 
+CREATE TABLE IF NOT EXISTS atom_references (
+    doc_id INTEGER NOT NULL,
+    rev_id INTEGER NOT NULL,
+    provision_id INTEGER NOT NULL,
+    atom_id INTEGER NOT NULL,
+    ref_index INTEGER NOT NULL,
+    work TEXT,
+    section TEXT,
+    pinpoint TEXT,
+    citation_text TEXT,
+    PRIMARY KEY (doc_id, rev_id, provision_id, atom_id, ref_index),
+    FOREIGN KEY (doc_id, rev_id, provision_id, atom_id)
+        REFERENCES atoms(doc_id, rev_id, provision_id, atom_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_atom_references_doc_rev
+ON atom_references(doc_id, rev_id, provision_id, atom_id);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS revisions_fts USING fts5(
     body, metadata, content='revisions', content_rowid='rowid'
 );


### PR DESCRIPTION
## Summary
- add an atom_references join table to store structured citation data for atoms
- update the versioned store to maintain the new table and rebuild Atom.refs during loads
- extend versioned store tests to assert references survive normalization without relying on document_json

## Testing
- pytest tests/test_versioned_store.py
- ruff check src/storage/versioned_store.py tests/test_versioned_store.py


------
https://chatgpt.com/codex/tasks/task_e_68d68fb34c7083229a694900c45619f4