### PR TITLE
Support subdivision nodes in section parsers

### DIFF
--- a/src/section_parser.py
+++ b/src/section_parser.py
@@ -15,6 +15,10 @@ DIVISION_RE = re.compile(
     r"^Division\s+(?P<number>[A-Za-z0-9]+)(?:\s*(?:[-–:]\s*)?(?P<heading>.+))?$",
     re.IGNORECASE,
 )
+SUBDIVISION_RE = re.compile(
+    r"^Subdivision(?:\s+(?P<number>[A-Za-z0-9]+))?(?:\s*(?:[-–:]\s*)?(?P<heading>.+))?$",
+    re.IGNORECASE,
+)
 SUBSECTION_RE = re.compile(r"^\((?P<number>\d+)\)\s*(?P<text>.+)$")
 
 # Single-pass combined regex mimicking an Aho–Corasick matcher for keywords
@@ -174,6 +178,7 @@ def parse_sections(text: str) -> List[Provision]:
     current_part: Optional[_ParsedNode] = None
     current_division: Optional[_ParsedNode] = None
     current_section: Optional[_ParsedNode] = None
+    current_subdivision: Optional[_ParsedNode] = None
     current_subsection: Optional[_ParsedNode] = None
 
     for raw_line in text.splitlines():
@@ -191,6 +196,7 @@ def parse_sections(text: str) -> List[Provision]:
             _attach_node(nodes, None, current_part)
             current_division = None
             current_section = None
+            current_subdivision = None
             current_subsection = None
             continue
 
@@ -203,13 +209,27 @@ def parse_sections(text: str) -> List[Provision]:
                 heading=division_match.group("heading"),
             )
             _attach_node(nodes, parent, current_division)
+            current_subdivision = None
+            current_section = None
+            current_subsection = None
+            continue
+
+        subdivision_match = SUBDIVISION_RE.match(line)
+        if subdivision_match:
+            parent = current_division or current_part
+            current_subdivision = _ParsedNode(
+                node_type="subdivision",
+                identifier=subdivision_match.group("number"),
+                heading=subdivision_match.group("heading"),
+            )
+            _attach_node(nodes, parent, current_subdivision)
             current_section = None
             current_subsection = None
             continue
 
         section_match = HEADING_RE.match(line)
         if section_match:
-            parent = current_division or current_part
+            parent = current_subdivision or current_division or current_part
             current_section = _ParsedNode(
                 node_type="section",
                 identifier=section_match.group("number"),
@@ -229,13 +249,20 @@ def parse_sections(text: str) -> List[Provision]:
             _attach_node(nodes, current_section, current_subsection)
             continue
 
-        target = current_subsection or current_section or current_division or current_part
+        target = (
+            current_subsection
+            or current_section
+            or current_subdivision
+            or current_division
+            or current_part
+        )
         if target is None:
             target = _ParsedNode(node_type="section", identifier=None)
             _attach_node(nodes, None, target)
             current_part = None
             current_division = None
             current_section = target
+            current_subdivision = None
             current_subsection = None
 
         target._buffer.append(line)

--- a/tests/pdf_ingest/fixtures.py
+++ b/tests/pdf_ingest/fixtures.py
@@ -7,3 +7,15 @@ Division 1 Introductory
 2 Application of Act
 The Minister must not delay action if urgent circumstances exist.
 """
+
+STATUTE_WITH_SUBDIVISIONS = """Part 2 Governance
+Division 1 Establishment
+Subdivision A - Preliminary matters
+3 Board established
+The Board is established.
+
+Subdivision B
+4 Membership requirements
+(1) Members must be appointed by the Minister.
+(2) Members must possess relevant expertise.
+"""

--- a/tests/pdf_ingest/test_subdivision_parsing.py
+++ b/tests/pdf_ingest/test_subdivision_parsing.py
@@ -1,0 +1,65 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[2]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+
+fixtures_path = Path(__file__).with_name("fixtures.py")
+spec = importlib.util.spec_from_file_location("pdf_ingest_fixtures", fixtures_path)
+fixtures = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(fixtures)
+STATUTE_WITH_SUBDIVISIONS = fixtures.STATUTE_WITH_SUBDIVISIONS
+
+from src.section_parser import parse_sections as parse_sections_core
+from src.ingestion.section_parser import parse_sections as parse_sections_ingest
+
+
+def _assert_subdivision_structure(nodes):
+    assert len(nodes) == 1
+    part = nodes[0]
+    assert part.node_type == "part"
+
+    assert len(part.children) == 1
+    division = part.children[0]
+    assert division.node_type == "division"
+
+    assert len(division.children) == 2
+    subdivision_a, subdivision_b = division.children
+
+    assert subdivision_a.node_type == "subdivision"
+    assert subdivision_a.identifier == "A"
+    assert subdivision_a.heading == "Preliminary matters"
+
+    assert len(subdivision_a.children) == 1
+    section_three = subdivision_a.children[0]
+    assert section_three.node_type == "section"
+    assert section_three.identifier == "3"
+    assert "Board is established" in section_three.text
+    assert not section_three.children
+
+    assert subdivision_b.node_type == "subdivision"
+    assert subdivision_b.identifier == "B"
+    assert subdivision_b.heading is None
+
+    assert len(subdivision_b.children) == 1
+    section_four = subdivision_b.children[0]
+    assert section_four.node_type == "section"
+    assert section_four.identifier == "4"
+    assert len(section_four.children) == 2
+    first_subsection = section_four.children[0]
+    assert first_subsection.node_type == "subsection"
+    assert first_subsection.identifier == "(1)"
+    assert "Members must be appointed" in first_subsection.text
+
+
+def test_core_parser_emits_subdivisions():
+    provisions = parse_sections_core(STATUTE_WITH_SUBDIVISIONS)
+    _assert_subdivision_structure(provisions)
+
+
+def test_ingestion_parser_emits_subdivisions():
+    nodes = parse_sections_ingest(STATUTE_WITH_SUBDIVISIONS)
+    _assert_subdivision_structure(nodes)


### PR DESCRIPTION
## Summary
- teach the section parsers to recognise subdivision headings and insert subdivision nodes between divisions and sections
- add fixtures and regression tests exercising subdivision parsing for both ingestion and core parsers

## Testing
- pytest tests/pdf_ingest/test_subdivision_parsing.py

------
https://chatgpt.com/codex/tasks/task_e_68d7190536f4832299aa075f8a2752bf