### PR TITLE
Add TOC storage and link provisions to table-of-contents entries

### DIFF
--- a/src/models/provision.py
+++ b/src/models/provision.py
@@ -171,6 +171,7 @@ class RuleLint:
 class RuleAtom:
     """A richer representation of a rule with associated fragments."""
 
+    toc_id: Optional[int] = None
     atom_type: Optional[str] = "rule"
     role: Optional[str] = None
     party: Optional[str] = None
@@ -191,6 +192,7 @@ class RuleAtom:
 
     def to_dict(self) -> Dict[str, Any]:
         return {
+            "toc_id": self.toc_id,
             "atom_type": self.atom_type,
             "role": self.role,
             "party": self.party,
@@ -217,6 +219,7 @@ class RuleAtom:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "RuleAtom":
         return cls(
+            toc_id=data.get("toc_id"),
             atom_type=data.get("atom_type"),
             role=data.get("role"),
             party=data.get("party"),
@@ -361,6 +364,7 @@ class Provision:
     identifier: Optional[str] = None
     heading: Optional[str] = None
     node_type: Optional[str] = None
+    toc_id: Optional[int] = None
     rule_tokens: Dict[str, Any] = field(default_factory=dict)
     cultural_flags: List[str] = field(default_factory=list)
     references: List[Tuple[str, Optional[str], Optional[str], Optional[str], str]] = (
@@ -380,6 +384,7 @@ class Provision:
             "identifier": self.identifier,
             "heading": self.heading,
             "node_type": self.node_type,
+            "toc_id": self.toc_id,
             "rule_tokens": dict(self.rule_tokens),
             "cultural_flags": list(self.cultural_flags),
             "references": [tuple(ref) for ref in self.references],
@@ -398,6 +403,7 @@ class Provision:
             identifier=data.get("identifier"),
             heading=data.get("heading"),
             node_type=data.get("node_type"),
+            toc_id=data.get("toc_id"),
             rule_tokens=dict(data.get("rule_tokens", {})),
             cultural_flags=list(data.get("cultural_flags", [])),
             references=[
@@ -432,6 +438,11 @@ class Provision:
 
         if self.rule_atoms and not self.atoms:
             self.atoms = self.flatten_rule_atoms()
+
+        if self.rule_atoms:
+            for rule_atom in self.rule_atoms:
+                if rule_atom.toc_id is None:
+                    rule_atom.toc_id = self.toc_id
 
     def sync_legacy_atoms(self) -> None:
         """Refresh ``atoms`` based on the structured rule representation."""

--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -84,6 +84,27 @@ CREATE TABLE IF NOT EXISTS revisions (
     FOREIGN KEY (doc_id) REFERENCES documents(id)
 );
 
+CREATE TABLE IF NOT EXISTS toc (
+    doc_id INTEGER NOT NULL,
+    rev_id INTEGER NOT NULL,
+    toc_id INTEGER NOT NULL,
+    parent_id INTEGER,
+    node_type TEXT,
+    identifier TEXT,
+    title TEXT,
+    position INTEGER NOT NULL,
+    PRIMARY KEY (doc_id, rev_id, toc_id),
+    FOREIGN KEY (doc_id, rev_id) REFERENCES revisions(doc_id, rev_id),
+    FOREIGN KEY (doc_id, rev_id, parent_id)
+        REFERENCES toc(doc_id, rev_id, toc_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_toc_doc_rev
+ON toc(doc_id, rev_id, toc_id);
+
+CREATE INDEX IF NOT EXISTS idx_toc_parent
+ON toc(doc_id, rev_id, parent_id);
+
 CREATE TABLE IF NOT EXISTS provisions (
     doc_id INTEGER NOT NULL,
     rev_id INTEGER NOT NULL,
@@ -98,12 +119,18 @@ CREATE TABLE IF NOT EXISTS provisions (
     principles TEXT,
     customs TEXT,
     cultural_flags TEXT,
+    toc_id INTEGER,
     PRIMARY KEY (doc_id, rev_id, provision_id),
-    FOREIGN KEY (doc_id, rev_id) REFERENCES revisions(doc_id, rev_id)
+    FOREIGN KEY (doc_id, rev_id) REFERENCES revisions(doc_id, rev_id),
+    FOREIGN KEY (doc_id, rev_id, toc_id)
+        REFERENCES toc(doc_id, rev_id, toc_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_provisions_doc_rev
 ON provisions(doc_id, rev_id, provision_id);
+
+CREATE INDEX IF NOT EXISTS idx_provisions_toc
+ON provisions(doc_id, rev_id, toc_id);
 
 CREATE TABLE IF NOT EXISTS atoms (
     doc_id INTEGER NOT NULL,
@@ -133,6 +160,7 @@ CREATE TABLE IF NOT EXISTS rule_atoms (
     rev_id INTEGER NOT NULL,
     provision_id INTEGER NOT NULL,
     rule_id INTEGER NOT NULL,
+    toc_id INTEGER,
     atom_type TEXT,
     role TEXT,
     party TEXT,
@@ -148,11 +176,16 @@ CREATE TABLE IF NOT EXISTS rule_atoms (
     subject_gloss_metadata TEXT,
     PRIMARY KEY (doc_id, rev_id, provision_id, rule_id),
     FOREIGN KEY (doc_id, rev_id, provision_id)
-        REFERENCES provisions(doc_id, rev_id, provision_id)
+        REFERENCES provisions(doc_id, rev_id, provision_id),
+    FOREIGN KEY (doc_id, rev_id, toc_id)
+        REFERENCES toc(doc_id, rev_id, toc_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_rule_atoms_doc_rev
 ON rule_atoms(doc_id, rev_id, provision_id);
+
+CREATE INDEX IF NOT EXISTS idx_rule_atoms_toc
+ON rule_atoms(doc_id, rev_id, toc_id);
 
 CREATE TABLE IF NOT EXISTS rule_atom_subjects (
     doc_id INTEGER NOT NULL,


### PR DESCRIPTION
## Summary
- extend the SQLite schema with a toc table, toc_id foreign keys, and supporting indexes
- assign toc identifiers during revision storage so provisions and rule atoms can reference the toc hierarchy
- expose toc_id on provision and rule atom models and add tests that verify toc joins and snapshot access

## Testing
- `pytest tests/test_versioned_store.py`


------
https://chatgpt.com/codex/tasks/task_e_68d6a7b0726c8322b9290d920e76cf8d