### PR TITLE
Add stable IDs and normalize rule atom hashes

### DIFF
--- a/src/storage/schema.sql
+++ b/src/storage/schema.sql
@@ -107,6 +107,9 @@ ON toc(doc_id, rev_id, toc_id);
 CREATE INDEX IF NOT EXISTS idx_toc_parent
 ON toc(doc_id, rev_id, parent_id);
 
+CREATE UNIQUE INDEX idx_toc_stable
+ON toc(doc_id, stable_id);
+
 
 CREATE TABLE IF NOT EXISTS provisions (
     doc_id INTEGER NOT NULL,
@@ -273,6 +276,7 @@ CREATE TABLE IF NOT EXISTS rule_atoms (
     rule_id INTEGER NOT NULL,
     text_hash TEXT NOT NULL,
     toc_id INTEGER,
+    stable_id TEXT,
     atom_type TEXT,
     role TEXT,
     party TEXT,
@@ -297,8 +301,8 @@ CREATE TABLE IF NOT EXISTS rule_atoms (
 CREATE INDEX IF NOT EXISTS idx_rule_atoms_doc_rev
 ON rule_atoms(doc_id, rev_id, provision_id);
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_rule_atoms_unique_text
-ON rule_atoms(doc_id, rev_id, provision_id, party, role, text_hash);
+CREATE UNIQUE INDEX idx_rule_atoms_unique_text
+ON rule_atoms(doc_id, stable_id, party, role, text_hash);
 CREATE INDEX IF NOT EXISTS idx_rule_atoms_toc
 ON rule_atoms(doc_id, rev_id, toc_id);
 


### PR DESCRIPTION
## Summary
- add stable_id support to the SQL schema and recreate toc and rule_atoms uniqueness constraints
- normalize stored metadata and recompute rule atom and element text hashes deterministically
- harden glossary backfill and stable_id migrations to avoid pre-migration assumptions

## Testing
- pytest *(fails: existing test suite contains syntax errors and missing fixtures that prevent collection)*

------
https://chatgpt.com/codex/tasks/task_e_68d725f00a908322bc1cee8489d7dc8a