### PR TITLE
Replace atoms table with compatibility view

### DIFF
--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -133,29 +133,135 @@ ON provisions(doc_id, rev_id, provision_id);
 CREATE INDEX IF NOT EXISTS idx_provisions_toc
 ON provisions(doc_id, rev_id, toc_id);
 
-CREATE TABLE IF NOT EXISTS atoms (
-    doc_id INTEGER NOT NULL,
-    rev_id INTEGER NOT NULL,
-    provision_id INTEGER NOT NULL,
-    atom_id INTEGER NOT NULL,
-    type TEXT,
-    role TEXT,
-    party TEXT,
-    who TEXT,
-    who_text TEXT,
-    text TEXT,
-    conditions TEXT,
-    refs TEXT,
-    gloss TEXT,
-    gloss_metadata TEXT,
-    glossary_id INTEGER,
-    PRIMARY KEY (doc_id, rev_id, provision_id, atom_id),
-    FOREIGN KEY (doc_id, rev_id, provision_id)
-        REFERENCES provisions(doc_id, rev_id, provision_id)
-);
-
-CREATE INDEX IF NOT EXISTS idx_atoms_doc_rev
-ON atoms(doc_id, rev_id, provision_id);
+CREATE VIEW IF NOT EXISTS atoms AS
+WITH subject_rows AS (
+    SELECT
+        ra.doc_id AS doc_id,
+        ra.rev_id AS rev_id,
+        ra.provision_id AS provision_id,
+        ra.rule_id AS rule_id,
+        0 AS group_order,
+        0 AS sequence_order,
+        COALESCE(rs.type, ra.atom_type, 'rule') AS type,
+        COALESCE(rs.role, ra.role) AS role,
+        COALESCE(rs.party, ra.party) AS party,
+        COALESCE(rs.who, ra.who) AS who,
+        COALESCE(rs.who_text, ra.who_text) AS who_text,
+        COALESCE(rs.text, ra.text) AS text,
+        COALESCE(rs.conditions, ra.conditions) AS conditions,
+        rs.refs AS refs,
+        COALESCE(rs.gloss, ra.subject_gloss) AS gloss,
+        COALESCE(rs.gloss_metadata, ra.subject_gloss_metadata) AS gloss_metadata,
+        COALESCE(rs.glossary_id, ra.glossary_id) AS glossary_id
+    FROM rule_atoms AS ra
+    LEFT JOIN rule_atom_subjects AS rs
+        ON ra.doc_id = rs.doc_id
+        AND ra.rev_id = rs.rev_id
+        AND ra.provision_id = rs.provision_id
+        AND ra.rule_id = rs.rule_id
+), element_reference_json AS (
+    SELECT
+        doc_id,
+        rev_id,
+        provision_id,
+        rule_id,
+        element_id,
+        json_group_array(
+            COALESCE(
+                citation_text,
+                TRIM(
+                    (CASE WHEN work IS NOT NULL AND work <> '' THEN work || ' ' ELSE '' END) ||
+                    (CASE WHEN section IS NOT NULL AND section <> '' THEN section || ' ' ELSE '' END) ||
+                    COALESCE(pinpoint, '')
+                )
+            )
+        ) AS refs
+    FROM rule_element_references
+    GROUP BY doc_id, rev_id, provision_id, rule_id, element_id
+), element_rows AS (
+    SELECT
+        ra.doc_id AS doc_id,
+        ra.rev_id AS rev_id,
+        ra.provision_id AS provision_id,
+        re.rule_id AS rule_id,
+        1 AS group_order,
+        re.element_id AS sequence_order,
+        COALESCE(re.atom_type, 'element') AS type,
+        re.role AS role,
+        ra.party AS party,
+        ra.who AS who,
+        ra.who_text AS who_text,
+        re.text AS text,
+        re.conditions AS conditions,
+        er.refs AS refs,
+        re.gloss AS gloss,
+        re.gloss_metadata AS gloss_metadata,
+        COALESCE(re.glossary_id, ra.glossary_id) AS glossary_id
+    FROM rule_elements AS re
+    JOIN rule_atoms AS ra
+        ON ra.doc_id = re.doc_id
+        AND ra.rev_id = re.rev_id
+        AND ra.provision_id = re.provision_id
+        AND ra.rule_id = re.rule_id
+    LEFT JOIN element_reference_json AS er
+        ON re.doc_id = er.doc_id
+        AND re.rev_id = er.rev_id
+        AND re.provision_id = er.provision_id
+        AND re.rule_id = er.rule_id
+        AND re.element_id = er.element_id
+), lint_rows AS (
+    SELECT
+        ra.doc_id AS doc_id,
+        ra.rev_id AS rev_id,
+        ra.provision_id AS provision_id,
+        rl.rule_id AS rule_id,
+        2 AS group_order,
+        rl.lint_id AS sequence_order,
+        COALESCE(rl.atom_type, 'lint') AS type,
+        rl.code AS role,
+        ra.party AS party,
+        ra.who AS who,
+        ra.who_text AS who_text,
+        rl.message AS text,
+        NULL AS conditions,
+        NULL AS refs,
+        ra.subject_gloss AS gloss,
+        rl.metadata AS gloss_metadata,
+        ra.glossary_id AS glossary_id
+    FROM rule_lints AS rl
+    JOIN rule_atoms AS ra
+        ON rl.doc_id = ra.doc_id
+        AND rl.rev_id = ra.rev_id
+        AND rl.provision_id = ra.provision_id
+        AND rl.rule_id = ra.rule_id
+)
+SELECT
+    doc_id,
+    rev_id,
+    provision_id,
+    ROW_NUMBER() OVER (
+        PARTITION BY doc_id, rev_id, provision_id
+        ORDER BY rule_id, group_order, sequence_order
+    ) AS atom_id,
+    type,
+    role,
+    party,
+    who,
+    who_text,
+    text,
+    conditions,
+    refs,
+    gloss,
+    gloss_metadata,
+    glossary_id
+FROM (
+    SELECT * FROM subject_rows
+    UNION ALL
+    SELECT * FROM element_rows
+    UNION ALL
+    SELECT * FROM lint_rows
+)
+ORDER BY doc_id, rev_id, provision_id, atom_id;
 
 CREATE TABLE IF NOT EXISTS rule_atoms (
     doc_id INTEGER NOT NULL,

--- a/tests/test_versioned_store.py
+++ b/tests/test_versioned_store.py
@@ -188,6 +188,19 @@ def test_rule_atom_subjects_loaded(tmp_path: Path):
         store.close()
 
 
+def test_atoms_view_created_for_new_store(tmp_path: Path):
+    db_path = tmp_path / "store.db"
+    store = VersionedStore(str(db_path))
+    try:
+        row = store.conn.execute(
+            "SELECT type FROM sqlite_master WHERE name = 'atoms'"
+        ).fetchone()
+        assert row is not None
+        assert row["type"] == "view"
+    finally:
+        store.close()
+
+
 def test_toc_join(tmp_path: Path):
     store, doc_id = make_store(tmp_path)
     try:


### PR DESCRIPTION
## Summary
- replace the atoms table definition with a compatibility view derived from structured rule data
- update the versioned store initialisation to manage the atoms view safely and skip view mutations in legacy backfills
- add a regression test ensuring new stores expose the atoms view through sqlite_master

## Testing
- pytest tests/test_versioned_store.py

------
https://chatgpt.com/codex/tasks/task_e_68d718ab20ac832282fd9196c1f12afd