### PR TITLE
Add table-of-contents parsing and persistence

### DIFF
--- a/src/pdf_ingest.py
+++ b/src/pdf_ingest.py
@@ -15,8 +15,8 @@ from pdfminer.high_level import extract_text
 from .culture.overlay import get_default_overlay
 from .glossary.service import lookup as lookup_gloss
 from .ingestion.cache import HTTPCache
-from .models.document import Document, DocumentMetadata, Provision
-from .models.provision import Atom, RuleAtom, RuleElement, RuleLint
+from .models.document import Document, DocumentMetadata, DocumentTOCEntry
+from .models.provision import Atom, Provision, RuleAtom, RuleElement, RuleLint
 from .rules import UNKNOWN_PARTY
 from .rules.extractor import extract_rules
 from .storage.core import Storage
@@ -29,6 +29,15 @@ _CULTURAL_OVERLAY = get_default_overlay()
 
 
 _QUOTE_CHARS = "\"'“”‘’"
+_TOC_PREFIX_RE = re.compile(
+    r"^(?P<type>Part|Division|Subdivision|Section)\b", re.IGNORECASE
+)
+_TOC_LINE_RE = re.compile(
+    r"^(?P<type>Part|Division|Subdivision|Section)\s+(?P<content>.+?)\s*(?P<page>\d+)$",
+    re.IGNORECASE,
+)
+_TOC_DOT_LEADER_RE = re.compile(r"[.·⋅•●∙]{2,}")
+_TOC_TITLE_SPLIT_RE = re.compile(r"\s*[-–—:]\s*")
 _DEFINITION_START_RE = re.compile(
     r"^\s*(?P<term>[\"“][^\"”]+[\"”]|'[^']+')\s+"
     r"(?P<verb>means|includes)\s+(?P<definition>.+)$",
@@ -260,8 +269,124 @@ def extract_pdf_text(pdf_path: Path) -> List[dict]:
             continue
         heading = lines[0]
         body = " ".join(lines[1:]) if len(lines) > 1 else ""
-        pages.append({"page": i, "heading": heading, "text": body})
+        pages.append({"page": i, "heading": heading, "text": body, "lines": lines})
     return pages
+
+
+def _normalise_toc_candidate(parts: List[str]) -> str:
+    joined = " ".join(parts)
+    joined = _TOC_DOT_LEADER_RE.sub(" ", joined)
+    return re.sub(r"\s+", " ", joined).strip()
+
+
+def _split_toc_identifier(content: str) -> Tuple[Optional[str], Optional[str]]:
+    content = content.strip()
+    if not content:
+        return None, None
+
+    split = _TOC_TITLE_SPLIT_RE.split(content, maxsplit=1)
+    if len(split) == 2 and split[1].strip():
+        identifier_part, title_part = split
+    else:
+        pieces = content.split(" ", 1)
+        identifier_part = pieces[0]
+        title_part = pieces[1] if len(pieces) > 1 else None
+
+    identifier = identifier_part.strip().rstrip(".") or None
+    title = title_part.strip() if title_part and title_part.strip() else None
+    return identifier, title
+
+
+def _parse_toc_page(lines: List[str]) -> List[DocumentTOCEntry]:
+    entries: List[DocumentTOCEntry] = []
+    buffer: List[str] = []
+
+    for raw_line in lines:
+        cleaned = re.sub(r"\s+", " ", raw_line).strip()
+        if not cleaned:
+            continue
+
+        candidate_parts = buffer + [cleaned] if buffer else [cleaned]
+        normalised = _normalise_toc_candidate(candidate_parts)
+        match = _TOC_LINE_RE.match(normalised)
+        if match:
+            node_type = match.group("type").lower()
+            content = match.group("content").strip()
+            page_str = match.group("page")
+            try:
+                page_number = int(page_str)
+            except ValueError:
+                page_number = None
+            identifier, title = _split_toc_identifier(content)
+            entries.append(
+                DocumentTOCEntry(
+                    node_type=node_type,
+                    identifier=identifier,
+                    title=title,
+                    page_number=page_number,
+                )
+            )
+            buffer = []
+            continue
+
+        if buffer:
+            buffer.append(cleaned)
+            continue
+
+        if _TOC_PREFIX_RE.match(cleaned):
+            buffer = [cleaned]
+
+    return entries
+
+
+def _page_lines_for_toc(page: Dict[str, Any]) -> List[str]:
+    lines = page.get("lines")
+    if isinstance(lines, list):
+        return [str(line) for line in lines]
+
+    collected: List[str] = []
+    heading = page.get("heading")
+    if heading:
+        collected.append(str(heading))
+    text = page.get("text")
+    if text:
+        collected.extend(str(text).splitlines())
+    return collected
+
+
+def parse_table_of_contents(pages: List[dict]) -> List[DocumentTOCEntry]:
+    """Parse table-of-contents pages into a hierarchical structure."""
+
+    flat_entries: List[DocumentTOCEntry] = []
+    for page in pages:
+        lines = _page_lines_for_toc(page)
+        parsed = _parse_toc_page(lines)
+        if len(parsed) >= 2:
+            flat_entries.extend(parsed)
+
+    if not flat_entries:
+        return []
+
+    hierarchy_order = {
+        "part": 0,
+        "division": 1,
+        "subdivision": 2,
+        "section": 3,
+    }
+    root_entries: List[DocumentTOCEntry] = []
+    stack: List[Tuple[int, DocumentTOCEntry]] = []
+
+    for entry in flat_entries:
+        level = hierarchy_order.get(entry.node_type or "", len(hierarchy_order))
+        while stack and stack[-1][0] >= level:
+            stack.pop()
+        if stack:
+            stack[-1][1].children.append(entry)
+        else:
+            root_entries.append(entry)
+        stack.append((level, entry))
+
+    return root_entries
 
 
 def build_metadata(pdf_path: Path, pages: List[dict]) -> dict:
@@ -589,6 +714,8 @@ def build_document(
     for term, definition in definitions.items():
         registry.register_definition(term, definition)
 
+    toc_entries = parse_table_of_contents(pages)
+
     provisions = parse_sections(body)
     if not provisions:
         parser_available = _has_section_parser()
@@ -635,7 +762,12 @@ def build_document(
         merged = _dedupe_principles([*existing, *rule_principles])
         prov.principles = merged
 
-    document = Document(metadata=metadata, body=body, provisions=provisions)
+    document = Document(
+        metadata=metadata,
+        body=body,
+        provisions=provisions,
+        toc_entries=toc_entries,
+    )
     _CULTURAL_OVERLAY.apply(document)
     return document
 

--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -93,6 +93,7 @@ CREATE TABLE IF NOT EXISTS toc (
     identifier TEXT,
     title TEXT,
     position INTEGER NOT NULL,
+    page_number INTEGER,
     PRIMARY KEY (doc_id, rev_id, toc_id),
     FOREIGN KEY (doc_id, rev_id) REFERENCES revisions(doc_id, rev_id),
     FOREIGN KEY (doc_id, rev_id, parent_id)

--- a/tests/models/test_document_serialization.py
+++ b/tests/models/test_document_serialization.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 import json
 
-from src.models.document import Document, DocumentMetadata
+from src.models.document import Document, DocumentMetadata, DocumentTOCEntry
 from src.models.provision import Atom, Provision
 
 
@@ -41,7 +41,18 @@ def test_document_serialization_round_trip():
         customs=["custom"],
         atoms=[atom],
     )
-    document = Document(metadata=metadata, body="Body text", provisions=[provision])
+    toc_entry = DocumentTOCEntry(
+        node_type="section",
+        identifier="p1",
+        title="Sample provision",
+        page_number=7,
+    )
+    document = Document(
+        metadata=metadata,
+        body="Body text",
+        provisions=[provision],
+        toc_entries=[toc_entry],
+    )
 
     # Dictionary round trip
     doc_dict = document.to_dict()

--- a/tests/test_pdf_ingest.py
+++ b/tests/test_pdf_ingest.py
@@ -23,8 +23,18 @@ def test_extract_pdf(tmp_path):
 
     pages = pdf_ingest.extract_pdf_text(pdf_path)
     assert pages == [
-        {"page": 1, "heading": "Heading 1", "text": "Hello World"},
-        {"page": 2, "heading": "Heading2", "text": "Second Page"},
+        {
+            "page": 1,
+            "heading": "Heading 1",
+            "text": "Hello World",
+            "lines": ["Heading 1", "Hello", "World"],
+        },
+        {
+            "page": 2,
+            "heading": "Heading2",
+            "text": "Second Page",
+            "lines": ["Heading2", "Second Page"],
+        },
     ]
 
     meta = pdf_ingest.build_metadata(pdf_path, pages)

--- a/tests/test_versioned_store.py
+++ b/tests/test_versioned_store.py
@@ -13,7 +13,7 @@ if str(ROOT / "src") not in sys.path:
     sys.path.insert(0, str(ROOT / "src"))
 
 import src.pdf_ingest as pdf_ingest
-from src.models.document import Document, DocumentMetadata
+from src.models.document import Document, DocumentMetadata, DocumentTOCEntry
 from src.models.provision import Atom, Provision, RuleAtom
 from src.storage import VersionedStore
 
@@ -58,6 +58,12 @@ def make_store(tmp_path: Path) -> tuple[VersionedStore, int]:
             )
         ],
     )
