### PR TITLE
Add aggregated rule subject storage and migration

### DIFF
--- a/src/pdf_ingest.py
+++ b/src/pdf_ingest.py
@@ -15,7 +15,7 @@ from .culture.overlay import get_default_overlay
 from .glossary.service import lookup as lookup_gloss
 from .ingestion.cache import HTTPCache
 from .models.document import Document, DocumentMetadata, Provision
-from .models.provision import RuleAtom, RuleElement, RuleLint
+from .models.provision import Atom, RuleAtom, RuleElement, RuleLint
 from .rules import UNKNOWN_PARTY
 from .rules.extractor import extract_rules
 from .storage.versioned_store import VersionedStore
@@ -164,6 +164,18 @@ def _rules_to_atoms(rules) -> List[RuleAtom]:
             scope=scope,
             text=text,
             subject_gloss=who_text or actor or None,
+        )
+
+        rule_atom.subject = Atom(
+            type=rule_atom.atom_type,
+            role=rule_atom.role,
+            party=rule_atom.party,
+            who=rule_atom.who,
+            who_text=rule_atom.who_text,
+            conditions=rule_atom.conditions,
+            text=rule_atom.text,
+            gloss=rule_atom.subject_gloss,
+            gloss_metadata=rule_atom.subject_gloss_metadata,
         )
 
         for role, fragments in (getattr(r, "elements", None) or {}).items():

--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -154,6 +154,29 @@ CREATE TABLE IF NOT EXISTS rule_atoms (
 CREATE INDEX IF NOT EXISTS idx_rule_atoms_doc_rev
 ON rule_atoms(doc_id, rev_id, provision_id);
 
+CREATE TABLE IF NOT EXISTS rule_atom_subjects (
+    doc_id INTEGER NOT NULL,
+    rev_id INTEGER NOT NULL,
+    provision_id INTEGER NOT NULL,
+    rule_id INTEGER NOT NULL,
+    type TEXT,
+    role TEXT,
+    party TEXT,
+    who TEXT,
+    who_text TEXT,
+    text TEXT,
+    conditions TEXT,
+    refs TEXT,
+    gloss TEXT,
+    gloss_metadata TEXT,
+    PRIMARY KEY (doc_id, rev_id, provision_id, rule_id),
+    FOREIGN KEY (doc_id, rev_id, provision_id, rule_id)
+        REFERENCES rule_atoms(doc_id, rev_id, provision_id, rule_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rule_atom_subjects_doc_rev
+ON rule_atom_subjects(doc_id, rev_id, provision_id);
+
 CREATE TABLE IF NOT EXISTS rule_atom_references (
     doc_id INTEGER NOT NULL,
     rev_id INTEGER NOT NULL,


### PR DESCRIPTION
## Summary
- add a dedicated `rule_atom_subjects` table and indexes to persist aggregated subject metadata
- populate and hydrate structured rule atoms with the aggregated subject values, including legacy backfill support
- extend versioned store tests to cover subject persistence, loading, and migration

## Testing
- ruff check src/models/provision.py src/storage/versioned_store.py src/pdf_ingest.py tests/test_versioned_store.py
- pytest tests/test_versioned_store.py


------
https://chatgpt.com/codex/tasks/task_e_68d6a0b5235483228da4d4c40a315f2e