+    toc_entry = DocumentTOCEntry(
+        node_type="section",
+        identifier="s 2",
+        title="Second heading",
+        page_number=42,
+    )
     store.add_revision(
         doc_id,
         Document(meta, "first", provisions=[first_provision]),
@@ -65,7 +71,12 @@ def make_store(tmp_path: Path) -> tuple[VersionedStore, int]:
     )
     store.add_revision(
         doc_id,
-        Document(meta, "second", provisions=[second_provision]),
+        Document(
+            meta,
+            "second",
+            provisions=[second_provision],
+            toc_entries=[toc_entry],
+        ),
         date(2021, 1, 1),
     )
     return store, doc_id
@@ -218,6 +229,24 @@ def test_toc_join(tmp_path: Path):
             (doc_id, 2),
         ).fetchall()
         assert {row["toc_id"] for row in rule_rows} == {rows[0]["toc_id"]}
+    finally:
+        store.close()
+
+
+def test_toc_page_numbers_persisted(tmp_path: Path):
+    store, doc_id = make_store(tmp_path)
+    try:
+        rows = store.conn.execute(
+            "SELECT page_number FROM toc WHERE doc_id = ? AND rev_id = ? ORDER BY toc_id",
+            (doc_id, 2),
+        ).fetchall()
+        assert rows, "expected toc rows for revision"
+        assert rows[-1]["page_number"] == 42
+
+        snapshot = store.snapshot(doc_id, date(2022, 1, 1))
+        assert snapshot is not None
+        assert snapshot.toc_entries
+        assert snapshot.toc_entries[0].page_number == 42
     finally:
         store.close()
 


### PR DESCRIPTION
## Summary
- add a DocumentTOCEntry structure so documents carry parsed table-of-contents metadata
- extract table-of-contents pages during PDF ingestion and attach the hierarchy to documents
- persist TOC entries with page numbers in the versioned store and update tests for the richer data

## Testing
- pytest tests/pdf_ingest/test_build_document_multiple_provisions_regression.py tests/test_pdf_ingest.py tests/models/test_document_serialization.py tests/test_versioned_store.py::test_toc_page_numbers_persisted
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7190444088322944c0261e4c29b6a