### PR TITLE
[codex] review packet grounding

### DIFF
--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -791,6 +791,37 @@ def _handle_wikidata_build_split_plan(args: argparse.Namespace) -> None:
     _print_json(report)
 
 
+def _handle_wikidata_nat_cohort_c_operator_packet(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata import (
+        build_nat_cohort_c_operator_packet,
+        build_nat_cohort_c_population_scan_live,
+    )
+
+    if args.input:
+        scan_payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    else:
+        scan_payload = build_nat_cohort_c_population_scan_live(
+            row_limit=args.row_limit,
+            timeout_seconds=args.timeout_seconds,
+        )
+    report = build_nat_cohort_c_operator_packet(scan_payload)
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "decision": report["decision"],
+                "candidate_count": report["summary"]["candidate_count"],
+            }
+        )
+        return
+    _print_json(report)
+
+
 def _handle_wikidata_hotspot_generate_clusters(args: argparse.Namespace) -> None:
     from src.ontology.wikidata_hotspot import generate_hotspot_cluster_pack, load_hotspot_manifest
 
@@ -2525,6 +2556,35 @@ def build_parser() -> argparse.ArgumentParser:
     )
     wikidata_build_split_plan.set_defaults(
         func=_handle_wikidata_build_split_plan
+    )
+    wikidata_nat_cohort_c_operator_packet = wikidata_sub.add_parser(
+        "cohort-c-operator-packet",
+        help="Build an operator-facing packet from the Cohort C live preview or a saved scan payload",
+    )
+    wikidata_nat_cohort_c_operator_packet.add_argument(
+        "--input",
+        type=Path,
+        help="Optional path to a saved Cohort C scan payload JSON",
+    )
+    wikidata_nat_cohort_c_operator_packet.add_argument(
+        "--row-limit",
+        type=int,
+        default=20,
+        help="Maximum number of live candidate rows to request when no --input is supplied",
+    )
+    wikidata_nat_cohort_c_operator_packet.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=30,
+        help="Timeout for the live Wikidata query when no --input is supplied",
+    )
+    wikidata_nat_cohort_c_operator_packet.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the operator packet JSON",
+    )
+    wikidata_nat_cohort_c_operator_packet.set_defaults(
+        func=_handle_wikidata_nat_cohort_c_operator_packet
     )
     wikidata_hotspot_generate_clusters = wikidata_sub.add_parser(
         "hotspot-generate-clusters",

--- a/cli/__main__.py
+++ b/cli/__main__.py
@@ -822,6 +822,395 @@ def _handle_wikidata_nat_cohort_c_operator_packet(args: argparse.Namespace) -> N
     _print_json(report)
 
 
+def _handle_wikidata_nat_cohort_c_operator_evidence(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata import build_nat_cohort_c_population_scan_live
+    from src.ontology.wikidata_cohort_c_operator_evidence import (
+        build_nat_cohort_c_operator_evidence_packet,
+    )
+
+    if args.input:
+        scan_payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    else:
+        scan_payload = build_nat_cohort_c_population_scan_live(
+            row_limit=args.row_limit,
+            timeout_seconds=args.timeout_seconds,
+        )
+    report = build_nat_cohort_c_operator_evidence_packet(scan_payload)
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "candidate_count": report["summary"]["candidate_count"],
+            }
+        )
+        return
+    _print_json(report)
+
+
+def _handle_wikidata_nat_cohort_c_operator_report(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata_cohort_c_operator_evidence import (
+        build_nat_cohort_c_operator_evidence_packet,
+    )
+    from src.ontology.wikidata_cohort_c_operator_report import (
+        build_nat_cohort_c_operator_report,
+    )
+
+    if args.input:
+        packet = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    else:
+        payload = build_nat_cohort_c_population_scan_live(
+            row_limit=20,
+            timeout_seconds=30,
+        )
+        packet = build_nat_cohort_c_operator_evidence_packet(payload)
+    report = build_nat_cohort_c_operator_report(packet)
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "candidate_count": report["candidate_count"],
+            }
+        )
+        return
+    _print_json(report)
+
+
+def _handle_wikidata_nat_cohort_c_operator_report_batch(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata_cohort_c_operator_evidence import (
+        build_nat_cohort_c_operator_evidence_packet,
+    )
+    from src.ontology.wikidata_cohort_c_operator_report_batch import (
+        build_nat_cohort_c_operator_report_batch,
+    )
+
+    packets = []
+    for path in args.inputs:
+        packet = json.loads(Path(path).read_text(encoding="utf-8"))
+        packets.append(packet)
+    if not packets:
+        raise ValueError("At least one input packet is required")
+    report = build_nat_cohort_c_operator_report_batch(packets)
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "batch_candidate_count": report["batch_candidate_count"],
+            }
+        )
+        return
+    _print_json(report)
+
+
+def _handle_wikidata_nat_cohort_c_operator_digest(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata_cohort_c_operator_digest import (
+        build_nat_cohort_c_operator_digest,
+    )
+
+    packets = [
+        json.loads(Path(path).read_text(encoding="utf-8"))
+        for path in args.inputs
+    ]
+    report = build_nat_cohort_c_operator_digest(packets)
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "candidate_count": report["candidate_count"],
+            }
+        )
+        return
+    _print_json(report)
+
+
+def _handle_wikidata_nat_cohort_d_operator_review(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata_nat_cohort_d_review import (
+        build_wikidata_nat_cohort_d_operator_review_surface,
+    )
+
+    type_probing_surface = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    report = build_wikidata_nat_cohort_d_operator_review_surface(
+        type_probing_surface=type_probing_surface,
+    )
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "readiness": report["readiness"],
+                "queue_size": report["queue_size"],
+                "unresolved_packet_ref_count": report["unresolved_packet_ref_count"],
+            }
+        )
+        return
+    _print_json(report)
+
+
+def _handle_wikidata_nat_cohort_d_operator_report(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata_nat_cohort_d_review import (
+        build_wikidata_nat_cohort_d_operator_report,
+    )
+
+    operator_review_surface = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    report = build_wikidata_nat_cohort_d_operator_report(operator_review_surface)
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "readiness": report["readiness"],
+                "decision": report["decision"],
+                "promotion_allowed": report["promotion_allowed"],
+                "queue_size": report["summary"]["queue_size"],
+            }
+        )
+        return
+    _print_json(report)
+
+
+def _handle_wikidata_nat_cohort_d_operator_report_batch(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata_nat_cohort_d_review import (
+        build_wikidata_nat_cohort_d_operator_report_batch,
+    )
+
+    payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    surfaces = payload.get("operator_review_surfaces")
+    if not isinstance(surfaces, list):
+        raise SystemExit("Cohort D operator report batch input requires operator_review_surfaces")
+    report = build_wikidata_nat_cohort_d_operator_report_batch(
+        operator_review_surfaces=surfaces,
+        batch_id=str(payload.get("batch_id", "")).strip() or None,
+    )
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "batch_id": report["batch_id"],
+                "decision": report["decision"],
+                "promotion_allowed": report["promotion_allowed"],
+                "case_count": report["summary"]["case_count"],
+                "all_cases_ready": report["summary"]["all_cases_ready"],
+            }
+        )
+        return
+    _print_json(report)
+
+
+def _handle_wikidata_nat_cohort_d_review_control_index(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata_nat_cohort_d_review import (
+        build_wikidata_nat_cohort_d_review_control_index,
+    )
+
+    payload = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    batch_reports = payload.get("batch_reports")
+    if not isinstance(batch_reports, list):
+        raise SystemExit("Cohort D review control index input requires batch_reports")
+    report = build_wikidata_nat_cohort_d_review_control_index(
+        batch_reports=batch_reports,
+        index_id=str(payload.get("index_id", "")).strip() or None,
+    )
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "index_id": report["index_id"],
+                "decision": report["decision"],
+                "promotion_allowed": report["promotion_allowed"],
+                "batch_count": report["summary"]["batch_count"],
+                "all_batches_ready": report["summary"]["all_batches_ready"],
+            }
+        )
+        return
+    _print_json(report)
+
+
+def _handle_wikidata_nat_automation_graduation_eval(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata_nat_automation_graduation import (
+        build_nat_automation_graduation_report,
+    )
+
+    criteria = json.loads(Path(args.criteria).read_text(encoding="utf-8"))
+    proposal = json.loads(Path(args.proposal).read_text(encoding="utf-8"))
+    report = build_nat_automation_graduation_report(criteria, proposal)
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "proposal_id": report["proposal_id"],
+                "gate_id": report["gate_id"],
+                "status": report["status"],
+                "decision": report["decision"],
+                "promotion_allowed": report["promotion_allowed"],
+            }
+        )
+        return
+    _print_json(report)
+
+
+def _handle_wikidata_nat_automation_graduation_eval_batch(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata_nat_automation_graduation import (
+        build_nat_automation_graduation_batch_report,
+    )
+
+    criteria = json.loads(Path(args.criteria).read_text(encoding="utf-8"))
+    proposal_batch = json.loads(Path(args.proposal_batch).read_text(encoding="utf-8"))
+    report = build_nat_automation_graduation_batch_report(criteria, proposal_batch)
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "batch_id": report["batch_id"],
+                "proposal_count": report["proposal_count"],
+                "summary": report["summary"],
+            }
+        )
+        return
+    _print_json(report)
+
+
+def _handle_wikidata_nat_automation_graduation_evidence_report(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata_nat_automation_graduation import (
+        build_nat_automation_graduation_evidence_report,
+    )
+
+    criteria = json.loads(Path(args.criteria).read_text(encoding="utf-8"))
+    proposal_batches = json.loads(Path(args.proposal_batches).read_text(encoding="utf-8"))
+    report = build_nat_automation_graduation_evidence_report(
+        criteria,
+        proposal_batches,
+        min_runs=args.min_runs,
+    )
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "evidence_batch_id": report["evidence_batch_id"],
+                "status": report["status"],
+                "decision": report["decision"],
+                "promotion_ready": report["promotion_ready"],
+                "summary": report["summary"],
+            }
+        )
+        return
+    _print_json(report)
+
+
+def _handle_wikidata_nat_automation_graduation_governance_index(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata_nat_automation_graduation import (
+        build_nat_automation_graduation_governance_index,
+    )
+
+    criteria = json.loads(Path(args.criteria).read_text(encoding="utf-8"))
+    evidence_snapshots = json.loads(Path(args.evidence_snapshots).read_text(encoding="utf-8"))
+    report = build_nat_automation_graduation_governance_index(
+        criteria,
+        evidence_snapshots,
+        min_snapshots=args.min_snapshots,
+    )
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "governance_batch_id": report["governance_batch_id"],
+                "status": report["status"],
+                "decision": report["decision"],
+                "promotion_ready": report["promotion_ready"],
+                "summary": report["summary"],
+            }
+        )
+        return
+    _print_json(report)
+
+
+def _handle_wikidata_nat_automation_graduation_governance_summary(args: argparse.Namespace) -> None:
+    from src.ontology.wikidata_nat_automation_graduation import (
+        build_nat_automation_graduation_governance_summary,
+    )
+
+    criteria = json.loads(Path(args.criteria).read_text(encoding="utf-8"))
+    governance_snapshots = json.loads(Path(args.governance_snapshots).read_text(encoding="utf-8"))
+    report = build_nat_automation_graduation_governance_summary(
+        criteria,
+        governance_snapshots,
+        min_indexes=args.min_indexes,
+    )
+    if args.output:
+        Path(args.output).write_text(
+            json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        _print_json(
+            {
+                "output": str(args.output),
+                "schema_version": report["schema_version"],
+                "governance_summary_id": report["governance_summary_id"],
+                "status": report["status"],
+                "decision": report["decision"],
+                "promotion_ready": report["promotion_ready"],
+                "summary": report["summary"],
+            }
+        )
+        return
+    _print_json(report)
+
+
 def _handle_wikidata_hotspot_generate_clusters(args: argparse.Namespace) -> None:
     from src.ontology.wikidata_hotspot import generate_hotspot_cluster_pack, load_hotspot_manifest
 
@@ -2585,6 +2974,300 @@ def build_parser() -> argparse.ArgumentParser:
     )
     wikidata_nat_cohort_c_operator_packet.set_defaults(
         func=_handle_wikidata_nat_cohort_c_operator_packet
+    )
+    wikidata_nat_cohort_c_operator_evidence = wikidata_sub.add_parser(
+        "cohort-c-operator-evidence",
+        help="Materialize the richer Cohort C operator evidence packet deterministically",
+    )
+    wikidata_nat_cohort_c_operator_evidence.add_argument(
+        "--input",
+        type=Path,
+        help="Optional path to a saved Cohort C scan payload JSON",
+    )
+    wikidata_nat_cohort_c_operator_evidence.add_argument(
+        "--row-limit",
+        type=int,
+        default=20,
+        help="Maximum number of live candidate rows to request when no --input is supplied",
+    )
+    wikidata_nat_cohort_c_operator_evidence.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=30,
+        help="Timeout for the live Wikidata query when no --input is supplied",
+    )
+    wikidata_nat_cohort_c_operator_evidence.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the operator evidence JSON",
+    )
+    wikidata_nat_cohort_c_operator_evidence.set_defaults(
+        func=_handle_wikidata_nat_cohort_c_operator_evidence
+    )
+    wikidata_nat_cohort_c_operator_report = wikidata_sub.add_parser(
+        "cohort-c-operator-report",
+        help="Summarize the Cohort C operator evidence packet for deterministic reporting",
+    )
+    wikidata_nat_cohort_c_operator_report.add_argument(
+        "--input",
+        type=Path,
+        help="Optional path to a saved Cohort C operator evidence packet JSON",
+    )
+    wikidata_nat_cohort_c_operator_report.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the operator report JSON",
+    )
+    wikidata_nat_cohort_c_operator_report.set_defaults(
+        func=_handle_wikidata_nat_cohort_c_operator_report
+    )
+    wikidata_nat_cohort_c_operator_report_batch = wikidata_sub.add_parser(
+        "cohort-c-operator-report-batch",
+        help="Aggregate multiple Cohort C evidence packets into a batch report",
+    )
+    wikidata_nat_cohort_c_operator_report_batch.add_argument(
+        "--inputs",
+        type=Path,
+        nargs="+",
+        required=True,
+        help="Paths to Cohort C operator evidence packet JSON files",
+    )
+    wikidata_nat_cohort_c_operator_report_batch.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the batch report JSON",
+    )
+    wikidata_nat_cohort_c_operator_report_batch.set_defaults(
+        func=_handle_wikidata_nat_cohort_c_operator_report_batch
+    )
+    wikidata_nat_cohort_c_operator_digest = wikidata_sub.add_parser(
+        "cohort-c-operator-digest",
+        help="Create a Cohort C governance digest from multiple operator indexes",
+    )
+    wikidata_nat_cohort_c_operator_digest.add_argument(
+        "--inputs",
+        type=Path,
+        nargs="+",
+        required=True,
+        help="Path(s) to Cohort C operator evidence packet JSONs",
+    )
+    wikidata_nat_cohort_c_operator_digest.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the digest JSON",
+    )
+    wikidata_nat_cohort_c_operator_digest.set_defaults(
+        func=_handle_wikidata_nat_cohort_c_operator_digest
+    )
+    wikidata_nat_cohort_d_operator_review = wikidata_sub.add_parser(
+        "cohort-d-operator-review",
+        help="Materialize the Cohort D operator/reviewer queue from a type-probing surface",
+    )
+    wikidata_nat_cohort_d_operator_review.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to a Cohort D type-probing surface JSON payload",
+    )
+    wikidata_nat_cohort_d_operator_review.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the Cohort D operator/reviewer surface JSON",
+    )
+    wikidata_nat_cohort_d_operator_review.set_defaults(
+        func=_handle_wikidata_nat_cohort_d_operator_review
+    )
+    wikidata_nat_cohort_d_operator_report = wikidata_sub.add_parser(
+        "cohort-d-operator-report",
+        help="Build a bounded Cohort D operator report from a Cohort D operator/reviewer queue surface",
+    )
+    wikidata_nat_cohort_d_operator_report.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to a Cohort D operator/reviewer surface JSON payload",
+    )
+    wikidata_nat_cohort_d_operator_report.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the Cohort D operator report JSON",
+    )
+    wikidata_nat_cohort_d_operator_report.set_defaults(
+        func=_handle_wikidata_nat_cohort_d_operator_report
+    )
+    wikidata_nat_cohort_d_operator_report_batch = wikidata_sub.add_parser(
+        "cohort-d-operator-report-batch",
+        help="Build a bounded Cohort D batch report from multiple Cohort D operator/reviewer surfaces",
+    )
+    wikidata_nat_cohort_d_operator_report_batch.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to a Cohort D operator report batch input JSON payload",
+    )
+    wikidata_nat_cohort_d_operator_report_batch.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the Cohort D batch report JSON",
+    )
+    wikidata_nat_cohort_d_operator_report_batch.set_defaults(
+        func=_handle_wikidata_nat_cohort_d_operator_report_batch
+    )
+    wikidata_nat_cohort_d_review_control_index = wikidata_sub.add_parser(
+        "cohort-d-review-control-index",
+        help="Build a broader Cohort D review-control index from multiple Cohort D batch reports",
+    )
+    wikidata_nat_cohort_d_review_control_index.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to a Cohort D review-control-index input JSON payload",
+    )
+    wikidata_nat_cohort_d_review_control_index.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the Cohort D review-control index JSON",
+    )
+    wikidata_nat_cohort_d_review_control_index.set_defaults(
+        func=_handle_wikidata_nat_cohort_d_review_control_index
+    )
+    wikidata_nat_automation_graduation_eval = wikidata_sub.add_parser(
+        "automation-graduation-eval",
+        help="Evaluate a Nat automation promotion proposal against pinned graduation criteria",
+    )
+    wikidata_nat_automation_graduation_eval.add_argument(
+        "--criteria",
+        type=Path,
+        required=True,
+        help="Path to Nat automation graduation criteria JSON",
+    )
+    wikidata_nat_automation_graduation_eval.add_argument(
+        "--proposal",
+        type=Path,
+        required=True,
+        help="Path to a promotion proposal JSON",
+    )
+    wikidata_nat_automation_graduation_eval.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the graduation evaluation report JSON",
+    )
+    wikidata_nat_automation_graduation_eval.set_defaults(
+        func=_handle_wikidata_nat_automation_graduation_eval
+    )
+    wikidata_nat_automation_graduation_eval_batch = wikidata_sub.add_parser(
+        "automation-graduation-eval-batch",
+        help="Evaluate a batch of Nat automation promotion proposals against pinned graduation criteria",
+    )
+    wikidata_nat_automation_graduation_eval_batch.add_argument(
+        "--criteria",
+        type=Path,
+        required=True,
+        help="Path to Nat automation graduation criteria JSON",
+    )
+    wikidata_nat_automation_graduation_eval_batch.add_argument(
+        "--proposal-batch",
+        type=Path,
+        required=True,
+        help="Path to promotion proposal batch JSON",
+    )
+    wikidata_nat_automation_graduation_eval_batch.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the graduation batch evaluation report JSON",
+    )
+    wikidata_nat_automation_graduation_eval_batch.set_defaults(
+        func=_handle_wikidata_nat_automation_graduation_eval_batch
+    )
+    wikidata_nat_automation_graduation_evidence_report = wikidata_sub.add_parser(
+        "automation-graduation-evidence-report",
+        help="Build repeated-run promotion-readiness evidence from multiple proposal batches",
+    )
+    wikidata_nat_automation_graduation_evidence_report.add_argument(
+        "--criteria",
+        type=Path,
+        required=True,
+        help="Path to Nat automation graduation criteria JSON",
+    )
+    wikidata_nat_automation_graduation_evidence_report.add_argument(
+        "--proposal-batches",
+        type=Path,
+        required=True,
+        help="Path to repeated proposal-batch input JSON",
+    )
+    wikidata_nat_automation_graduation_evidence_report.add_argument(
+        "--min-runs",
+        type=int,
+        default=2,
+        help="Minimum number of repeated runs required before readiness can be promoted",
+    )
+    wikidata_nat_automation_graduation_evidence_report.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the repeated-run evidence report JSON",
+    )
+    wikidata_nat_automation_graduation_evidence_report.set_defaults(
+        func=_handle_wikidata_nat_automation_graduation_evidence_report
+    )
+    wikidata_nat_automation_graduation_governance_index = wikidata_sub.add_parser(
+        "automation-graduation-governance-index",
+        help="Aggregate multiple repeated-run evidence snapshots into a promotion-governance index",
+    )
+    wikidata_nat_automation_graduation_governance_index.add_argument(
+        "--criteria",
+        type=Path,
+        required=True,
+        help="Path to Nat automation graduation criteria JSON",
+    )
+    wikidata_nat_automation_graduation_governance_index.add_argument(
+        "--evidence-snapshots",
+        type=Path,
+        required=True,
+        help="Path to repeated evidence-snapshot input JSON",
+    )
+    wikidata_nat_automation_graduation_governance_index.add_argument(
+        "--min-snapshots",
+        type=int,
+        default=2,
+        help="Minimum number of evidence snapshots required before readiness can be promoted",
+    )
+    wikidata_nat_automation_graduation_governance_index.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the governance index JSON",
+    )
+    wikidata_nat_automation_graduation_governance_index.set_defaults(
+        func=_handle_wikidata_nat_automation_graduation_governance_index
+    )
+    wikidata_nat_automation_graduation_governance_summary = wikidata_sub.add_parser(
+        "automation-graduation-governance-summary",
+        help="Aggregate multiple governance indexes into a broader repeated-run governance summary",
+    )
+    wikidata_nat_automation_graduation_governance_summary.add_argument(
+        "--criteria",
+        type=Path,
+        required=True,
+        help="Path to Nat automation graduation criteria JSON",
+    )
+    wikidata_nat_automation_graduation_governance_summary.add_argument(
+        "--governance-snapshots",
+        type=Path,
+        required=True,
+        help="Path to repeated governance-snapshot input JSON",
+    )
+    wikidata_nat_automation_graduation_governance_summary.add_argument(
+        "--min-indexes",
+        type=int,
+        default=2,
+        help="Minimum number of governance indexes required before readiness can be promoted",
+    )
+    wikidata_nat_automation_graduation_governance_summary.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the governance summary JSON",
+    )
+    wikidata_nat_automation_graduation_governance_summary.set_defaults(
+        func=_handle_wikidata_nat_automation_graduation_governance_summary
     )
     wikidata_hotspot_generate_clusters = wikidata_sub.add_parser(
         "hotspot-generate-clusters",

--- a/cli/cohort_b_operator_control_summary.py
+++ b/cli/cohort_b_operator_control_summary.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from src.ontology.wikidata_nat_cohort_b_operator_control_summary import (
+    build_nat_cohort_b_operator_control_summary,
+)
+
+_FIXTURE_DIR = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "wikidata"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Materialize Cohort B operator control summary from evidence indexes."
+    )
+    parser.add_argument(
+        "--inputs",
+        nargs="+",
+        type=Path,
+        default=[
+            _FIXTURE_DIR / "wikidata_nat_cohort_b_operator_evidence_index_20260402.json",
+            _FIXTURE_DIR / "wikidata_nat_cohort_b_operator_evidence_index_case2_20260402.json",
+        ],
+        help="Cohort B evidence-index JSON files to summarize.",
+    )
+    parser.add_argument(
+        "--min-ready-indexes",
+        type=int,
+        default=2,
+        help="Minimum ready indexes required for review_control_ready status.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=_FIXTURE_DIR / "wikidata_nat_cohort_b_operator_control_summary_20260402.json",
+        help="Path to write the Cohort B control summary JSON output.",
+    )
+    args = parser.parse_args(argv)
+
+    payloads = [json.loads(path.read_text(encoding="utf-8")) for path in args.inputs]
+    summary = build_nat_cohort_b_operator_control_summary(
+        payloads,
+        min_ready_indexes=args.min_ready_indexes,
+    )
+
+    rendered = json.dumps(summary, ensure_ascii=False, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/cohort_b_operator_index.py
+++ b/cli/cohort_b_operator_index.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from src.ontology.wikidata_nat_cohort_b_operator_evidence_index import (
+    build_nat_cohort_b_operator_evidence_index,
+)
+
+_FIXTURE_DIR = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "wikidata"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Materialize Cohort B operator evidence index from batch reports."
+    )
+    parser.add_argument(
+        "--inputs",
+        nargs="+",
+        type=Path,
+        default=[
+            _FIXTURE_DIR / "wikidata_nat_cohort_b_operator_batch_report_20260402.json",
+            _FIXTURE_DIR / "wikidata_nat_cohort_b_operator_batch_report_case2_20260402.json",
+        ],
+        help="Batch-report JSON files to aggregate into the Cohort B evidence index.",
+    )
+    parser.add_argument(
+        "--min-ready-batches",
+        type=int,
+        default=2,
+        help="Minimum ready batches required before index status can be review_index_ready.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=_FIXTURE_DIR / "wikidata_nat_cohort_b_operator_evidence_index_20260402.json",
+        help="Path to write the materialized Cohort B evidence index.",
+    )
+    args = parser.parse_args(argv)
+
+    batch_reports = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in args.inputs
+    ]
+    payload = build_nat_cohort_b_operator_evidence_index(
+        batch_reports,
+        min_ready_batches=args.min_ready_batches,
+    )
+    output_text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output_text, encoding="utf-8")
+    else:
+        sys.stdout.write(output_text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/cohort_e_diagnostics.py
+++ b/cli/cohort_e_diagnostics.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from src.ontology.wikidata_cohort_e_diagnostics import (
+    build_cohort_e_diagnostic_report,
+    summarize_cohort_e_reports,
+)
+from src.ontology.wikidata_cohort_e_summary_index import build_summary_index
+
+_FIXTURE_DIR = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "wikidata"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Emit Cohort E diagnostics report.")
+    parser.add_argument(
+        "--samples",
+        type=Path,
+        default=_FIXTURE_DIR / "wikidata_nat_cohort_e_split_axis_sample_20260403.json",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=_FIXTURE_DIR / "wikidata_nat_cohort_e_diagnostic_report_20260403.json",
+    )
+    parser.add_argument(
+        "--summary-output",
+        type=Path,
+        default=_FIXTURE_DIR / "wikidata_nat_cohort_e_diagnostic_summary_20260403.json",
+    )
+    parser.add_argument(
+        "--summaries",
+        type=Path,
+        nargs="+",
+        help="Paths to existing summary JSON files for aggregation.",
+    )
+    parser.add_argument(
+        "--index-output",
+        type=Path,
+        help="Write the aggregated disagreement index built from summaries.",
+    )
+    parser.add_argument(
+        "--batch",
+        action="store_true",
+        help="Emit one diagnostic report per successive sample pair.",
+    )
+    args = parser.parse_args()
+
+    samples = json.loads(args.samples.read_text(encoding="utf-8"))
+    if args.batch:
+        reports = []
+        total = len(samples["samples"])
+        for index in range(total - 1):
+            primary = samples["samples"][index]
+            references = [samples["samples"][index + 1]]
+            report = build_cohort_e_diagnostic_report(
+                primary_candidate=primary,
+                reference_candidates=references,
+                max_comparisons=1,
+            )
+            reports.append(report)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(reports, ensure_ascii=False, indent=2), encoding="utf-8")
+        summary = summarize_cohort_e_reports(reports)
+    else:
+        primary = samples["samples"][0]
+        references = samples["samples"][1:]
+        report = build_cohort_e_diagnostic_report(
+            primary_candidate=primary,
+            reference_candidates=references,
+            max_comparisons=min(2, len(references)),
+        )
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+        summary = summarize_cohort_e_reports([report])
+    args.summary_output.parent.mkdir(parents=True, exist_ok=True)
+    args.summary_output.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    if args.summaries and args.index_output:
+        _write_summary_index(args.summaries, args.index_output)
+
+
+def _write_summary_index(summary_paths: Iterable[Path], output: Path) -> None:
+    summaries = []
+    for summary_path in summary_paths:
+        summaries.append(json.loads(summary_path.read_text(encoding="utf-8")))
+    index = build_summary_index(summaries)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(index, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/cli/grounding_depth.py
+++ b/cli/grounding_depth.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from src.ontology import wikidata_grounding_depth
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build grounding depth batch for Nat review packets"
+    )
+    parser.add_argument(
+        "--summary",
+        required=True,
+        type=Path,
+        help="path to grounding-depth summary fixture",
+    )
+    parser.add_argument(
+        "--packets",
+        required=True,
+        type=Path,
+        help="path to review packet list fixture",
+    )
+    parser.add_argument(
+        "--outfile",
+        type=Path,
+        default=None,
+        help="path to write the grounding batch output (defaults to stdout)",
+    )
+    parser.add_argument(
+        "--report-out",
+        type=Path,
+        default=None,
+        help="path to write the grounding evidence report JSON",
+    )
+    parser.add_argument(
+        "--compare",
+        action="append",
+        type=Path,
+        default=[],
+        help="paths to grounding batch JSONs to include in the comparison report",
+    )
+    parser.add_argument(
+        "--comparison-out",
+        type=Path,
+        default=None,
+        help="path to write the grounding comparison JSON",
+    )
+    parser.add_argument(
+        "--scorecard-run",
+        action="append",
+        default=[],
+        help="run_id=path for grounding comparison files contributing to the scorecard",
+    )
+    parser.add_argument(
+        "--scorecard-out",
+        type=Path,
+        default=None,
+        help="path to write the grounding evidence scorecard JSON",
+    )
+    args = parser.parse_args(argv)
+
+    summary_source = _read_json(args.summary)
+    summary = wikidata_grounding_depth.build_grounding_depth_summary(fixture=summary_source)
+    packets = json.loads(args.packets.read_text(encoding="utf-8"))
+    batch = wikidata_grounding_depth.build_grounding_depth_batch(
+        review_packets=packets,
+        grounding_summary=summary,
+    )
+    report = wikidata_grounding_depth.build_grounding_depth_evidence_report(
+        grounding_summary=summary
+    )
+    comparison_batches = []
+    for path in args.compare:
+        comparison_batches.append(json.loads(path.read_text(encoding="utf-8")))
+    comparison = None
+    if comparison_batches:
+        comparison = wikidata_grounding_depth.build_grounding_depth_comparison(
+            batches=comparison_batches
+        )
+    output_text = json.dumps(batch, indent=2)
+    if args.outfile:
+        args.outfile.write_text(output_text + "\n", encoding="utf-8")
+    else:
+        sys.stdout.write(output_text + "\n")
+    if args.report_out:
+        args.report_out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    if args.comparison_out and comparison is not None:
+        args.comparison_out.write_text(json.dumps(comparison, indent=2) + "\n", encoding="utf-8")
+    if args.scorecard_run and args.scorecard_out:
+        runs: list[Mapping[str, Any]] = []
+        for spec in args.scorecard_run:
+            if "=" not in spec:
+                raise ValueError("scorecard-run must be run_id=path")
+            run_id, run_path_str = spec.split("=", 1)
+            runs.append(
+                {
+                    "run_id": run_id,
+                    "comparison": json.loads(Path(run_path_str).read_text(encoding="utf-8")),
+                }
+            )
+        scorecard = wikidata_grounding_depth.build_grounding_depth_scorecard(runs=runs)
+        args.scorecard_out.write_text(json.dumps(scorecard, indent=2) + "\n", encoding="utf-8")
+    return 0

--- a/docs/planning/wikidata_nat_automation_graduation_criteria_20260402.md
+++ b/docs/planning/wikidata_nat_automation_graduation_criteria_20260402.md
@@ -1,0 +1,263 @@
+# Wikidata Nat Automation Graduation Criteria
+
+Date: 2026-04-02
+
+## Purpose
+
+Define explicit, auditable gates for graduating the Nat lane from review-first
+operation to broader automation, and finally to moonshot-level blind
+execution.
+
+This is a governance document, not an implementation shortcut.
+
+## Scope
+
+Applies to the Nat `P5991 -> P14143` migration lane and its cohort branches.
+
+Out of scope:
+
+- policy edits that bypass current split/verification controls
+- full-population blind execution before gate evidence is satisfied
+
+## Graduation Ladder
+
+`Level 0` Review-first only
+`Level 1` Reviewer-assisted split execution
+`Level 2` Family-scoped measured automation
+`Level 3` Broad automation with strict holds/abstains
+`Level 4` Moonshot blind migration bot
+
+## Required Gate Families
+
+Every graduation decision must clear all five families:
+
+1. Evidence grounding
+2. Claim-boundary reliability
+3. Verification quality
+4. Policy-risk containment
+5. Operational control and rollback
+
+Fail one family, fail the gate.
+
+## Gate Criteria By Level
+
+### Gate A: Level 0 -> Level 1
+
+Must show:
+
+- reviewer packets exist for representative split shapes
+- bounded follow-depth evidence exists and is fail-closed
+- split plans are verified on representative reviewed plans
+- unresolved uncertainty remains explicit in packet outputs
+
+Blocked if:
+
+- packet evidence is mostly inferred without revision-locked anchors
+- split verification exists only on one narrow shape
+
+### Gate B: Level 1 -> Level 2
+
+Must show:
+
+- at least one backlog family has repeated measured direct-safe behavior
+- after-state verification stays stable across repeated tranches
+- false-positive incidence is below the family budget
+- abstain/hold behavior remains active and effective
+
+Blocked if:
+
+- direct-safe yield is unstable between tranches
+- repeated tranches collapse back to mostly `split_required`
+
+### Gate C: Level 2 -> Level 3
+
+Must show:
+
+- automation works across more than one structural family
+- policy-risk cohorts remain separated and governed
+- cross-source disagreement handling is explicit and deterministic
+- rollback and replay paths are validated end to end
+
+Blocked if:
+
+- automation gain depends on suppressing hold/abstain paths
+- verification receipts are incomplete or non-replayable
+
+### Gate D: Level 3 -> Level 4
+
+Must show:
+
+- broad coverage under bounded risk with sustained quality
+- blind execution is safer than reviewer-gated execution for the promoted
+  families
+- complete auditability for source, split decision, and after-state receipts
+- on-call rollback and kill-switch controls are proven
+
+Blocked if:
+
+- policy-risk families are still materially unresolved
+- audit trails are incomplete or human-reconstruction dependent
+
+## Core Metrics
+
+Minimum tracked metrics for every candidate promotion window:
+
+- direct-safe yield by family
+- split-required rate by family
+- hold/abstain rate and reason distribution
+- after-state verification pass rate
+- false-positive rate and severity
+- rollback invocation and recovery success
+- receipt completeness coverage
+
+## Promotion Decision Contract
+
+A promotion proposal must include:
+
+- candidate level transition
+- evidence window and sampled families
+- metric summary with threshold comparison
+- explicit risks and mitigations
+- signed recommendation:
+  - `promote`
+  - `hold`
+  - `revert`
+
+No implicit promotion from narrative confidence.
+
+## Machine-Checkable Evaluator
+
+The first bounded evaluator surface now exists:
+
+- runtime helper:
+  `SensibLaw/src/ontology/wikidata_nat_automation_graduation.py`
+- deterministic entrypoint:
+  `evaluate_nat_automation_promotion(criteria, proposal)`
+- tests:
+  `SensibLaw/tests/test_wikidata_nat_automation_graduation.py`
+
+Design constraints:
+
+- fail-closed by default
+- explicit failed checks for missing families/evidence/metrics
+- blocker signals force hold/reject
+- unknown gate ids reject immediately
+
+Next bounded operator/control surface now also exists:
+
+- CLI command:
+  `sensiblaw wikidata automation-graduation-eval --criteria ... --proposal ...`
+- deterministic report wrapper:
+  `build_nat_automation_graduation_report(criteria, proposal)`
+- pinned proposal fixtures:
+  - `wikidata_nat_automation_promotion_proposal_gate_a_promote_20260402.json`
+  - `wikidata_nat_automation_promotion_proposal_gate_b_hold_20260402.json`
+
+Next bounded queue/index surface now also exists:
+
+- deterministic batch wrapper:
+  `build_nat_automation_graduation_batch_report(criteria, proposal_batch)`
+- CLI command:
+  `sensiblaw wikidata automation-graduation-eval-batch --criteria ... --proposal-batch ...`
+- pinned batch fixture:
+  `wikidata_nat_automation_promotion_proposal_batch_20260402.json`
+
+This keeps operator triage deterministic across multiple proposals while
+remaining fail-closed per proposal and at batch-summary level.
+
+Next bounded measured-evidence surface now also exists:
+
+- deterministic repeated-run scorecard:
+  `build_nat_automation_graduation_evidence_report(criteria, proposal_batches)`
+- CLI command:
+  `sensiblaw wikidata automation-graduation-evidence-report --criteria ... --proposal-batches ...`
+- pinned repeated-run fixture:
+  `wikidata_nat_automation_promotion_proposal_batches_20260402.json`
+
+Fail-closed readiness rule:
+
+- any rejected proposal across repeated runs keeps readiness on hold
+- any fail-closed proposal across repeated runs keeps readiness on hold
+- mixed gate scope across repeated runs keeps readiness on hold
+- insufficient repeated run count keeps readiness on hold
+
+Next bounded governance-index surface now also exists:
+
+- deterministic cross-snapshot index:
+  `build_nat_automation_graduation_governance_index(criteria, evidence_snapshots)`
+- CLI command:
+  `sensiblaw wikidata automation-graduation-governance-index --criteria ... --evidence-snapshots ...`
+- pinned snapshot fixture:
+  `wikidata_nat_automation_evidence_snapshots_20260402.json`
+
+Fail-closed governance rule:
+
+- any not-ready snapshot keeps governance readiness on hold
+- any rejected/fail-closed proposal totals keep governance readiness on hold
+- mixed gate scope across snapshots keeps governance readiness on hold
+- insufficient snapshot count keeps governance readiness on hold
+
+Next bounded governance-summary surface now also exists:
+
+- deterministic repeated-index governance summary:
+  `build_nat_automation_graduation_governance_summary(criteria, governance_snapshots)`
+- CLI command:
+  `sensiblaw wikidata automation-graduation-governance-summary --criteria ... --governance-snapshots ...`
+- pinned governance-snapshot fixture:
+  `wikidata_nat_automation_governance_snapshots_20260402.json`
+
+Fail-closed repeated-index governance rule:
+
+- any not-ready governance index keeps summary readiness on hold
+- any rejected/fail-closed totals in governance indexes keep summary readiness on hold
+- mixed gate scope across governance indexes keeps summary readiness on hold
+- insufficient governance index count keeps summary readiness on hold
+
+## Current Read (Pinned)
+
+Current lane posture remains below Gate B:
+
+- review-first controls are strong
+- split verification is real
+- packet and follow-depth support is real
+- broad measured direct-safe stability is not yet demonstrated
+
+So the honest current automation ceiling is `Level 1`.
+
+## ZKP Frame
+
+### O
+
+- Nat and ontology/workgroup reviewers
+- ITIR/SensibLaw control-plane owners
+
+### R
+
+- safe, evidence-backed graduation to higher automation levels
+
+### C
+
+- reviewer packet lane
+- split verification lane
+- cohort automation lanes
+
+### S
+
+- good review-first maturity, insufficient broad automation maturity
+
+### L
+
+`L0 -> L1 -> L2 -> L3 -> L4`
+
+### P
+
+- enforce explicit gate checks instead of informal readiness claims
+
+### G
+
+- fail-closed default
+- promotion only by multi-family evidence
+
+### F
+
+- missing broad, stable automation evidence beyond review-first strengths

--- a/docs/planning/wikidata_nat_cohort_b_operator_batch_report_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_b_operator_batch_report_20260402.md
@@ -1,0 +1,54 @@
+# Wikidata Nat Cohort B Operator Batch Evidence Surface
+
+Date: 2026-04-02
+
+## Scope
+
+Lane-local Cohort B only:
+
+- aggregates more than one Cohort B operator packet
+- materializes deterministic queue + report evidence in one batch payload
+
+No Cohort C/D/E behavior is changed.
+
+## Runtime Helper
+
+- `src/ontology/wikidata_nat_cohort_b_operator_batch_report.py`
+- `build_nat_cohort_b_operator_batch_report(operator_packets, max_queue_items=100, max_examples=10)`
+
+The batch helper composes:
+
+1. `build_nat_cohort_b_operator_queue(...)`
+2. `build_nat_cohort_b_operator_report(...)`
+
+and emits:
+
+- `case_summaries` and `packet_decision_counts`
+- nested queue/report materialization
+- `batch_status` with bounded fail-closed reasons
+
+## Fail-Closed Rules
+
+Batch status is `hold` when:
+
+- fewer than two operator cases are provided
+- queue is not ready
+- report is not ready
+
+This keeps the broader evidence lane review-only.
+
+## Pinned Surface
+
+- second-case packet fixture:
+  `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_packet_case2_20260402.json`
+- pinned batch fixture:
+  `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_batch_report_20260402.json`
+- regression tests:
+  `tests/test_wikidata_nat_cohort_b_operator_batch_report.py`
+
+## Non-Claims
+
+- not migration execution
+- not autonomous promotion
+- not cross-cohort arbitration
+

--- a/docs/planning/wikidata_nat_cohort_b_operator_control_summary_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_b_operator_control_summary_20260402.md
@@ -1,0 +1,55 @@
+# Wikidata Nat Cohort B Operator Control Summary
+
+Date: 2026-04-02
+
+## Scope
+
+Lane-local Cohort B repeated-run control surface:
+
+- aggregates multiple Cohort B evidence indexes
+- emits one deterministic control summary for broader-slice readiness tracking
+
+No migration execution or cross-cohort routing is introduced.
+
+## Runtime Surface
+
+- helper:
+  `src/ontology/wikidata_nat_cohort_b_operator_control_summary.py`
+- builder:
+  `build_nat_cohort_b_operator_control_summary(index_payloads, min_ready_indexes=2)`
+- CLI:
+  `cli/cohort_b_operator_control_summary.py`
+
+The summary surfaces:
+
+- per-index readiness entries
+- ready/hold index counts and aggregate batch counts
+- bounded control readiness status with explicit fail-closed reasons
+
+## Fail-Closed Rules
+
+Control status is `hold` when:
+
+- validation errors exist
+- ready index count is below threshold
+- any hold index is present
+
+Ready index ids are emitted only when `control_status=review_control_ready`.
+
+## Pinned Surface
+
+- evidence-index fixtures:
+  - `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_evidence_index_20260402.json`
+  - `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_evidence_index_case2_20260402.json`
+- pinned control-summary fixture:
+  `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_control_summary_20260402.json`
+- tests:
+  - `tests/test_wikidata_nat_cohort_b_operator_control_summary.py`
+  - `tests/test_wikidata_nat_cohort_b_operator_control_summary_cli.py`
+
+## Non-Claims
+
+- not migration execution
+- not autonomous promotion
+- not cross-cohort arbitration
+

--- a/docs/planning/wikidata_nat_cohort_b_operator_evidence_index_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_b_operator_evidence_index_20260402.md
@@ -1,0 +1,55 @@
+# Wikidata Nat Cohort B Operator Evidence Index
+
+Date: 2026-04-02
+
+## Scope
+
+Lane-local Cohort B broader operator control surface:
+
+- aggregates multiple Cohort B batch reports
+- emits one deterministic evidence index for broader-slice review readiness
+
+No shared cross-cohort routing or execution semantics are introduced.
+
+## Runtime Surface
+
+- helper:
+  `src/ontology/wikidata_nat_cohort_b_operator_evidence_index.py`
+- builder:
+  `build_nat_cohort_b_operator_evidence_index(batch_reports, min_ready_batches=2)`
+- CLI materializer:
+  `cli/cohort_b_operator_index.py`
+
+The index summarizes:
+
+- per-batch readiness entries
+- ready/hold counts and reasons
+- ready-batch ids only when threshold is met
+- fail-closed validation diagnostics
+
+## Fail-Closed Rules
+
+Index status is `hold` when:
+
+- validation errors are present
+- ready-batch count is below threshold
+
+Ready-batch ids are suppressed in hold status.
+
+## Pinned Surface
+
+- batch fixtures:
+  - `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_batch_report_20260402.json`
+  - `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_batch_report_case2_20260402.json`
+- pinned index fixture:
+  `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_evidence_index_20260402.json`
+- tests:
+  - `tests/test_wikidata_nat_cohort_b_operator_evidence_index.py`
+  - `tests/test_wikidata_nat_cohort_b_operator_index_cli.py`
+
+## Non-Claims
+
+- not migration execution
+- not autonomous promotion
+- not cross-cohort arbitration
+

--- a/docs/planning/wikidata_nat_cohort_b_operator_packet_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_b_operator_packet_20260402.md
@@ -1,0 +1,64 @@
+# Wikidata Nat Cohort B Operator Packet (Bounded)
+
+Date: 2026-04-02
+
+## Scope
+
+Lane-local Cohort B tranche only:
+
+- reconciled non-business `instance of` rows
+- review-first packet surface for operators/reviewers
+
+No Cohort C/D/E routing is changed by this slice.
+
+## Runtime Helper
+
+- `src/ontology/wikidata_nat_cohort_b_operator_packet.py`
+- `build_nat_cohort_b_operator_packet(review_bucket_payload, max_rows=5)`
+
+Pinned fixture contract:
+
+- input fixture:
+  `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_packet_input_20260402.json`
+- expected packet fixture:
+  `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_packet_20260402.json`
+- regression test:
+  `tests/test_wikidata_nat_cohort_b_operator_packet.py`
+
+Input contract:
+
+- payload from `build_nat_cohort_b_review_bucket(...)`
+- cohort id must be `cohort_b_reconciled_non_business`
+- source bucket decision must be `review_only` or `hold`
+
+Output contract:
+
+- packet decision: `review` or `hold`
+- selected rows (bounded by `max_rows`)
+- variance-flag counts for reviewer triage
+- fail-closed governance fields and non-claims
+
+## Fail-Closed Rules
+
+The operator packet holds when:
+
+- source bucket is `hold`
+- no valid review rows are available
+- input shape is invalid
+
+The helper never authorizes migration execution.
+
+## Reviewer Surface
+
+- triage prompts prioritize:
+  - unexpected qualifier variance
+  - unexpected reference variance
+  - temporal qualifier-mode mixing
+- rows are ordered by variance pressure first
+- contract violations stay visible for operator correction
+
+## Non-Claims
+
+- not a migration executor
+- not full semantic decomposition
+- not cross-cohort arbitration

--- a/docs/planning/wikidata_nat_cohort_b_operator_queue_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_b_operator_queue_20260402.md
@@ -1,0 +1,51 @@
+# Wikidata Nat Cohort B Operator Queue Materialization
+
+Date: 2026-04-02
+
+## Scope
+
+Lane-local Cohort B control surface only:
+
+- consumes Cohort B operator packets
+- emits bounded review queue items for operator worklists
+- stays review-only and fail-closed
+
+No Cohort C/D/E logic is modified.
+
+## Runtime Helper
+
+- `src/ontology/wikidata_nat_cohort_b_operator_queue.py`
+- `build_nat_cohort_b_operator_queue(operator_packets, max_queue_items=50)`
+
+Queue output fields:
+
+- `queue_status` (`review_queue_ready` or `hold`)
+- `queue_items` (priority-ranked, bounded by `max_queue_items`)
+- `blocked_packets` and `validation_errors` for fail-closed diagnostics
+- governance and non-claim fields
+
+## Fail-Closed Rules
+
+Queue status becomes `hold` when:
+
+- any input packet is `decision=hold`
+- any packet fails Cohort B validation
+- no review rows are available
+
+When `hold`, queue items are not emitted.
+
+## Pinned Surface
+
+- input packet fixture:
+  `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_packet_20260402.json`
+- pinned queue fixture:
+  `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_queue_20260402.json`
+- regression test:
+  `tests/test_wikidata_nat_cohort_b_operator_queue.py`
+
+## Non-Claims
+
+- not migration execution
+- not autonomous approval
+- not cross-cohort queue arbitration
+

--- a/docs/planning/wikidata_nat_cohort_b_operator_report_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_b_operator_report_20260402.md
@@ -1,0 +1,46 @@
+# Wikidata Nat Cohort B Operator Report Surface
+
+Date: 2026-04-02
+
+## Scope
+
+Lane-local Cohort B review-only reporting surface:
+
+- consumes Cohort B operator queue payloads
+- emits bounded reviewer-facing operator reports
+
+No cross-cohort routing or execution semantics are introduced.
+
+## Runtime Helper
+
+- `src/ontology/wikidata_nat_cohort_b_operator_report.py`
+- `build_nat_cohort_b_operator_report(queue_payload, max_examples=5)`
+
+Output shape includes:
+
+- `report_status` (`review_only_report_ready` or `hold`)
+- queue-derived examples for bounded operator briefing
+- summary counts by priority, variance flags, and `instance of` classes
+- blocked packet + validation diagnostics
+
+## Fail-Closed Rules
+
+- if queue status is not `review_queue_ready`, report status is `hold`
+- when `hold`, examples are empty and diagnostics stay visible
+- report remains non-executing and review-first
+
+## Pinned Surface
+
+- input queue fixture:
+  `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_queue_20260402.json`
+- pinned report fixture:
+  `tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_report_20260402.json`
+- regression test:
+  `tests/test_wikidata_nat_cohort_b_operator_report.py`
+
+## Non-Claims
+
+- not migration execution
+- not autonomous approval
+- not cross-cohort arbitration
+

--- a/docs/planning/wikidata_nat_cohort_b_packetization_plan_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_b_packetization_plan_20260402.md
@@ -1,0 +1,65 @@
+# Wikidata Nat Cohort B Packetization Plan
+
+Date: 2026-04-02
+
+## Scope
+
+Lane-local to **Cohort B only**:
+
+- reconciled non-business `instance of` rows
+- outside business-family tranche (`Q4830453`, `Q6881511`, `Q891723`)
+
+This plan does not alter Cohort C/D/E handling.
+
+## Runtime Surface (Bounded)
+
+New helper surface:
+
+- `src/ontology/wikidata_nat_cohort_b_review_bucket.py`
+- `build_nat_cohort_b_review_bucket(payload)`
+
+Bounded output:
+
+- decision: `review_only` or `hold`
+- `review_bucket_rows` with qualifier/reference variance flags
+- reviewer questions per row
+- contract violations for out-of-lane contamination
+
+## Fail-Closed Contract
+
+The helper holds (`decision=hold`) when:
+
+- payload schema/version is wrong
+- payload includes business-family rows
+- payload includes unreconciled `instance of` rows
+- no valid Cohort B rows remain after validation
+
+No output path executes migrations.
+
+## Packetization Slice
+
+1. Materialize Cohort B candidate rows into `candidates`.
+2. Build review bucket via `build_nat_cohort_b_review_bucket`.
+3. If `decision=hold`, route to lane diagnostics only.
+4. If `decision=review_only`, emit row-level reviewer prompts and variance
+   flags for packet attachment or operator review.
+
+## Expected Shape Baseline
+
+Qualifier baseline:
+
+- `P459`, `P3831`, `P585`, `P580`, `P582`, `P518`, `P7452`
+
+Reference baseline:
+
+- `P854`, `P1065`, `P813`, `P1476`, `P2960`
+
+Variance outside these sets remains reviewer-visible; it is not silently
+collapsed.
+
+## Non-Claims
+
+- not full semantic decomposition
+- not migration execution authorization
+- not cross-cohort generalization
+

--- a/docs/planning/wikidata_nat_cohort_b_review_bucket_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_b_review_bucket_20260402.md
@@ -1,0 +1,94 @@
+# Wikidata Nat Cohort B Review-First Bucket
+
+Date: 2026-04-02
+
+## Change Class
+
+Standard change.
+
+## Scope
+
+This artifact is lane-local to **Nat Cohort B only**:
+
+- all reconciled `instance of` classes outside the business-family tranche
+  (`Q4830453`, `Q6881511`, `Q891723`)
+
+This artifact does not classify or redefine Cohort C, D, or E behavior.
+
+## Purpose
+
+Define a bounded, review-first characterization for Cohort B so the lane can
+separate high-variance reconciled classes from Cohort A while keeping qualifier
+and reference variance explicit for reviewers.
+
+## Cohort B Characterization
+
+- bucket role: secondary reconciled-class tranche after Cohort A
+- execution posture: review-first
+- expected risk: higher semantic variance across subject classes and statement
+  contexts
+- migration posture: no blanket auto-migration claim from cohort membership
+  alone
+
+## Expected Qualifier Variance Surface
+
+Baseline expected qualifier family (from the sandbox migration mapping):
+
+- `P459` determination method or standard
+- `P3831` object of statement has role
+- `P585` point in time
+- `P580` start time
+- `P582` end time
+- `P518` applies to part
+- `P7452` reason for preferred rank
+
+Review variance policy for Cohort B:
+
+- if these qualifiers are missing where axis splits imply they matter, hold for
+  review
+- if additional qualifier properties appear, surface as variance rather than
+  dropping silently
+- mixed temporal qualifier resolution (`P585` vs `P580/P582`) remains explicit
+  review pressure
+
+## Expected Reference Variance Surface
+
+Baseline expected reference family:
+
+- `P854` reference URL
+- `P1065` archive URL
+- `P813` retrieved
+- `P1476` title
+- `P2960` archive date
+
+Review variance policy for Cohort B:
+
+- unexpected reference properties are reviewer-visible
+- missing baseline reference fields in high-impact rows are review triggers
+- reference preservation remains required where migration candidates are later
+  approved
+
+## Reviewer Questions (Cohort B)
+
+1. Do class-specific semantics for this non-business reconciled class still
+   support a carbon-footprint to GHG-emissions mapping?
+2. Are split axes (`P518`, temporal qualifiers, method qualifiers) sufficient
+   to prevent claim-boundary collapse?
+3. Does the statement require additional class-local qualifiers before any
+   migration-equivalence decision?
+4. Do references ground the mapped claim at comparable specificity after split?
+5. Is rank handling (`preferred` plus `P7452`) preserved or does the row remain
+   review-only?
+
+## Bounded Output Contract For This Bucket
+
+- output class: Cohort B review packet or review-only row
+- minimum visible fields:
+  - class identity (`instance of` target)
+  - qualifier/reference variance flags
+  - split-axis pressure summary
+  - unresolved reviewer questions
+- explicit non-claim:
+  - this bucket characterization is not full semantic decomposition and not an
+    execution authorization by itself
+

--- a/docs/planning/wikidata_nat_cohort_c_live_preview_extension_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_c_live_preview_extension_20260402.md
@@ -1,0 +1,90 @@
+# Wikidata Nat Cohort C Live Preview Extension
+
+Date: 2026-04-02
+
+## Purpose
+
+Push the next Cohort C step by expanding the live preview coverage for the
+non-GHG or missing `determination method (P459)` lane, improving the operator
+packet evidence while keeping every artifact review-first and fail-closed.
+
+## Context
+
+- Builds on `wikidata_nat_cohort_c_population_scan_20260402.md` (review-first scan
+  plan) and the pinned branch artifact `wikidata_nat_cohort_c_branch_20260401.md`.
+- This extension stays entirely within Cohort C and does not influence Cohort
+  B/D/E semantics or shared repo-wide policy documents.
+- Cohort C already has a live preview helper and operator packet; this artifact
+  covers the next highest-yield step: a broader live preview sample plus
+  explicit operator routing cues that emphasize the lane remains review-only.
+
+## Inputs
+
+- Cohort C population scan fixture: `tests/fixtures/wikidata/wikidata_nat_cohort_c_population_scan_20260402.json`
+- New live preview fixture: `tests/fixtures/wikidata/wikidata_nat_cohort_c_live_preview_extension_20260402.json`
+- Operator packet CLI entrypoint: `sensiblaw wikidata cohort-c-operator-packet`
+
+## ZKP Frame
+
+### O
+
+- Nat lane reviewers engaging with Cohort C preview results
+- Operators rerunning gateway preview scans
+- Governance leads tracking policy-risk buckets
+
+### R
+
+- broaden the live preview sample so operators can verify that P459 is not
+  the GHG protocol or is missing across more candidates
+- surface per-candidate evidence (`p459_status`, qualifiers, references) inside
+  a small lane-local fixture that the operator packet can cite
+- keep the lane fail-closed by binding every preview row to a hold/review gate
+
+### C
+
+- Cohort C branch and scan plan artifacts
+- this document and the new live preview fixture
+- runtime preview helper invoked via CLI, producing operator packet evidence
+
+### S
+
+- the selection rule is locked to Cohort C statements
+- preview helper already gated to fail-closed and review-first
+- operator packet surfaces demand explicit hold reasons before any promotion
+
+### L
+
+1. reuse the selection rule from the scan plan to gather a broader preview sample
+2. package the sample into the lane-local fixture plus CLI packet
+3. surface the fixture to operators while enforcing hold/review metadata
+
+### P
+
+- run the `non_ghg_protocol_or_missing_p459` preview helper across additional
+  segments of the sandbox `P5991` statements
+- for each candidate emit `p459_status`, `preview_hold_reason`, qualifier hints,
+  and reference pointers in the lane-local fixture
+- extend the operator packet to cite the fixture and clarify that each row
+  remains under a `review_first_population_scan` promise
+
+### G
+
+- no automation claims; preview remains a discovery artifact
+- all preview rows carry `promotion_guard: hold` plus a documented
+  `preview_hold_reason`
+- lane stays disjoint from Cohort B/D/E while feeding operator review lanes
+
+### F
+
+- preview samples remain narrow; this extension scales coverage without
+  opening promotion claims
+
+## Operator Guidance
+
+1. Use the preview fixture to answer: “Which qualifiers or references reinforce
+   that `P459` is missing or non-GHG?” Document answers inside
+   `preview_hold_reason`.
+2. Keep `progress_claim` anchored to `reviewable_packet` and require a second
+   reviewer to confirm any typing/anomaly before the packet leaves review.
+3. Log the CLI command plus fixture hash when annotating the cohort’s review log
+   so follow-up scans trace the same data slice.

--- a/docs/planning/wikidata_nat_cohort_c_operator_evidence_20260403.md
+++ b/docs/planning/wikidata_nat_cohort_c_operator_evidence_20260403.md
@@ -1,0 +1,83 @@
+# Wikidata Nat Cohort C Operator Evidence Packet Extension
+
+Date: 2026-04-03
+
+## Purpose
+
+Strengthen the Cohort C operator evidence surface by packetizing a broader live-preview result set with richer policy-risk annotations. This maintains the review-first, fail-closed posture while providing operators a clearer next gate for any classification or pilot actions.
+
+## Context
+
+- Builds off the existing Cohort C scan plan (`wikidata_nat_cohort_c_population_scan_20260402.md`), live preview extension, and CLI operator packet entrypoints.
+- This artifact does not change Cohort B/D/E or introduce automation; it simply documents the next operator-facing packet that wraps the current preview fixture with traceable holds.
+- The lane keeps `progress_claim: reviewable_packet` and `promotion_guard: hold` for every row.
+
+## Inputs
+
+- Extended preview fixture: `tests/fixtures/wikidata/wikidata_nat_cohort_c_operator_packet_extension_20260403.json`
+- Operator CLI: `sensiblaw wikidata cohort-c-operator-packet`
+
+## ZKP Frame
+
+### O
+
+- Operators reviewing policy-risk evidence before any type resolution
+- Nat reviewers overseeing Cohort C hold decisions
+
+### R
+
+- deliver an operator packet that a) cites a broader set of preview candidates and b) annotates each row with hold reasons, reference anchors, and qualifier notes
+- keep the lane fail-closed by logging policy concerns per row
+- provide a clear next gate: confirm policy risk before any migration planning
+
+### C
+
+- Cohort C branch/scan/live preview artifacts
+- this new operator packet extension doc plus the fixture
+ 
+### S
+
+- preview helper and CLI exist; this extension simply clarifies evidence packaging
+- each candidate remains tied to `review_first_population_scan`
+- operators must reference the fixture when running follow-up triage
+
+### L
+
+1. produce a broader sample from the existing non-GHG/missing `P459` selector
+2. package the sample into the operator packet fixture with hold metadata and evidence links
+3. refer to the fixture in CLI/packet notes so the evidence remains reproducible
+
+### P
+
+- extend the fixture to include `reference_anchor`, `qualifier_hint`, and
+  `operator_hold_reason` for each candidate
+- require the operator packet to cite the fixture hash plus CLI command that
+  produced it
+- confirm each row remains under `promotion_guard: hold`
+
+### G
+
+- no automation claims; the packet is for operator review only
+- each row documents why the hold remains (`preview_hold_reason` plus
+  `operator_hold_reason`)
+- keep policy-risk gate `review_first_population_scan`
+
+### F
+
+- this is a documentation/evidence step; any further automation requires
+  explicit bridge-out guidance in future docs
+
+## Operator Notes
+
+1. Use the fixture to inspect reference anchors before updating classification logs.
+2. Keep `promotion_guard: hold` until a second reviewer confirms the policy risk is mitigated.
+3. Log CLI execution (`sensiblaw wikidata cohort-c-operator-packet`) as part of the fix-it review so the packet ties back to the documented fixture.
+
+## Runtime Seam
+
+- The new helper `build_nat_cohort_c_operator_evidence_packet` (see `src/ontology/wikidata_cohort_c_operator_evidence.py`)
+  deterministically materializes this richer evidence packet from any Cohort C preview payload.
+- Use `sensiblaw wikidata cohort-c-operator-evidence` to rerun the preview helper, regenerate the fixture, and append the packet hash so operators can confirm the data slice.
+- Run `sensiblaw wikidata cohort-c-operator-report` (or point it at the generated evidence packet via `--input`) to materialize the derived hold/reference summary that operators cite in downstream review logs.
+- Run `sensiblaw wikidata cohort-c-operator-report-batch --inputs <file1> <file2> ...` to merge several evidence packets into one batch summary, keeping every candidate clearly held under the same gating semantics.
+- The CLI command shares the same fail-closed gate (`review_first_population_scan`) and respects the `promotion_guard: hold` semantics so the evidence remains a review artifact.

--- a/docs/planning/wikidata_nat_cohort_c_operator_index_20260406.md
+++ b/docs/planning/wikidata_nat_cohort_c_operator_index_20260406.md
@@ -1,0 +1,20 @@
+# Wikidata Nat Cohort C Operator Index
+
+Date: 2026-04-06
+
+## Purpose
+
+The Ptolemy lane’s next step is to produce a deterministic operator index over the broader Cohort C evidence slices so governance reviewers can compare qualifiers and references without promoting the lane. The index summarizes hold reasons, reference anchors, and candidate-level gates while preserving the failure posture (`promotion_guard: hold`).
+
+## Inputs
+
+- Evidence packets such as `tests/fixtures/wikidata/wikidata_nat_cohort_c_operator_evidence_packet_20260404.json`
+- Ptolemy evidence fixture `tests/fixtures/wikidata/wikidata_nat_cohort_c_ptolemy_evidence_sample_20260405.json`
+- The helper `build_nat_cohort_c_operator_index` in `src/ontology/wikidata_cohort_c_operator_index.py`
+
+## Operator Guidance
+
+- Run the helper after batch reporting to produce an index that maps reference anchors to all qualifier hints seen on nearby policy-risk candidates.
+- Share the index alongside the batch report so reviewers can quickly scan where hold reasons concentrate and how qualifiers spread while a gate remains closed.
+- No automation claims are made; rerun live preview if candidate populations shift before reusing the index.
+- Operators can now run `sensiblaw wikidata cohort-c-operator-digest --inputs <packet1> <packet2> ...` to materialize a governance digest that aggregates hold reasons and reference qualifier penetration across indexes while keeping every row under `promotion_guard: hold`.

--- a/docs/planning/wikidata_nat_cohort_c_population_scan_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_c_population_scan_20260402.md
@@ -55,6 +55,8 @@ Cohort B/D/E.
 - the live population scan gate remains fail-closed and review-first
 - live-query failure is surfaced as an explicit unavailable state rather than
   raising into a silent retry loop
+- the preview is now packaged into an operator-facing review packet that makes
+  the candidate set, triage prompts, and hold/review decision explicit
 
 ### L
 
@@ -104,4 +106,5 @@ be verified during the scan.
 - `review_first_population_scan` (documented candidate set)
 - `review_first_population_scan_ready` (runtime normalizer surface)
 - `review_first_population_scan_live_preview` (bounded live helper surface)
+- `review_first_population_scan_operator_packet` (review packet surface)
 - future packetized review surface once the scan yields reproducible rows

--- a/docs/planning/wikidata_nat_cohort_c_population_scan_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_c_population_scan_20260402.md
@@ -8,6 +8,9 @@ Advance the non-GHG-protocol / missing `determination method (P459)` lane toward
 its first review-first population scan so the policy-risk cohort is bound into
 the repo rather than remaining an abstract branch note.
 
+The runtime now has a bounded Cohort C scan normalizer for the pinned sample
+fixture, but the live population scan gate remains unopened.
+
 This artifact stays within Cohort C: it reuses the migration mapping plan from
 `wikidata_nat_wdu_sandbox_migration_mapping_20260401.md` and the pinned branch
 state from `wikidata_nat_cohort_c_branch_20260401.md` and does not reach into
@@ -45,13 +48,15 @@ Cohort B/D/E.
 
 - Cohort C selection rule is already pinned
 - the sandbox page defines the qualifier/reference expectations
-- no actual population scan has run yet
+- no actual live population scan has run yet
+- the runtime scan normalizer exists for the pinned sample fixture
 
 ### L
 
 1. capture the policy-risk branch state (`branch_pinned`)
 2. plan a first review-first population scan (this document)
-3. generate per-statement scan results and hold them in a review-only surface
+3. normalize the pinned sample fixture into a review-first Cohort C surface
+4. generate per-statement scan results and hold them in a review-only surface
 
 ### P
 
@@ -92,5 +97,5 @@ be verified during the scan.
 ## Next Gates
 
 - `review_first_population_scan` (documented candidate set)
+- `review_first_population_scan_ready` (runtime normalizer surface)
 - future packetized review surface once the scan yields reproducible rows
-

--- a/docs/planning/wikidata_nat_cohort_c_population_scan_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_c_population_scan_20260402.md
@@ -1,0 +1,96 @@
+# Wikidata Nat Cohort C Population Scan Plan
+
+Date: 2026-04-02
+
+## Purpose
+
+Advance the non-GHG-protocol / missing `determination method (P459)` lane toward
+its first review-first population scan so the policy-risk cohort is bound into
+the repo rather than remaining an abstract branch note.
+
+This artifact stays within Cohort C: it reuses the migration mapping plan from
+`wikidata_nat_wdu_sandbox_migration_mapping_20260401.md` and the pinned branch
+state from `wikidata_nat_cohort_c_branch_20260401.md` and does not reach into
+Cohort B/D/E.
+
+## Inputs
+
+- `SensibLaw/docs/planning/wikidata_nat_wdu_sandbox_migration_mapping_20260401.md`
+- `SensibLaw/docs/planning/wikidata_nat_cohort_c_branch_20260401.md`
+- `SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_c_population_scan_20260402.json`
+
+## ZKP Frame
+
+### O
+
+- Nat lane reviewers
+- ontology workgroup reviewers
+- Cohort C policy-risk branch surface
+  
+### R
+
+- conduct a bounded extraction of statements where `P459` is missing or not
+  the GHG protocol
+- capture a short set of candidate rows that can be reviewed before any
+  execution claim
+- record the scan plan so it can be re-run with real data
+
+### C
+
+- the existing Cohort C branch artifact
+- the sandbox migration mapping note that defines policy-risk families
+- this plan document plus the attached population-scan fixture
+
+### S
+
+- Cohort C selection rule is already pinned
+- the sandbox page defines the qualifier/reference expectations
+- no actual population scan has run yet
+
+### L
+
+1. capture the policy-risk branch state (`branch_pinned`)
+2. plan a first review-first population scan (this document)
+3. generate per-statement scan results and hold them in a review-only surface
+
+### P
+
+- run the `non_ghg_protocol_or_missing_p459` selection rule against the `P5991`
+  source fixture, filter the results, and persist a review-only candidate set
+- ensure each candidate records whether `P459` was absent or present but
+  non-GHG, plus a short annotation of its qualifier shape
+
+### G
+
+- stay fail-closed: do not pretend this scan is a migration step, just a
+  discovery artifact
+- keep the review-first gate (next gate: `review_first_population_scan`)
+
+### F
+
+- Cohort C exists only as a policy branch; this artifact begins the work
+  toward populating it with reviewable candidates
+
+## Candidate Summary
+
+The attached fixture lists a small, bounded sample of statements flagged by the
+selection rule. Each row captures the tabular key (`qid`, `label`), the
+`p459_status` (missing vs non-GHG), and the qualifier/reference shape that must
+be verified during the scan.
+
+## First Review-First Scan Steps
+
+1. Run the `non_ghg_protocol_or_missing_p459` selector on the `P5991` statements
+   from `wiki_revision_nat_wdu_sandbox_p5991_p14143_20260401.json`.
+2. For each row, record the candidate `qid`, label, and whether `P459` is
+   missing or not the GHG protocol in the lane-local fixture.
+3. Surface the qualifier/reference annotations alongside the scan results so
+   reviewers can focus on policy risk.
+4. Use this document plus fixture to steer the first review-first inspection
+   before granting any classification or export gate.
+
+## Next Gates
+
+- `review_first_population_scan` (documented candidate set)
+- future packetized review surface once the scan yields reproducible rows
+

--- a/docs/planning/wikidata_nat_cohort_c_population_scan_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_c_population_scan_20260402.md
@@ -9,7 +9,8 @@ its first review-first population scan so the policy-risk cohort is bound into
 the repo rather than remaining an abstract branch note.
 
 The runtime now has a bounded Cohort C scan normalizer for the pinned sample
-fixture, but the live population scan gate remains unopened.
+fixture and a bounded live scan preview helper that uses the same selection
+rule while keeping the live population scan gate fail-closed.
 
 This artifact stays within Cohort C: it reuses the migration mapping plan from
 `wikidata_nat_wdu_sandbox_migration_mapping_20260401.md` and the pinned branch
@@ -50,6 +51,10 @@ Cohort B/D/E.
 - the sandbox page defines the qualifier/reference expectations
 - no actual live population scan has run yet
 - the runtime scan normalizer exists for the pinned sample fixture
+- the bounded live scan preview helper now exists for the same selection rule
+- the live population scan gate remains fail-closed and review-first
+- live-query failure is surfaced as an explicit unavailable state rather than
+  raising into a silent retry loop
 
 ### L
 
@@ -98,4 +103,5 @@ be verified during the scan.
 
 - `review_first_population_scan` (documented candidate set)
 - `review_first_population_scan_ready` (runtime normalizer surface)
+- `review_first_population_scan_live_preview` (bounded live helper surface)
 - future packetized review surface once the scan yields reproducible rows

--- a/docs/planning/wikidata_nat_cohort_c_population_scan_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_c_population_scan_20260402.md
@@ -107,4 +107,5 @@ be verified during the scan.
 - `review_first_population_scan_ready` (runtime normalizer surface)
 - `review_first_population_scan_live_preview` (bounded live helper surface)
 - `review_first_population_scan_operator_packet` (review packet surface)
+- CLI entrypoint: `sensiblaw wikidata cohort-c-operator-packet`
 - future packetized review surface once the scan yields reproducible rows

--- a/docs/planning/wikidata_nat_cohort_c_ptolemy_evidence_20260405.md
+++ b/docs/planning/wikidata_nat_cohort_c_ptolemy_evidence_20260405.md
@@ -1,0 +1,24 @@
+# Wikidata Nat Cohort C Ptolemy Evidence Slice
+
+Date: 2026-04-05
+
+## Purpose
+
+Push the Ptolemy lane by recording a broader operator evidence slice for Cohort C derived from multiple live-preview rows, keeping the lane review-first and fail-closed. This note clarifies how the new sample should be treated, how it feeds into the existing CLI reporter/batch workflows, and what operators must log.
+
+## Inputs
+
+- Extended evidence fixture `tests/fixtures/wikidata/wikidata_nat_cohort_c_operator_evidence_packet_20260404.json`
+- New broader fixture `tests/fixtures/wikidata/wikidata_nat_cohort_c_ptolemy_evidence_sample_20260405.json`
+- CLI entrypoints: `sensiblaw wikidata cohort-c-operator-evidence` and `sensiblaw wikidata cohort-c-operator-report-batch`
+
+## Ptolemy Operator Surface
+
+- The new fixture mirrors a broader live-preview slice (3+ candidates) with per-candidate `reference_anchor`, `preview_hold_reason`, `operator_hold_reason`, and `qualifier_hint` statements.
+- Operators feed the evidence fixture into `sensiblaw wikidata cohort-c-operator-report-batch` along with previously generated packets to produce an aggregated hold/reference summary that always stays within the review-first gate.
+- The aggregate summary can be published as governance evidence; every row retains `promotion_guard: hold` and `hold_gate: review_first_population_scan`.
+
+## Live-Preview/Runtime Boundary
+
+- This sample is derived from deterministic runs of the existing live preview helper; the fixture is a snapshot of those rows, so rerunning the preview should reproduce the candidate set when the query results are stable.
+- No automation or migration claims are made; operators must rerun the preview helper if they suspect the dataset has drifted before reusing the batch report.

--- a/docs/planning/wikidata_nat_cohort_d_operator_report_batch_surface_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_d_operator_report_batch_surface_20260402.md
@@ -1,0 +1,45 @@
+# Wikidata Nat Cohort D Operator Report Batch Surface
+
+Date: 2026-04-02
+
+## Purpose
+
+Broaden Cohort D operator review evidence from single-surface reporting to a
+deterministic multi-case batch summary.
+
+This remains non-executing and fail-closed.
+
+## Runtime Helper
+
+- `SensibLaw/src/ontology/wikidata_nat_cohort_d_review.py`
+- builder:
+  `build_wikidata_nat_cohort_d_operator_report_batch(...)`
+
+## CLI Surface
+
+- `sensiblaw wikidata cohort-d-operator-report-batch --input <batch_input.json> [--output <batch_report.json>]`
+
+## Pinned Artifacts
+
+- input:
+  `SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_report_batch_input_20260402.json`
+- output:
+  `SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_report_batch_20260402.json`
+
+Current bounded output:
+
+- batch id: `cohort_d_operator_batch_20260402`
+- case count: `2`
+- readiness counts:
+  - `review_queue_ready`: `1`
+  - `review_queue_incomplete`: `1`
+- decision: `review`
+- promotion allowed: `false`
+
+## Governance
+
+- fail-closed batch summary only
+- no direct migration execution
+- no checked-safe promotion from missing `instance of` alone
+- blocked signals are surfaced when any case is incomplete
+

--- a/docs/planning/wikidata_nat_cohort_d_operator_report_surface_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_d_operator_report_surface_20260402.md
@@ -1,0 +1,39 @@
+# Wikidata Nat Cohort D Operator Report Surface
+
+Date: 2026-04-02
+
+## Purpose
+
+Add a bounded, non-executing report layer above the Cohort D operator/reviewer
+queue so operators can consume a compact decision surface without changing lane
+governance.
+
+## Runtime Helper
+
+- `SensibLaw/src/ontology/wikidata_nat_cohort_d_review.py`
+- builder:
+  `build_wikidata_nat_cohort_d_operator_report(...)`
+
+## CLI Surface
+
+- `sensiblaw wikidata cohort-d-operator-report --input <operator_review.json> [--output <operator_report.json>]`
+
+## Pinned Artifact
+
+- `SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_report_20260402.json`
+
+Current bounded output:
+
+- readiness: `review_queue_ready`
+- decision: `review`
+- promotion allowed: `false`
+- queue size: `2`
+- blocked signals: `[]`
+
+## Governance
+
+- fail-closed
+- non-executing
+- no direct migration execution
+- no checked-safe promotion from missing `instance of` alone
+

--- a/docs/planning/wikidata_nat_cohort_d_operator_review_cli_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_d_operator_review_cli_20260402.md
@@ -1,0 +1,36 @@
+# Wikidata Nat Cohort D Operator Review CLI
+
+Date: 2026-04-02
+
+## Purpose
+
+Add a bounded, non-executing CLI surface that materializes the Cohort D
+operator/reviewer queue from a Cohort D type-probing artifact.
+
+## Command
+
+- `sensiblaw wikidata cohort-d-operator-review --input <type_probing.json> [--output <operator_review.json>]`
+
+## Behavior
+
+- reads a Cohort D type-probing surface JSON
+- builds a Cohort D operator/reviewer queue surface
+- emits summary when `--output` is used:
+  - schema version
+  - readiness
+  - queue size
+  - unresolved packet-ref count
+
+## Governance
+
+- fail-closed and non-executing
+- `automation_allowed=false`
+- `can_execute_edits=false`
+- no direct migration execution
+
+## Non-Claims
+
+- this command does not perform reconciliation edits
+- this command does not promote checked-safe rows
+- this command only packages review queue state for operator use
+

--- a/docs/planning/wikidata_nat_cohort_d_operator_review_surface_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_d_operator_review_surface_20260402.md
@@ -1,0 +1,50 @@
+# Wikidata Nat Cohort D Operator/Reviewer Surface
+
+Date: 2026-04-02
+
+## Purpose
+
+Package the Cohort D type-probing artifact into an operator/reviewer queue
+surface while staying fail-closed and non-executing.
+
+This is a bounded packaging layer above the existing type-probing helper.
+
+## Runtime Helper
+
+- `SensibLaw/src/ontology/wikidata_nat_cohort_d_review.py`
+- builder:
+  `build_wikidata_nat_cohort_d_operator_review_surface(...)`
+
+## Pinned Artifact
+
+- `SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_review_surface_20260402.json`
+
+Current bounded output:
+
+- readiness: `review_queue_ready`
+- queue size: `2`
+- unresolved packet refs: `0`
+- execution: disallowed for every queue row
+
+## Queue Semantics
+
+- each queue row includes:
+  - review entity qid
+  - packet id
+  - split plan id
+  - smallest next check
+  - recommended next step
+  - uncertainty flags
+  - priority
+- governance remains explicit:
+  - `automation_allowed=false`
+  - `can_execute_edits=false`
+  - `promotion_guard=hold`
+  - `fail_closed=true`
+
+## Non-Claims
+
+- no direct migration execution
+- no checked-safe promotion from missing `instance of` alone
+- no cohort widening beyond Cohort D
+

--- a/docs/planning/wikidata_nat_cohort_d_review_control_index_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_d_review_control_index_20260402.md
@@ -1,0 +1,45 @@
+# Wikidata Nat Cohort D Review Control Index
+
+Date: 2026-04-02
+
+## Purpose
+
+Add a broader Cohort D review-control surface that aggregates multiple Cohort D
+batch reports while preserving explicit blockers and hold signals.
+
+This is a deterministic index layer above batch reporting.
+
+## Runtime Helper
+
+- `SensibLaw/src/ontology/wikidata_nat_cohort_d_review.py`
+- builder:
+  `build_wikidata_nat_cohort_d_review_control_index(...)`
+
+## CLI Surface
+
+- `sensiblaw wikidata cohort-d-review-control-index --input <index_input.json> [--output <index.json>]`
+
+## Pinned Artifacts
+
+- input:
+  `SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_d_review_control_index_input_20260402.json`
+- output:
+  `SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_d_review_control_index_20260402.json`
+
+Current bounded output:
+
+- index id: `cohort_d_review_control_index_20260402`
+- batch count: `2`
+- readiness:
+  - `review_queue_ready`: `1`
+  - `review_queue_incomplete`: `1`
+- decision: `review`
+- promotion allowed: `false`
+- hold signals include incomplete batch and unresolved packet refs
+
+## Governance
+
+- fail-closed and non-executing
+- no direct migration execution
+- no checked-safe promotion from missing `instance of` alone
+

--- a/docs/planning/wikidata_nat_cohort_d_review_lane_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_d_review_lane_20260402.md
@@ -1,0 +1,37 @@
+# Wikidata Nat Cohort D Review Lane
+
+Date: 2026-04-02
+
+## Lane Assignment
+
+- Lane: Nat Cohort D only
+- Scope: statements flagged in `SensibLaw/docs/planning/wikidata_nat_wdu_sandbox_migration_mapping_20260401.md`
+  under **Cohort D: subjects with no `instance of`** (1395 statements in the sandbox slice).
+
+## Purpose
+
+Frame Cohort D as a review-first bucket that reuses the Nat packet grammar while explicitly deferring migration execution. The lane should remain low-risk, disjoint from Cohorts B/C/E, and keep governance gates focused on typing clarity before promotion.
+
+## Packet Shape
+
+- Lane-local reviewers craft packets with the standard Nat reviewer-packet fields but restrict `progress_claim` to `reviewable_packet` and include a `promotion_guard` set to `hold` by default.
+- Required special notes:
+  - `subject_typing_gap`: reason why the subject lacks `instance of`.
+  - `suggested_typing_anchor`: any adjacent surface (related statements, qualifiers, references) that could supply typing candidates.
+  - `scan_plan_note`: enumerated checks (e.g., "confirm subclass path via P279", "inspect same-namespace summaries") that reviewers should cover before re-raising the packet.
+- `governance_flags` continue to include `automation_allowed:false` and `fail_closed` to signal this lane stays review-controlled.
+
+## Gate and Next Step
+
+The next gate for Cohort D is a dedicated typing-resolution review step:
+
+1. Confirm the subject truly lacks `instance of` by verifying the sandbox snapshot and adjacent query hits.
+2. Document any plausible type candidates in `suggested_typing_anchor`.
+3. Once a reviewer has enumerated at least one typing candidate and assessed references/qualifiers, update `promotion_guard` to `revisit_after_typing` and signal the packet as ready for a lightweight `type-probing scan` that keeps the lane review-first.
+
+`type-probing scan` is a bounded note (markdown or JSON) stored alongside the packet describing which properties or claims were checked; it does not trigger downstream automation but ensures a documented follow-up path.
+
+## Review Guidance
+
+- Keep Cohort D packets isolated from other cohorts: do not reuse the same packet data for B/C/E lanes.
+- Reviewers explicitly log their gating decisions inside the lane-local artifact before any promotion claim, so downstream workloads understand this bucket remains review-first.

--- a/docs/planning/wikidata_nat_cohort_d_type_probing_surface_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_d_type_probing_surface_20260402.md
@@ -1,0 +1,48 @@
+# Wikidata Nat Cohort D Type-Probing Surface
+
+Date: 2026-04-02
+
+## Purpose
+
+Turn Cohort D (subjects with no `instance of`) into a bounded type-probing
+review artifact that remains fail-closed and non-executing.
+
+This tranche extends the Cohort D review lane without changing cohort scope.
+
+## Runtime Helper
+
+- `SensibLaw/src/ontology/wikidata_nat_cohort_d_review.py`
+- builder:
+  `build_wikidata_nat_cohort_d_type_probing_surface(...)`
+
+The builder projects:
+
+- the Cohort D review surface fixture
+- bounded reviewer packets for Cohort D probe rows
+
+into one review-only type-probing artifact.
+
+## Pinned Artifact
+
+- `SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_d_type_probing_surface_20260402.json`
+
+Current bounded output:
+
+- artifact status: `review_only_ready`
+- probe rows: `2` (`Q738421`, `Q1785637`)
+- unresolved packet refs: `0`
+- governance: `automation_allowed=false`, `can_execute_edits=false`,
+  `promotion_guard=hold`, `fail_closed=true`
+
+## Non-Claims
+
+- no direct migration execution
+- no checked-safe promotion from missing `instance of` alone
+- no cross-cohort expansion (B/C/E remain out of scope)
+
+## Next Gate
+
+- keep gate as `type_probing_scan_review_only`
+- if packet refs are missing, artifact status must remain
+  `review_only_incomplete` and surface unresolved refs explicitly
+

--- a/docs/planning/wikidata_nat_cohort_e_diagnostics_cli_20260403.md
+++ b/docs/planning/wikidata_nat_cohort_e_diagnostics_cli_20260403.md
@@ -1,0 +1,34 @@
+# Cohort E Diagnostics CLI
+
+Date: 2026-04-03
+
+## Purpose
+
+Provide a bounded operational surface so reviewers can regenerate the Cohort E
+diagnostic report from the sample axis fixture without touching shared scripts.
+
+## Usage
+
+```
+sensiblaw cohort-e-diagnostics \
+  --samples SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_e_split_axis_sample_20260403.json \
+  --output SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_e_diagnostic_report_20260403.json
+```
+
+This command reruns the helper, keeps the lane hold-only, and reproduces the
+fixture for auditing. Use `--batch` to emit a series of diagnostic reports
+(simulating repeated review runs) and compare them against
+`SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_e_diagnostic_batch_report_20260403.json`.
+The summary file now records aggregated disagreement counts (see
+`SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_e_diagnostic_summary_20260403.json`)
+so repeated batch runs yield a broader evidence surface. Pass multiple summary
+paths with `--summaries` and provide `--index-output` to produce the lane-local
+summary index fixture at `SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_e_summary_index_20260403.json`.
+The `--summary-output` option now writes grouped disagreement tallies (see
+`SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_e_diagnostic_summary_20260403.json`)
+so reviewers can quickly see axis-level pressure.
+
+## Governance
+
+- the CLI is explicit that Cohort E is still review-first and non-promoting
+- outputs stay marked `non_authoritative` and retain the `hold_reason`

--- a/docs/planning/wikidata_nat_cohort_e_reconciliation_scan_plan_20260403.md
+++ b/docs/planning/wikidata_nat_cohort_e_reconciliation_scan_plan_20260403.md
@@ -1,0 +1,41 @@
+# Cohort E Reconciliation Scan Plan
+
+Date: 2026-04-03
+
+## Purpose
+
+Turn Cohort E from framing into a bounded review-first helper lane by
+pinning the diagnostics surface reviewers need when typing remains
+unreconciled.
+
+## Scope
+
+- this note stays inside Cohort E: `unreconciled instance of`
+- it documents the diagnostics helper, not any shared roadmaps or
+  execution lanes
+- the lane remains `review_only`
+
+## Plan
+
+1. capture the `split://` plans for the 142 Cohort E statements
+2. normalize their merged split axes so we have a canonical axis map per row
+3. compare each row’s axes to the axes already solved by other cohorts
+4. record agreement/disagreement per axis plus the suggested action
+5. emit a bounded report that reviewers can inspect before any reconciliation
+   (the `wikidata_nat_cohort_e_split_axis_sample_20260403.json` fixture captures
+   two canonical axis maps as a reference)
+
+## Fail-Closed Posture
+
+- only emit the diagnostics; every row stays in Cohort E until a reconciliation
+  path is documented
+- no row is promoted or migrated without human confirmation of resolved typing
+
+## Sample Fixture
+
+- `SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_e_split_axis_sample_20260403.json`
+  (a tiny subset of candidate axis maps) can seed the helper and keep
+  reviewers aligned.
+- pinned diagnostics report fixture:
+  `SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_e_diagnostic_report_20260403.json`
+  shows how the helper reports hold-first disagreement results.

--- a/docs/planning/wikidata_nat_cohort_e_unreconciled_instanceof_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_e_unreconciled_instanceof_20260402.md
@@ -50,6 +50,15 @@ Pinned next gate:
 
 - `review_first_reconciliation_scan`
 
+Supporting runtime helper:
+
+- gather the `split://` plans for Cohort E subjects and normalize their
+  split axes
+- compare unreconciled typing axes against known reconciled axes to
+  surface agreement/disagreement diagnostics
+- emit a report that keeps each row in hold until an explicit reconciliation
+  path is documented
+
 Gate intent:
 
 - classify unreconciled typing causes before any migration decision
@@ -67,6 +76,9 @@ Gate exit condition:
 - Cohort E is not an execution lane.
 - No unreconciled `instance of` row should be treated as checked-safe by default.
 - Reconciliation deficit is a first-class reason to hold.
+- The diagnostics helper documented in `wikidata_nat_cohort_e_reconciliation_scan_plan_20260403.md`
+  emits axis-level agreements/disagreements plus `hold_reason` so reviewers see
+  exactly why a row stays in Cohort E.
 
 ## Compact ZKP
 
@@ -102,4 +114,3 @@ Gate exit condition:
 ### F
 
 - unresolved typing prevents safe cohort promotion until reconciled or held
-

--- a/docs/planning/wikidata_nat_cohort_e_unreconciled_instanceof_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_e_unreconciled_instanceof_20260402.md
@@ -1,0 +1,105 @@
+# Wikidata Nat Cohort E: Unreconciled `instance of`
+
+Date: 2026-04-02
+
+## Change Class
+
+Standard change.
+
+## Purpose
+
+Make Nat Cohort E explicit as a bounded governance/reconciliation-deficit
+bucket and pin the next gate as review-first.
+
+This artifact is lane-local to Cohort E.
+
+## Scope
+
+In scope:
+
+- Cohort E only: subjects whose `instance of` could not be reconciled
+- explicit governance posture for this cohort
+- one review-first next gate
+
+Out of scope:
+
+- Cohort B, Cohort C, Cohort D
+- execution expansion
+- shared progress counters
+
+## Source Alignment
+
+Source mapping note:
+
+- `SensibLaw/docs/planning/wikidata_nat_wdu_sandbox_migration_mapping_20260401.md`
+
+Inherited Cohort E bucket:
+
+- `142` statements with unreconciled `instance of`
+
+## Cohort Definition
+
+- lane id: `wikidata_nat_cohort_e_unreconciled_instanceof`
+- cohort type: `governance_reconciliation_deficit`
+- expected handling: `review_only`
+- migration default: `hold`
+
+## Review-First Next Gate
+
+Pinned next gate:
+
+- `review_first_reconciliation_scan`
+
+Gate intent:
+
+- classify unreconciled typing causes before any migration decision
+- keep statement-bundle semantics visible while typing remains unreconciled
+- surface unresolved typing as explicit review pressure, never silent fallback
+
+Gate exit condition:
+
+- each row is either:
+  - mapped to a reconciled typing path and promoted to a different cohort, or
+  - retained in Cohort E with an explicit hold rationale
+
+## Governance
+
+- Cohort E is not an execution lane.
+- No unreconciled `instance of` row should be treated as checked-safe by default.
+- Reconciliation deficit is a first-class reason to hold.
+
+## Compact ZKP
+
+### O
+
+- Nat lane reviewers
+- ontology-group reviewers
+
+### R
+
+- isolate unreconciled typing into one explicit review bucket
+
+### C
+
+- this lane-local Cohort E artifact only
+
+### S
+
+- Cohort E is already identified in the Nat mapping note as 142 rows
+
+### L
+
+- unreconciled typing -> review-first scan -> reconcile-or-hold
+
+### P
+
+- pin one explicit review-first gate for Cohort E
+
+### G
+
+- no promotion from unreconciled typing without reconciliation path
+
+### F
+
+- unresolved typing prevents safe cohort promotion until reconciled or held
+

--- a/docs/planning/wikidata_nat_end_product_and_tiered_automation_20260401.md
+++ b/docs/planning/wikidata_nat_end_product_and_tiered_automation_20260401.md
@@ -6,7 +6,13 @@ Date: 2026-04-01
 
 State the full intended end product for Nat's `P5991 -> P14143` lane in plain
 operational terms, and make explicit that full pipeline coverage is the real
-goal, not blind full-population execution.
+goal. The long-term P0 moonshot is a blind migration bot, but the current lane
+is the review-and-split workbench that has to earn that level of automation.
+
+Use
+`SensibLaw/docs/planning/wikidata_nat_gap_to_moonshot_program_20260402.md`
+for the explicit staged gap, promotion gates, and roadmap from the current
+review-first posture to that moonshot.
 
 ## Plain-Language End Product
 
@@ -24,10 +30,13 @@ It should let reviewers:
 
 The product is therefore:
 
-- not a blind migration bot
+- not a blind migration bot yet
 - not a vague queue of hard rows
 - but a governed backlog-processing system with different lanes for different
   levels of certainty
+
+The blind migration bot is the P0 moonshot for the lane, but it sits on top of
+the review-and-split workbench rather than replacing it.
 
 Operationally, that also means Nat can be run with multiple disjoint review
 lanes at once when the surface is wide enough: one nonblocking lane per worker
@@ -94,9 +103,18 @@ promote or split safely.
 ### What is not complete
 
 - The wider online lane is not yet a broad direct execution lane.
-- The generic reviewer packet contract/parser/follow-receipt lane is not yet
-  implemented.
-- Cohort C remains a separate review-first branch.
+- The reviewer-packet lane is real, but its remaining leverage is grounding
+  depth and non-company structural breadth rather than more packet shape.
+- Cohorts B, C, D, and E remain review-first branches rather than promoted
+  automation families.
+- the automation-graduation ceiling remains at Level 1, not yet at broad
+  family-scoped automation.
+- several moonshot-gap branches now have reproducible operator/report surfaces
+  and CLIs, but those improve auditability and repeatability rather than
+  changing the current automation tier by themselves.
+- those same branches now also have broader operator/governance indexes over
+  repeated batches or evidence snapshots, but those still improve control and
+  auditability rather than changing the automation tier by themselves.
 
 ## ZKP Frame
 
@@ -117,6 +135,7 @@ promote or split safely.
 - split plans
 - split verification
 - next reviewer-packet lane
+- grounding-depth, cohort-review, and graduation operator/report surfaces
 
 ### S
 
@@ -136,16 +155,21 @@ promote or split safely.
 
 - design for full pipeline coverage across all rows, while only automating the
   rows that repeatedly justify it
+- treat the blind migration bot as the P0 moonshot after the review/split
+  workbench proves the safe lanes are stable enough to automate further
 
 ### G
 
 - full backlog coverage is allowed
 - blind full-population execution is not the target
+- blind migration bot automation is the moonshot, not the current default
 
 ### F
 
-- the main missing piece is the generic reviewer-packet layer that compresses
-  hard review cases without overclaiming authority
+- the main missing pieces are:
+  - stronger grounded evidence on hard rows
+  - broader structural coverage across non-company cohorts
+  - measured promotion evidence from the new operator/report surfaces
 
 ## ITIL Reading
 
@@ -228,10 +252,12 @@ review-first lanes rather than a single monolithic worker loop.
 
 It is:
 
-1. generic reviewer-packet contract
-2. bounded parser
-3. bounded follow receipts
-4. packet attachment to held Nat split rows
+1. grounding depth on representative hard packets
+2. structural breadth on Cohort C and the other non-company lanes
+3. measured batch/report evidence across those lanes
+4. explicit automation graduation criteria with repeated-run evidence
+5. only then additional packet attachment when a genuinely new split shape
+   appears
 
 That is the missing layer that makes the wider review-and-split goal truly
 usable at scale.

--- a/docs/planning/wikidata_nat_gap_to_moonshot_program_20260402.md
+++ b/docs/planning/wikidata_nat_gap_to_moonshot_program_20260402.md
@@ -1,0 +1,416 @@
+# Wikidata Nat Gap To Moonshot Program
+
+Date: 2026-04-02
+
+## Purpose
+
+Make the current gap between the review-first Nat lane and the long-term blind
+migration-bot moonshot explicit, measurable, and governable.
+
+The point of this note is not to relabel the current lane as already solved.
+The point is to say exactly what still has to be true before blind execution is
+honest, and what the next priorities are to close that gap.
+
+Companion gate specification:
+
+- `SensibLaw/docs/planning/wikidata_nat_automation_graduation_criteria_20260402.md`
+- `SensibLaw/tests/fixtures/wikidata/wikidata_nat_automation_graduation_criteria_20260402.json`
+
+## Current State
+
+The lane already has:
+
+- bounded migration-pack classification
+- split-plan generation and verification
+- checked-safe export and after-state verification for bounded direct-safe rows
+- reviewer packets with bounded follow receipts and semantic sidecar helpers
+- Cohort C as a separate review-first live-preview and operator-packet lane
+- a bounded grounding-depth helper for representative hard Nat packets
+- a bounded Cohort B review bucket plus operator-packet helper
+- a bounded Cohort D type-probing surface
+- a bounded Cohort E diagnostics helper
+- a fail-closed automation-graduation evaluator
+- operator-facing surfaces above several of those helpers:
+  - grounding-depth attachment surface
+  - grounding-depth batch artifact
+  - grounding-depth CLI plus batch review-packet report
+  - grounding-depth evidence report
+  - Cohort B operator packet
+  - Cohort B operator queue
+  - Cohort B operator report
+  - Cohort B operator batch report
+  - richer Cohort C operator evidence packet
+  - Cohort C operator report
+  - Cohort C operator report batch plus CLI
+  - Cohort C broader measured evidence sample
+  - Cohort D operator review queue
+  - Cohort D operator report plus CLI
+  - Cohort D operator report batch plus CLI
+  - Cohort E diagnostics CLI/report
+  - Cohort E diagnostics batch report
+  - Cohort E grouped diagnostics summary
+  - automation graduation report builder
+  - automation graduation CLI
+  - automation graduation batch evaluation CLI
+  - automation graduation repeated-run evidence report
+  - grounding-depth comparison/index report over multiple batches
+  - Cohort B operator evidence index
+  - Cohort C operator index over broader real-slice evidence
+  - Cohort D review-control index over multiple operator batches
+  - Cohort E aggregated disagreement/summary index
+  - automation graduation governance index over repeated evidence snapshots
+
+The lane does not yet have:
+
+- broad measured direct-safe yield across the wider backlog
+- claim-boundary grounding strong enough to remove reviewer dependence for hard
+  rows
+- stable policy handling across the non-company cohorts
+- quantitative evidence that blind execution would be safer than reviewer-gated
+  execution
+- broader operator/governance indexes that stay stable under repeated batch
+  runs and disagreement clustering
+
+## Moonshot Definition
+
+The P0 moonshot is:
+
+- a blind migration bot that can process the full `P5991 -> P14143` backlog
+  without per-row human review while staying within the repo's provenance,
+  qualifier, reference, and after-state governance boundaries
+
+That moonshot is only valid if it can do all of the following at production
+scale:
+
+- classify rows correctly
+- preserve qualifiers and references
+- decompose split-heavy rows correctly
+- abstain or hold on policy-risk cases
+- verify after-state automatically
+- expose enough evidence for audit after the fact
+
+## Gap To Moonshot
+
+The current gap is not "missing one more parser feature." The current gap is
+the distance between a strong review-and-split workbench and a trustworthy
+blind executor.
+
+That gap currently has five major classes:
+
+1. Evidence grounding gap
+   The packets and semantic sidecars reduce uncertainty, but they do not yet
+   ground enough revision-locked evidence to support broad blind promotion.
+
+2. Claim-boundary gap
+   The lane can surface likely split axes and candidate boundaries, but it does
+   not yet prove that those boundaries are stable enough for wide blind
+   execution.
+
+3. Coverage gap
+   Packetization, split verification, and safe verification are real, but they
+   do not yet cover enough of the structurally different backlog families to
+   justify moonshot-level trust.
+
+4. Policy-risk gap
+   Cohorts C, D, and E are still review-first branches. They are important
+   because they expose the cases most likely to break blind execution.
+
+5. Quality-management gap
+   The repo still needs explicit promotion gates and stop conditions that say
+   when a lane may graduate from review-first to semi-automated to blind.
+
+## Staged Program
+
+### Stage 0: Current
+
+- review-first
+- split-first
+- fail-closed
+- bounded safe automation only
+
+### Stage 1: Grounded Review Workbench
+
+Goal:
+
+- make reviewer packets strong enough that difficult rows are decided from a
+  compact evidence bundle rather than manual re-research
+
+Exit criteria:
+
+- more revision-locked evidence in packets
+- stronger claim-boundary mapping
+- cross-source agreement/disagreement surfaces on representative hard rows
+
+### Stage 2: Semi-Automated Split Execution
+
+Goal:
+
+- let the system propose, verify, and package split plans tightly enough that
+  human approval becomes fast and narrow
+
+Exit criteria:
+
+- representative split families verified repeatedly
+- reviewer packet plus split verifier covers the dominant hard-row patterns
+- policy-risk branches remain explicit and bounded
+
+### Stage 3: Measured Broad Automation
+
+Goal:
+
+- prove that some larger backlog families can move with no per-row review
+
+Exit criteria:
+
+- stable direct-safe yield on broad samples
+- stable after-state verification
+- explicit false-positive budget small enough to justify blind action on that
+  family
+
+### Stage 4: Blind Migration Bot Moonshot
+
+Goal:
+
+- full-lane blind execution with auditability and abstention
+
+Exit criteria:
+
+- broad family coverage
+- explicit hold/abstain reliability
+- production-grade quality and risk controls
+
+## Immediate Priorities
+
+The next priorities should close the largest moonshot gap, not just broaden the
+same company-heavy pattern.
+
+1. Ground the reviewer packets more deeply.
+   Focus on revision-locked evidence depth, not more shallow packet shape.
+
+2. Broaden across structurally different cohorts.
+   Cohort C is the highest-yield next axis because it changes the decision
+   regime instead of repeating the same company-family split pattern.
+
+3. Turn current helper lanes into promotion evidence.
+   Follow depth, claim boundaries, cross-source alignment, reviewer actions,
+   and bounded variant comparison should justify or block promotion decisions,
+   not just exist as diagnostics.
+
+4. Define graduation gates.
+   The repo needs explicit criteria for moving a lane from:
+   - review-first
+   - to semi-automated split
+   - to measured blind execution
+
+5. Keep parallelism lane-shaped.
+   When the work is broad enough, assign one nonblocking lane per worker, but
+   only when the lanes are genuinely disjoint and useful.
+
+## Current Roadmap To Close The Gap
+
+### Priority 1: Grounding
+
+- deepen revision-locked evidence receipts on representative Nat packets
+- tighten claim-boundary mapping on split-heavy representative rows
+- improve cross-source agreement/disagreement views for reviewer confidence
+- use `src/ontology/wikidata_grounding_depth.py` as the first executable
+  grounding-depth surface rather than relying on doc-only packet examples
+- attach grounding depth to actual review/operator packets where packet ids and
+  qids align, so reviewers consume the evidence as part of the packet rather
+  than as a separate note
+- prefer batch/report surfaces over one-off packet notes once a helper is
+  stable enough to aggregate multiple representative packets
+- once a batch/report surface exists, prefer a CLI-backed operator path so the
+  evidence surface is reproducible instead of doc-local only
+
+### Priority 2: Structural Breadth
+
+- exercise Cohort C live preview and operator packet on broader live candidates
+- keep Cohorts D and E review-first, but make their backlog shape measurable
+  through explicit helper surfaces
+- use Cohort B operator packets for reconciled non-business classes before
+  widening company-family packet coverage again
+- only expand company-family packet coverage again if a genuinely new split
+  shape appears
+- when a non-company lane already has a helper, prefer converting it into a
+  deterministic operator-facing queue/report surface before widening the lane
+- once a queue/report surface exists, prefer CLI-backed reproducibility over
+  additional prose-only notes
+- once a single-report CLI exists, prefer bounded batch reporting over
+  additional isolated examples
+- once a first batch/report surface exists, prefer broader measured evidence
+  across multiple representative cases rather than new one-off examples
+
+### Priority 3: Promotion Gates
+
+- define measurable lane graduation criteria
+- pin false-positive / abstain / hold expectations
+- keep proposal evaluation reproducible with CLI-backed single-proposal and
+  batch-proposal assessments
+- make safe automation promotion dependent on those criteria
+- use `evaluate_nat_automation_promotion(...)` as the bounded fail-closed
+  promotion checker rather than relying on narrative readiness claims
+- require machine-readable promotion reports when a gate is assessed so later
+  audit does not depend on hand-written summaries
+- where possible, expose those reports through a deterministic operator CLI so
+  promotion assessment can be rerun without ad hoc scripting
+- once single and batch proposal evaluation exist, prefer repeated-run
+  evidence reports over stronger readiness claims
+
+### Priority 4: Moonshot Readiness
+
+- only after the earlier stages are stable, evaluate whether any broad family
+  is ready for blind execution
+
+## ZKP Frame
+
+### O
+
+- Nat and related Wikidata reviewers
+- ITIR as review-packet and evidence-grounding substrate
+- SensibLaw as classification, split, and verification runtime
+
+### R
+
+- close the gap between a governed review workbench and a trustworthy blind
+  migration executor
+
+### C
+
+- migration-pack runtime
+- split-plan and split-verification runtime
+- reviewer packets and semantic sidecars
+- Cohort B/C/D/E review lanes
+
+### S
+
+- strong review-and-split control plane
+- weak basis for broad blind execution
+
+### L
+
+1. review-first
+2. semi-automated split
+3. measured blind-safe family
+4. blind migration bot moonshot
+
+### P
+
+- close the moonshot gap through staged grounding, breadth, and explicit
+  promotion gates rather than by relabeling the current lane as already blind
+  ready
+
+### G
+
+- fail-closed remains the default
+- blind execution must be earned by evidence
+- policy-risk cohorts remain separate until proven otherwise
+
+### F
+
+- the main gap is trustable automation readiness, not lack of one more packet
+  field
+
+## ITIL Reading
+
+- service strategy:
+  move from review-assist service to higher-autonomy execution service only
+  when quality controls are proven
+- change management:
+  use stage gates rather than rhetorical upgrades in automation claims
+
+## ISO 9000 Reading
+
+- quality objective:
+  improve reviewer throughput now while building evidence that automation is
+  actually correct later
+- nonconformity to avoid:
+  claiming automation maturity before the defect picture is understood
+
+## ISO 42001 Reading
+
+- human oversight remains primary until blind action is justified
+- the automation level must stay proportional to evidence quality
+
+## ISO 27001 Reading
+
+- revision locking, bounded receipts, and after-state verification reduce
+  unsafe action from drift or weak evidence
+
+## ISO 27701 Reading
+
+- keep followed-source and packet evidence bounded and auditable
+- do not widen collection scope beyond the narrow review need
+
+## ISO 23894 Reading
+
+- treat blind migration as a higher-risk operating mode that requires explicit
+  controls, residual-risk visibility, and conservative promotion gates
+
+## NIST AI RMF Reading
+
+- govern:
+  define explicit automation graduation criteria
+- map:
+  identify which cohorts carry the largest harm if misclassified
+- measure:
+  quantify safe yield, abstain quality, and split correctness
+- manage:
+  promote only the families that repeatedly meet the controls
+
+## Six Sigma Reading
+
+Primary defects to reduce before moonshot promotion:
+
+- false-safe migration decisions
+- incorrect split boundaries
+- policy-risk rows forced through the wrong lane
+- reviewer packet gaps that hide decisive evidence
+
+## C4 View
+
+### Context
+
+- Wiki proposal and source surfaces provide bounded context.
+- ITIR assembles evidence and reviewer packets.
+- SensibLaw classifies, splits, verifies, and measures promotion readiness.
+- Nat and related reviewers remain the current authority gate.
+
+### Container
+
+- evidence grounding layer
+- packet and sidecar layer
+- migration-pack classification layer
+- split verification layer
+- promotion-gate and after-state verification layer
+
+## PlantUML
+
+```plantuml
+@startuml
+title Nat Gap To Moonshot Program
+
+Component(WORKBENCH, "Review Workbench", "Current review-first lane")
+Component(GROUND, "Evidence Grounding", "Revision-locked receipts + claims")
+Component(SPLIT, "Semi-Automated Split", "Verified split assistance")
+Component(GATES, "Promotion Gates", "Measured graduation criteria")
+Component(MOONSHOT, "Blind Migration Bot", "P0 moonshot")
+
+Rel(WORKBENCH, GROUND, "deepen evidence")
+Rel(GROUND, SPLIT, "support narrower human approval")
+Rel(SPLIT, GATES, "measure promotion readiness")
+Rel(GATES, MOONSHOT, "promote only stable families")
+@enduml
+```
+
+## Immediate Planning Consequence
+
+The next roadmap should not be "more packet shape" and it should not be "more
+company rows by default."
+
+It should be:
+
+1. grounding depth on representative hard packets
+2. structural breadth on Cohort C and the other non-company lanes
+3. explicit automation graduation criteria
+4. only then broader moonshot-readiness claims

--- a/docs/planning/wikidata_nat_grounding_depth_evidence_20260402.md
+++ b/docs/planning/wikidata_nat_grounding_depth_evidence_20260402.md
@@ -1,0 +1,128 @@
+# Wikidata Nat Grounding-Depth Evidence Plan
+
+Date: 2026-04-02
+
+## Purpose
+
+The Nat grounding-depth lane exists to deepen the revision-locked evidence that
+reviewers already rely on for representative hard packets. This note records a
+bounded plan for generating and curating grounded evidence bundles for those
+packets rather than adding yet another packet shape.
+
+## Context
+
+- `SensibLaw/docs/planning/wikidata_nat_gap_to_moonshot_program_20260402.md`
+  calls out evidence grounding as the top gap toward the blind migration moonshot.
+- `SensibLaw/docs/planning/wikidata_nat_review_packet_attachment_coverage_20260401.md`
+  already pins the packetized surface that this lane uses as its testbed.
+- The grounding lane stays focused on reviewer packets and evidence depth; it
+  does not touch coverage count work, helper docs outside this scope, or shared
+  root doc TODO/changelog/status files.
+
+## Strategy
+
+1. Pick a handful of representative hard Nat packets (split-heavy rows,
+   high-profile business families, mix of held/live) and capture:
+   - the revision-locked source URL and follow receipts
+   - bounded evidence excerpts (any follow receipt or page snippet marked as
+     grounded to the locked revision)
+   - a short handoff summary explaining why the snippet is trustworthy
+2. Store those bundles in
+   `SensibLaw/tests/fixtures/wikidata/wikidata_nat_grounding_depth_packets_20260402.json`
+   so downstream helpers/tests can verify the evidence depth.
+3. Surface the bundles alongside a textual plan so reviewers can reference
+   both the doc and fixture when evaluating grounding readiness.
+
+## Evidence Bundle Outline
+
+- `packet_id`: the locked review packet (matching the pinned packet IDs in the
+  coverage fixture)
+- `qid`: the reviewed entity
+- `revision_evidence`: list of objects containing `follow_receipt_url`,
+  `excerpt`, and `excerpt_summary`
+- `source_notes`: text explaining how the excerpt ties back to the locked
+  revision and why it stops uncertainty
+
+## Operator Attachment Surface
+
+- The helper `build_grounding_depth_attachment` (under
+  `SensibLaw/src/ontology/wikidata_grounding_depth.py`) builds a fail-closed
+  attachment for Nat reviewer packets using the grounding summary fixture.
+- Each attachment exposes the grounding status, revision URL, and the evidence
+  excerpts that validate the hard packet's revision-locked claims.
+- Sample attachment output is stored in
+  `SensibLaw/tests/fixtures/wikidata/wikidata_nat_grounding_depth_operator_surface_20260402.json`.
+
+## Operator Batch Surface
+
+- The new `build_grounding_depth_batch` helper aggregates multiple attachments
+  into a single operator-facing surface that can be consumed alongside the
+  Nat review packets in a review queue.
+- The batch surface is fail-closed: packets without grounding data simply show
+  `grounding_status: no_grounding_data` in their entry.
+- A representative batch fixture lives at
+  `SensibLaw/tests/fixtures/wikidata/wikidata_nat_grounding_depth_batch_20260402.json`
+  so automation or reviewer tooling can verify the entire grounding bundle before
+  presenting packets to operators.
+
+## Evidence Report Surface
+
+- The new `build_grounding_depth_evidence_report` helper produces a packet list
+  that summarizes the evidence depth per representative packet, including counts
+  and missing-field markers, so reviewers can quickly gauge where deeper digging
+  is still needed.
+- Pin the report fixture at
+  `SensibLaw/tests/fixtures/wikidata/wikidata_nat_grounding_depth_evidence_report_20260402.json`
+  and regenerate it via the CLI when evidence inputs change.
+
+## Comparison Surface
+
+- The latest helper `build_grounding_depth_comparison` joins multiple grounding
+  batches into a deterministic comparison table, showing attachment counts,
+  grounded counts, and qid lists per batch index.
+- We pin the comparison fixture at
+  `SensibLaw/tests/fixtures/wikidata/wikidata_nat_grounding_depth_comparison_20260402.json`.
+- The CLI now accepts `--compare` files and `--comparison-out` so operators can
+  reproduce the comparison surface across batches when reviewing new grounding
+  evidence.
+
+## Scorecard Surface
+
+- `build_grounding_depth_scorecard` aggregates multiple comparison runs into a
+  repeatable scorecard, tracking per-run grounding counts and attachment totals
+  so operators can spot drift over repeated grounding-depth inspections.
+- Each run is referenced by `run_id` in the `--scorecard-run` CLI argument, and
+  the resulting artifact is written under `--scorecard-out`.
+- The pinned scorecard fixture lives at
+  `SensibLaw/tests/fixtures/wikidata/wikidata_nat_grounding_depth_scorecard_20260402.json`.
+
+## Operator CLI
+
+- The new CLI command `SensibLaw.cli.grounding_depth` builds the grounding batch
+  by combining the summary fixture with a list of packets that should receive
+  grounding evidence attachments.
+- It writes JSON to the provided `--outfile` (or stdout) for operators to
+  consume or checkpoint.
+- Running the CLI against the grounding fixtures reproduces the pinned batch
+  surface, ensuring the operator artifact stays deterministic and review-first.
+
+
+## Next Steps
+
+1. Run the grounding helper against the fixture to produce an auditable
+   summary (e.g., using `enrich_review_packet_follow_depth` or a similar helper).
+2. Review the sample packets with the grounding-depth evidence to confirm the
+   extra revision-locked context is sufficient.
+3. Expand the fixture incrementally only when new hard-row patterns need the
+   same depth; keep the sample bounded so it stays reviewable.
+
+## Validation
+
+- `SensibLaw/tests/test_wikidata_nat_grounding_depth.py` validates the fixture
+  to ensure it lists packets, evidence snippets, and summaries for the
+  representative qids.
+
+## Links
+
+- Evidence sample fixture:
+  `SensibLaw/tests/fixtures/wikidata/wikidata_nat_grounding_depth_packets_20260402.json`

--- a/docs/planning/wikidata_nat_review_packet_attachment_coverage_20260401.md
+++ b/docs/planning/wikidata_nat_review_packet_attachment_coverage_20260401.md
@@ -18,9 +18,10 @@ This note covers:
 - the existing Nat review packet for `Q10403939`
 - a second packetized held split row for `Q10422059`
 - a third packetized held split row for `Q731938` (AstraZeneca) drawn from the live tranche
-- nine wider-online reviewed rows from the live tranche
+- ten wider-online reviewed rows from the live tranche
 - two additional sidecar-backed pilot-pack split plans for `Q10416948` and
   `Q56404383`
+- two additional wider-online reviewed rows for `Q1785637` and `Q738421`
 - the shared review-packet contract surface
 
 It does not cover:
@@ -39,11 +40,11 @@ Held split rows in the current Nat tranche:
 
 Packetized held split rows in this slice:
 
-- packetized rows: `13`
-- packetization coverage: `13 / 53`
+- packetized rows: `15`
+- packetization coverage: `15 / 53`
 
 That is the first actual coverage expansion beyond the docs-only checkpoint.
-It now includes the original two held rows, the AstraZeneca held row, the
+It now includes the original two held rows, the AstraZeneca held row, ten
 wider-online reviewed rows from the live tranche, and two additional
 pilot-pack packets that carry the semantic sidecar. It is still partial.
 
@@ -102,7 +103,7 @@ The packet surface now includes:
 1. the original packet for `Q10403939`
 2. a second packetized held row for `Q10422059`
 3. a third held-row packet for `Q731938` (AstraZeneca)
-4. nine wider-online reviewed rows from the live tranche
+4. ten wider-online reviewed rows from the live tranche
 5. two additional pilot-pack sidecar packets for `Q10416948` and `Q56404383`
 6. a machine-readable index that records all attachments
 
@@ -118,7 +119,7 @@ Reviewers now have:
 - the new AstraZeneca held row from the live tranche plus the surrounding
   wider-online rows
 - two additional sidecar-backed pilot-pack packets
-- a coverage index showing 13 / 53 packetized rows
+- a coverage index showing 15 / 53 packetized rows
 
 In practical terms, that gives reviewers a broader packet surface without
 pretending the whole tranche is packetized.
@@ -183,7 +184,7 @@ title Wikidata Nat Review Packet Attachment Coverage
 Component(contract, "Review Packet Contract", "Existing Nat review-packet contract")
 Component(packet1, "Held Row Packet 1", "Q10403939")
 Component(packet2, "Held Row Packet 2", "Q10422059")
-Component(index, "Attachment Coverage Index", "13 / 53 packetized rows")
+Component(index, "Attachment Coverage Index", "15 / 53 packetized rows")
 Component(reviewer, "Reviewer", "Nat / ontology reviewers")
 
 Rel(contract, packet1, "supports")

--- a/docs/planning/wikidata_review_packet_contract_20260401.md
+++ b/docs/planning/wikidata_review_packet_contract_20260401.md
@@ -95,6 +95,45 @@ An opt-in semantic sidecar now also exists behind
 derives only from existing bounded packet signals, and is intentionally a
 sidecar rather than a replacement for the shallow surface parse.
 
+The sidecar now emits candidate units derived directly from the `source_surface`
+anchors (anchor-derived reviewer units) plus split-review context units that
+summarize merged split axes and the recommended action. This lets the reviewer
+see why each span matters without implying that `parsed_page` already performs
+clause-level semantic-unit extraction.
+
+The same sidecar now also lifts bounded follow receipts into candidate units
+when they are present. That keeps the receipt boundary visible to reviewers
+without collapsing the receipt into a grounded semantic claim or pretending the
+packet has performed deeper source expansion than it has.
+
+The sidecar also turns its own `missing_evidence` list into candidate units so
+the reviewer can see the current semantic gaps alongside the surfaced spans.
+That remains a gap-reporting convenience, not a claim that the gaps are
+resolved.
+
+The optional semantic sidecar now aggregates the bounded helper lanes for:
+
+- follow depth
+- claim-boundary mapping
+- cross-source alignment
+- reviewer actions
+- bounded variant comparison
+
+Those helper lanes stay explicitly non-authoritative and remain separate from
+`parsed_page`, but they now hang off the same packet sidecar so reviewers can
+see them together.
+
+When a case benefits from cross-variant inspection, the packet may also carry
+a bounded variant-comparison surface. That surface must stay small and
+diagnostic:
+
+- compare only a few relevant variants
+- keep the comparison anchored to the same held bundle and revision-locked
+  source
+- use disagreements to explain why a row is `split_required` or `review_only`
+- do not turn variant comparison into open-ended diff hunting or a hidden
+  truth engine
+
 ### 5. Reviewer view
 
 - decision focus areas
@@ -111,6 +150,13 @@ sidecar rather than a replacement for the shallow surface parse.
 - unresolved uncertainty must stay visible
 - shallow surface parse must not be misrepresented as full semantic
   decomposition
+- the helper lanes inside the optional semantic sidecar remain diagnostic and
+  non-authoritative
+- bounded variant comparison is a diagnostic aid, not an authority layer
+- bounded variant comparison may now be grounded automatically from sibling
+  Nat split plans present in the same split payload so the packet can surface
+  real agreement and disagreement patterns without becoming open-ended diff
+  hunting
 
 ## Acceptance criteria
 

--- a/docs/planning/wikidata_review_packet_plan_20260401.md
+++ b/docs/planning/wikidata_review_packet_plan_20260401.md
@@ -54,13 +54,15 @@ Update:
   - it is not the full SensibLaw decomposition or contingent-clause layer
   - richer semantic decomposition should land later as a separate semantic
     layer above or beside `parsed_page`
-- the first broader packet-coverage surface is now present at `13 / 53`
+- the first broader packet-coverage surface is now present at `15 / 53`
   packetized rows, spanning the original two held rows plus the AstraZeneca
-  held row, the wider-online reviewed rows from the live tranche, and two
+  held row, the wider-online reviewed rows from the live tranche, two
+  additional wider-online reviewed rows (`Q1785637`, `Q738421`), and two
   additional pilot-pack split plans (`Q10416948`, `Q56404383`) that now carry
   the semantic sidecar
-- the current packet coverage surface is now `13 / 53` after the two
-  pilot-pack sidecar packets were added
+- the current packet coverage surface is now `15 / 53` after the two
+  additional live-tranche rows and the two pilot-pack sidecar packets were
+  added
 - the optional semantic sidecar is now landed behind
   `include_semantic_decomposition=True` and stays separate from
   `parsed_page`

--- a/docs/planning/wikidata_review_packet_plan_20260401.md
+++ b/docs/planning/wikidata_review_packet_plan_20260401.md
@@ -13,7 +13,14 @@ review/split assist lane before any new code is written.
 
 The goal is not to create a freeform scraper or hidden authority path. The
 goal is to produce bounded reviewer packets that reduce uncertainty for
-split-heavy Nat/Wikidata review.
+split-heavy Nat/Wikidata review and build the runway toward the lane's
+long-term blind-migration moonshot without pretending that moonshot is already
+available.
+
+Use
+`SensibLaw/docs/planning/wikidata_nat_gap_to_moonshot_program_20260402.md`
+for the higher-level staged roadmap from reviewer packets to blind migration
+readiness.
 
 When the work surface is wide enough to justify parallelism, the orchestration
 rule is one nonblocking lane per worker, with disjoint lane ownership and no
@@ -33,6 +40,14 @@ What is still missing:
 - broader packet coverage across held Nat rows
 - later semantic decomposition above or beside `parsed_page`
 - a bounded variant-comparison lane for targeted uncertainty reduction
+- deeper evidence grounding on representative hard packets so the packet lane
+  can support promotion-gate evidence rather than only reviewer convenience
+
+The explicit product posture is:
+
+- current mode: review-first, split-first, fail-closed
+- long-term moonshot: blind migration automation only after the smaller lanes
+  prove the safe tiers are stable enough to trust
 
 Update:
 
@@ -88,12 +103,35 @@ Update:
   - cross-source alignment
   - reviewer actions
   - bounded variant comparison
-  - the remaining work is to extend their evidence inputs, not to widen the
-    packet contract
+- the remaining work is to extend their evidence inputs, not to widen the
+  packet contract
+- a first grounding-depth evidence lane is now pinned at:
+  - `SensibLaw/docs/planning/wikidata_nat_grounding_depth_evidence_20260402.md`
+  - `SensibLaw/tests/fixtures/wikidata/wikidata_nat_grounding_depth_packets_20260402.json`
+  - `SensibLaw/tests/test_wikidata_nat_grounding_depth.py`
+- that grounding lane now also has a reproducible operator path:
+  - `SensibLaw/src/ontology/wikidata_grounding_depth.py`
+  - `SensibLaw/cli/grounding_depth.py`
+  - `sensiblaw wikidata grounding-depth`
 - variant comparison now has a grounded Nat example path: when the split
   payload includes sibling plans from the same cohort, the packet can derive
   a small bounded comparison set automatically, so the comparison lane is no
   longer limited to abstract examples
+- that means the next pressure is no longer packet shape. It is:
+  - grounding depth and claim-boundary evidence that can feed the newer
+    operator/governance indexes above the lane-local moonshot helpers
+  - repeated broader-slice evidence and disagreement clustering rather than
+    more packet-shape expansion
+  - more grounded revision-locked evidence
+  - stronger claim-boundary confidence
+  - broader structural coverage across non-company cohorts
+  - reuse of the same packet grammar across Cohorts B/C/D/E rather than more
+    routine company-family packet attachment
+  - batch/report use of the operator surfaces so promotion evidence comes from
+    repeated measured runs rather than one-off examples
+  - attachment of the new grounding-depth evidence report and the broader
+    cohort batch/report summaries so packet-readiness claims are backed by
+    multi-case evidence rather than single packet anecdotes
 
 ## Planned Workflow
 
@@ -234,6 +272,9 @@ Promotion still requires the existing bounded checks:
 ### F
 
 - the gap is now implementation, not intent
+- specifically, the gap is no longer "do reviewer packets exist?" It is
+  "are reviewer packets grounded enough to justify later automation
+  graduation?"
 
 ## ITIL Reading
 

--- a/docs/planning/wikidata_review_packet_plan_20260401.md
+++ b/docs/planning/wikidata_review_packet_plan_20260401.md
@@ -32,6 +32,7 @@ What is still missing:
 
 - broader packet coverage across held Nat rows
 - later semantic decomposition above or beside `parsed_page`
+- a bounded variant-comparison lane for targeted uncertainty reduction
 
 Update:
 
@@ -63,9 +64,34 @@ Update:
 - the optional semantic sidecar is now landed behind
   `include_semantic_decomposition=True` and stays separate from
   `parsed_page`
+- the semantic sidecar now explicitly records anchor-derived reviewer units
+  and split-review context units (merged split axes + recommended action)
+  so reviewers can reach the same conclusion without assuming the parsed
+  surface is semantic decomposition
+- the same semantic sidecar now also lifts bounded follow receipts into
+  candidate units when they are present, so the receipt boundary stays visible
+  without being overstated as grounded semantic promotion
+- the same sidecar also promotes its `missing_evidence` list into explicit gap
+  units so the reviewer can see what still is not grounded yet
 - the next implementation pressure is broader packet coverage across the
   remaining held Nat rows, then any later expansion of the semantic sidecar
   above or beside `parsed_page`
+- from this point onward the packet coverage lane is experiencing diminishing
+  returns; only genuinely new split shapes should trigger another packet
+  attachment rather than repeated routine rows.
+- the helper-lane slices now exist as standalone modules and are aggregated
+  behind the optional semantic sidecar:
+  - follow depth
+  - claim-boundary mapping
+  - cross-source alignment
+  - reviewer actions
+  - bounded variant comparison
+  - the remaining work is to extend their evidence inputs, not to widen the
+    packet contract
+- variant comparison now has a grounded Nat example path: when the split
+  payload includes sibling plans from the same cohort, the packet can derive
+  a small bounded comparison set automatically, so the comparison lane is no
+  longer limited to abstract examples
 
 ## Planned Workflow
 
@@ -112,6 +138,21 @@ Every followed source must produce a receipt:
 - why it was followed
 - what evidence was extracted
 - what uncertainty remains
+
+### Step 3b: Compare variants
+
+Compare only a small bounded set of relevant variants when the comparison is
+likely to reduce reviewer uncertainty:
+
+- adjacent statement bundles in the same cohort
+- nearby wiki revisions of the same proposal/sandbox page
+- alternate query/result slices for the same target shape
+- source/reference variants that explain why one row splits differently from
+  another
+
+Variant comparison is a diagnostic lever, not a truth engine. It should help
+cluster split shapes and sharpen reviewer packets, but it must not become
+open-ended diff-hunting or a substitute for the review packet itself.
 
 ### Step 4: Packetize
 
@@ -173,12 +214,14 @@ Promotion still requires the existing bounded checks:
 2. page parsed
 3. refs/links exposed
 4. selected sources followed with receipts
-5. reviewer packet emitted
-6. reviewer decides
+5. targeted variants compared where useful
+6. reviewer packet emitted
+7. reviewer decides
 
 ### P
 
 - build reviewer-packet infrastructure above the existing split-plan lane
+- keep variant comparison bounded and diagnostic, not authoritative
 
 ### G
 
@@ -200,6 +243,7 @@ Promotion still requires the existing bounded checks:
   - bounded parser
   - broader packet coverage across held rows, now with an 11-row surface
   - optional semantic decomposition sidecar above or beside `parsed_page`
+  - bounded variant-comparison lane for targeted uncertainty reduction
 
 ## ISO 9000 Reading
 
@@ -281,7 +325,8 @@ Rel(PACKET, HUMAN, "review packet")
 Implement in this order:
 
 1. broader packet coverage across the remaining held Nat rows
-2. optional semantic decomposition layer above or beside `parsed_page`
+2. bounded variant-comparison lane for targeted uncertainty reduction
+3. optional semantic decomposition layer above or beside `parsed_page`
 
 ## This Pass
 
@@ -296,3 +341,6 @@ The implementation has since begun and the current lane state now includes:
 
 The remaining work is the broader packet coverage across held Nat rows and
 any later expansion of the semantic sidecar above or beside `parsed_page`.
+The new bounded variant-comparison lane now sits between those two stages so
+reviewers can compare a few relevant variants without turning the packet into
+an open-ended diff hunt.

--- a/docs/planning/wikidata_review_packet_semantic_layer_20260402.md
+++ b/docs/planning/wikidata_review_packet_semantic_layer_20260402.md
@@ -21,6 +21,16 @@ attaches:
 The new layer is explicitly a sidecar derived from existing bounded packet
 signals (`parsed_page`, `page_signals`, `follow_receipts`).
 
+It currently lifts:
+
+- query rows
+- follow receipts
+- open questions
+- todo items
+- anchor-derived reviewer spans
+- split-review context spans
+- explicit missing-evidence gap spans
+
 ## Non-claims
 
 - It does not replace or mutate `parsed_page`.

--- a/docs/wikidata_working_group_status.md
+++ b/docs/wikidata_working_group_status.md
@@ -149,6 +149,8 @@ shared handoff.
         - cohort-oriented task lines
       - bounded follow-receipt support now auto-attaches a query-link receipt
         when the source surface provides one
+      - bounded variant comparison is now explicitly available as a diagnostic
+        lever for targeted uncertainty reduction, not as a truth engine
       - explicit boundary:
         - `parsed_page` is only the current shallow surface-parse helper
         - it is not the full SensibLaw decomposition / contingent-clause layer
@@ -164,12 +166,35 @@ shared handoff.
       - the bounded parser upgrade is now landed
       - bounded follow receipts now exist for the Nat query-link surface, but
         broader follow-receipt coverage across held rows still remains
+      - bounded variant comparison is allowed, but only across a few relevant
+        variants and never as a substitute for the review packet
       - broader packet coverage across held rows now has a first
         13-row attachment surface, but it is still incomplete
       - a separate semantic sidecar now exists behind
         `include_semantic_decomposition=True`
-      - deeper SensibLaw-style semantic decomposition should still stay
-        explicit and separate from the shallow parser coverage
+      - that sidecar publishes anchor-derived reviewer units, bounded
+        follow-receipt units, explicit missing-evidence gap units, and
+        explicit split-review context units (merged split axes plus
+        recommended steps)
+      - the same sidecar now also aggregates bounded helper lanes for:
+        - follow depth
+        - claim-boundary mapping
+        - cross-source alignment
+        - reviewer actions
+        - bounded variant comparison
+      - bounded variant comparison now has a grounded Nat example path using
+        sibling split plans from the same cohort, and it can be derived
+        automatically from the split payload when sibling plans are present so
+        the comparison lane can surface real agreement/disagreement patterns
+        without becoming open ended diff hunting
+      - standalone helper modules now exist for:
+        - follow depth
+        - claim-boundary mapping
+        - cross-source alignment
+        - reviewer actions
+        - bounded variant comparison
+        - deeper SensibLaw-style semantic decomposition should still stay
+          explicit and separate from the shallow parser coverage
     - current packet coverage now has a first multi-row attachment index:
       `tests/fixtures/wikidata/wikidata_nat_review_packet_attachment_coverage_20260401.json`
       records `13 / 53` packetized held split rows, with the original packet
@@ -177,6 +202,8 @@ shared handoff.
       `Q10422059` and `Q731938`, nine wider-online reviewed rows from the
       live tranche, and two additional pilot-pack sidecar packets for
       `Q10416948` and `Q56404383`
+    - packet coverage is now creeping toward diminishing returns; only new split
+      shapes should justify another attachment step
     - the assist lane now has a parallel reviewer-packet alignment note:
       `docs/planning/wikidata_assist_lane_reviewer_packet_alignment_20260401.md`
       so the same packet grammar can be adopted without overstating parity or

--- a/docs/wikidata_working_group_status.md
+++ b/docs/wikidata_working_group_status.md
@@ -197,9 +197,9 @@ shared handoff.
           explicit and separate from the shallow parser coverage
     - current packet coverage now has a first multi-row attachment index:
       `tests/fixtures/wikidata/wikidata_nat_review_packet_attachment_coverage_20260401.json`
-      records `13 / 53` packetized held split rows, with the original packet
+      records `15 / 53` packetized held split rows, with the original packet
       for `Q10403939`, second and third packetized held rows for
-      `Q10422059` and `Q731938`, nine wider-online reviewed rows from the
+      `Q10422059` and `Q731938`, ten wider-online reviewed rows from the
       live tranche, and two additional pilot-pack sidecar packets for
       `Q10416948` and `Q56404383`
     - packet coverage is now creeping toward diminishing returns; only new split

--- a/docs/wikidata_working_group_status.md
+++ b/docs/wikidata_working_group_status.md
@@ -334,6 +334,9 @@ shared handoff.
       - live scan gate:
         still fail-closed and review-first; no blanket population scan implied,
         and endpoint unavailability is surfaced explicitly
+      - operator packet:
+        now exists and makes the candidate set, triage prompts, and hold/review
+        decision text explicit
 - current phase-2 posture is split deliberately:
   - real imported qualifier-bearing baseline slices via entity export
   - bounded synthetic drift fixture for explicit property-set change review

--- a/docs/wikidata_working_group_status.md
+++ b/docs/wikidata_working_group_status.md
@@ -328,6 +328,9 @@ shared handoff.
         `SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_c_branch_20260401.json`
       - next gate:
         review-first population scan
+      - runtime note:
+        the pinned Cohort C sample fixture now has a bounded scan normalizer,
+        but no live population scan has run yet
 - current phase-2 posture is split deliberately:
   - real imported qualifier-bearing baseline slices via entity export
   - bounded synthetic drift fixture for explicit property-set change review

--- a/docs/wikidata_working_group_status.md
+++ b/docs/wikidata_working_group_status.md
@@ -330,7 +330,10 @@ shared handoff.
         review-first population scan
       - runtime note:
         the pinned Cohort C sample fixture now has a bounded scan normalizer,
-        but no live population scan has run yet
+        and the same selection rule now has a bounded live scan preview helper
+      - live scan gate:
+        still fail-closed and review-first; no blanket population scan implied,
+        and endpoint unavailability is surfaced explicitly
 - current phase-2 posture is split deliberately:
   - real imported qualifier-bearing baseline slices via entity export
   - bounded synthetic drift fixture for explicit property-set change review

--- a/docs/wikidata_working_group_status.md
+++ b/docs/wikidata_working_group_status.md
@@ -336,7 +336,7 @@ shared handoff.
         and endpoint unavailability is surfaced explicitly
       - operator packet:
         now exists and makes the candidate set, triage prompts, and hold/review
-        decision text explicit
+        decision text explicit, with a CLI entrypoint for review packet export
 - current phase-2 posture is split deliberately:
   - real imported qualifier-bearing baseline slices via entity export
   - bounded synthetic drift fixture for explicit property-set change review

--- a/docs/wikidata_working_group_status.md
+++ b/docs/wikidata_working_group_status.md
@@ -1,6 +1,6 @@
 # Wikidata Working Group Status
 
-Last updated: 2026-04-01
+Last updated: 2026-04-03
 
 This is the single working-group link for the bounded Wikidata control-plane
 work in SensibLaw/ITIR. Keep this document current and treat it as the top-level
@@ -28,6 +28,41 @@ If you need the assist-lane reviewer-packet alignment note, use:
 If you need the full intended Nat end product and the tiered automation
 posture, use:
 - `planning/wikidata_nat_end_product_and_tiered_automation_20260401.md`
+
+If you need the explicit staged roadmap from the current lane to the blind
+migration-bot moonshot, use:
+- `planning/wikidata_nat_gap_to_moonshot_program_20260402.md`
+
+The Nat lane's long-term P0 moonshot is blind migration automation, but the
+current operating posture stays review-first, split-first, and fail-closed
+until that moonshot is earned by the smaller lanes.
+
+The current executable moonshot-gap surfaces now include reproducible
+operator/report paths for:
+- grounding depth
+- Cohort B operator packet, queue, and report
+- Cohort C operator evidence, report, and report batch
+- Cohort D operator review queue and operator report
+- Cohort E diagnostics report and batch report
+- automation graduation evaluation, report building, and batch proposal
+  evaluation
+
+The latest broader measured-evidence tranche now extends those surfaces with:
+- grounding-depth evidence reports over representative packet batches
+- Cohort B deterministic multi-case operator batch reports
+- Cohort C broader measured evidence samples over real candidate slices
+- Cohort D multi-case operator report batches
+- Cohort E grouped diagnostics summaries over batch runs
+- automation-graduation repeated-run evidence reports
+
+The next broader operator/governance tranche now extends those measured runs
+with deterministic higher-level control surfaces:
+- grounding-depth comparison/index reports across packet batches
+- Cohort B multi-batch operator evidence indexes
+- Cohort C operator indexes over broader real candidate slices
+- Cohort D multi-batch review-control indexes
+- Cohort E aggregated disagreement/summary indexes
+- automation-graduation governance indexes across repeated evidence snapshots
 
 Treat this status note as the Wikidata-specific detailed appendix after that
 shared handoff.
@@ -195,6 +230,28 @@ shared handoff.
         - bounded variant comparison
         - deeper SensibLaw-style semantic decomposition should still stay
           explicit and separate from the shallow parser coverage
+    - the non-company moonshot-gap lanes now also have executable operator
+      surfaces beyond packet-only notes:
+      - grounding depth:
+        `src/ontology/wikidata_grounding_depth.py`
+        plus `sensiblaw wikidata grounding-depth`
+      - Cohort B:
+        `src/ontology/wikidata_nat_cohort_b_operator_packet.py`,
+        `src/ontology/wikidata_nat_cohort_b_operator_queue.py`, and
+        `src/ontology/wikidata_nat_cohort_b_operator_report.py`
+      - Cohort C:
+        `src/ontology/wikidata_cohort_c_operator_report.py` and
+        `src/ontology/wikidata_cohort_c_operator_report_batch.py`
+      - Cohort D:
+        `src/ontology/wikidata_nat_cohort_d_review.py` plus
+        `sensiblaw wikidata cohort-d-operator-report`
+      - Cohort E:
+        `src/ontology/wikidata_cohort_e_diagnostics.py` plus
+        `cli/cohort_e_diagnostics.py`
+      - automation graduation:
+        `src/ontology/wikidata_nat_automation_graduation.py` plus
+        `sensiblaw wikidata automation-graduation-eval` and
+        `sensiblaw wikidata automation-graduation-eval-batch`
     - current packet coverage now has a first multi-row attachment index:
       `tests/fixtures/wikidata/wikidata_nat_review_packet_attachment_coverage_20260401.json`
       records `15 / 53` packetized held split rows, with the original packet
@@ -221,6 +278,84 @@ shared handoff.
       - Tier 4: hold
     - the wider Nat value proposition is therefore reviewer throughput and
       uncertainty reduction, not pretending all `~50k` rows belong to Tier 1
+  - gap-to-moonshot posture is now explicit:
+    - the current gap is trustable automation readiness, not lack of one more
+      packet field
+    - the current staged priorities are:
+      - grounding depth on representative hard packets
+      - structural breadth on Cohort C and the other non-company lanes
+      - explicit automation graduation criteria
+    - broader company-family packet attachment is now secondary unless it
+      reveals a genuinely new split shape
+  - the next non-company axis is now backed by lane-local artifacts:
+    - grounding depth lane:
+      `docs/planning/wikidata_nat_grounding_depth_evidence_20260402.md`
+      plus runtime helper:
+      `src/ontology/wikidata_grounding_depth.py`
+      and operator attachment fixture:
+      `tests/fixtures/wikidata/wikidata_nat_grounding_depth_operator_surface_20260402.json`
+      plus batch artifact fixture:
+      `tests/fixtures/wikidata/wikidata_nat_grounding_depth_batch_20260402.json`
+      plus evidence report fixture:
+      `tests/fixtures/wikidata/wikidata_nat_grounding_depth_evidence_report_20260402.json`
+    - Cohort B review bucket:
+      `docs/planning/wikidata_nat_cohort_b_review_bucket_20260402.md`
+      plus runtime helper:
+      `src/ontology/wikidata_nat_cohort_b_review_bucket.py`
+      and operator packet helper:
+      `src/ontology/wikidata_nat_cohort_b_operator_packet.py`
+      with packet note:
+      `docs/planning/wikidata_nat_cohort_b_operator_packet_20260402.md`
+      plus operator batch report helper:
+      `src/ontology/wikidata_nat_cohort_b_operator_batch_report.py`
+    - Cohort C live-preview extension:
+      `docs/planning/wikidata_nat_cohort_c_live_preview_extension_20260402.md`
+      and operator evidence packet:
+      `docs/planning/wikidata_nat_cohort_c_operator_evidence_20260403.md`
+      plus operator report helper:
+      `src/ontology/wikidata_cohort_c_operator_report.py`
+      plus broader measured evidence note:
+      `docs/planning/wikidata_nat_cohort_c_ptolemy_evidence_20260405.md`
+    - Cohort D review lane:
+      `docs/planning/wikidata_nat_cohort_d_review_lane_20260402.md`
+      plus type-probing helper:
+      `docs/planning/wikidata_nat_cohort_d_type_probing_surface_20260402.md`
+      and operator review queue fixture:
+      `tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_review_surface_20260402.json`
+      plus operator CLI note:
+      `docs/planning/wikidata_nat_cohort_d_operator_review_cli_20260402.md`
+      plus operator report batch note:
+      `docs/planning/wikidata_nat_cohort_d_operator_report_batch_surface_20260402.md`
+    - Cohort E diagnostics/reconciliation scan plan:
+      `docs/planning/wikidata_nat_cohort_e_reconciliation_scan_plan_20260403.md`
+      plus diagnostics helper:
+      `src/ontology/wikidata_cohort_e_diagnostics.py`
+      and diagnostics CLI note:
+      `docs/planning/wikidata_nat_cohort_e_diagnostics_cli_20260403.md`
+      plus grouped diagnostics summary fixture:
+      `tests/fixtures/wikidata/wikidata_nat_cohort_e_diagnostic_summary_20260403.json`
+    - automation graduation gate note:
+      `docs/planning/wikidata_nat_automation_graduation_criteria_20260402.md`
+      plus evaluator:
+      `src/ontology/wikidata_nat_automation_graduation.py`
+      and report builder:
+      `build_nat_automation_graduation_report(...)`
+      plus CLI:
+      `sensiblaw wikidata automation-graduation-eval`
+      plus repeated-run evidence CLI:
+      `sensiblaw wikidata automation-graduation-evidence-report`
+  - current honest read:
+    - the moonshot gap is now decomposed into real lane-local evidence work,
+      not only roadmap language
+    - the current automation ceiling remains Level 1 reviewer-assisted split
+      execution until broader family evidence is real
+    - the next useful move is using these helpers as review/control surfaces,
+      not adding more packet shape by default
+    - the current tranche has now crossed into reproducible operator/report
+      surfaces on multiple lanes, not just helper functions
+    - the next evidence tranche is now also real on several lanes, so repeated
+      measured runs are beginning to replace one-off examples as the dominant
+      moonshot-readiness artifact
   - immediate next assist target:
     - reduce the large `ambiguous_semantics` bucket for temporal/multi-value
       rows

--- a/src/ontology/wikidata.py
+++ b/src/ontology/wikidata.py
@@ -11,6 +11,22 @@ from typing import Any, Dict, Iterable, List, Mapping, Sequence
 
 import requests
 
+from .wikidata_review_packet_claim_boundaries import (
+    build_review_packet_claim_boundaries,
+)
+from .wikidata_review_packet_cross_source_alignment import (
+    summarize_cross_source_alignment,
+)
+from .wikidata_review_packet_follow_depth import (
+    enrich_review_packet_follow_depth,
+)
+from .wikidata_review_packet_reviewer_actions import (
+    build_wikidata_review_packet_reviewer_actions,
+)
+from .wikidata_review_packet_variant_compare import (
+    compare_review_packet_variants,
+)
+
 
 SCHEMA_VERSION = "wikidata_projection_v0_1"
 FINDER_SCHEMA_VERSION = "wikidata_qualifier_drift_finder_v0_1"
@@ -618,8 +634,53 @@ def _reviewer_view_for_packet(
     }
 
 
+def _comparison_variants_from_split_plan_payload(
+    *,
+    split_plan_payload: Mapping[str, Any],
+    split_plan_id: str,
+    max_variants: int = 3,
+) -> list[dict[str, Any]]:
+    plans = split_plan_payload.get("plans")
+    if not isinstance(plans, list):
+        return []
+    variants: list[dict[str, Any]] = []
+    for plan in plans:
+        if not isinstance(plan, Mapping):
+            continue
+        candidate_split_plan_id = _stringify(plan.get("split_plan_id")).strip()
+        if not candidate_split_plan_id:
+            entity_qid = _stringify(plan.get("entity_qid")).strip()
+            if entity_qid:
+                candidate_split_plan_id = f"split://{entity_qid}|{_stringify(split_plan_payload.get('source_property')).strip()}"
+        if not candidate_split_plan_id or candidate_split_plan_id == split_plan_id:
+            continue
+        variants.append(
+            {
+                "candidate_id": candidate_split_plan_id,
+                "classification": _stringify(plan.get("status")).strip(),
+                "suggested_action": _stringify(plan.get("suggested_action")).strip(),
+                "action": _stringify(plan.get("suggested_action")).strip(),
+                "merged_split_axes": [
+                    {
+                        "property": _stringify(axis.get("property")).strip(),
+                        "cardinality": int(axis.get("cardinality", 0) or 0),
+                        "reason": _stringify(axis.get("reason")).strip(),
+                        "source": _stringify(axis.get("source")).strip(),
+                    }
+                    for axis in plan.get("merged_split_axes", [])
+                    if isinstance(axis, Mapping)
+                ],
+            }
+        )
+        if len(variants) >= max_variants:
+            break
+    return variants
+
+
 def _build_review_packet_semantic_decomposition(
     *,
+    anchor_refs: Sequence[Mapping[str, Any]],
+    split_review_context: Mapping[str, Any],
     parsed_page: Mapping[str, Any],
     page_signals: Mapping[str, Any],
     follow_receipts: Sequence[Mapping[str, Any]],
@@ -642,6 +703,20 @@ def _build_review_packet_semantic_decomposition(
             for item in task_buckets.get("todo", [])
             if _stringify(item).strip()
         ]
+    normalized_anchor_refs = [
+        anchor for anchor in anchor_refs
+        if isinstance(anchor, Mapping) and _stringify(anchor.get("text_excerpt", "")).strip()
+    ]
+    split_plan_id = _stringify(split_review_context.get("split_plan_id", "")).strip()
+    split_axes = [
+        axis for axis in split_review_context.get("merged_split_axes", [])
+        if isinstance(axis, Mapping)
+    ]
+    source_candidate_ids = [
+        _stringify(candidate_id).strip()
+        for candidate_id in split_review_context.get("source_candidate_ids", [])
+        if _stringify(candidate_id).strip()
+    ]
 
     candidate_units: list[dict[str, str]] = []
     candidate_units.extend(
@@ -651,6 +726,23 @@ def _build_review_packet_semantic_decomposition(
             "text": row,
         }
         for index, row in enumerate(query_rows)
+    )
+    candidate_units.extend(
+        {
+            "unit_id": f"follow_receipt:{index + 1}",
+            "unit_type": "follow_receipt_surface",
+            "text": (
+                f"receipt_id={_stringify(receipt.get('receipt_id')).strip()} "
+                f"url={_stringify(receipt.get('url')).strip()} "
+                f"reason={_stringify(receipt.get('follow_reason')).strip()} "
+                f"evidence_count={len(receipt.get('extracted_evidence', []))} "
+                f"unresolved_count={len(receipt.get('unresolved_uncertainty', []))}"
+            ),
+        }
+        for index, receipt in enumerate(follow_receipts)
+        if isinstance(receipt, Mapping)
+        and _stringify(receipt.get("receipt_id")).strip()
+        and _stringify(receipt.get("url")).strip()
     )
     candidate_units.extend(
         {
@@ -668,6 +760,56 @@ def _build_review_packet_semantic_decomposition(
         }
         for index, item in enumerate(todo_items)
     )
+    candidate_units.extend(
+        {
+            "unit_id": f"anchor:{_stringify(anchor.get('anchor_id')).strip() or index + 1}",
+            "unit_type": "anchor_surface",
+            "text": (
+                f"{_stringify(anchor.get('label')).strip()}: "
+                f"{_stringify(anchor.get('text_excerpt')).strip()}"
+                if _stringify(anchor.get("label")).strip()
+                else _stringify(anchor.get("text_excerpt")).strip()
+            ),
+        }
+        for index, anchor in enumerate(normalized_anchor_refs)
+    )
+    if split_plan_id:
+        candidate_units.append(
+            {
+                "unit_id": "split_plan:context",
+                "unit_type": "split_context_surface",
+                "text": (
+                    f"{split_plan_id} status={_stringify(split_review_context.get('status'))} "
+                    f"action={_stringify(split_review_context.get('suggested_action'))} "
+                    f"review_required={bool(split_review_context.get('review_required'))} "
+                    f"proposed_bundle_count={int(split_review_context.get('proposed_bundle_count', 0) or 0)}"
+                ),
+            }
+        )
+    candidate_units.extend(
+        {
+            "unit_id": f"split_axis:{index + 1}",
+            "unit_type": "split_axis_surface",
+            "text": (
+                f"property={_stringify(axis.get('property'))} "
+                f"source={_stringify(axis.get('source'))} "
+                f"reason={_stringify(axis.get('reason'))} "
+                f"cardinality={int(axis.get('cardinality', 0) or 0)}"
+            ),
+        }
+        for index, axis in enumerate(split_axes)
+    )
+    if source_candidate_ids:
+        candidate_units.append(
+            {
+                "unit_id": "split_candidates:summary",
+                "unit_type": "split_context_surface",
+                "text": (
+                    f"source_candidate_ids={len(source_candidate_ids)} "
+                    f"sample={','.join(source_candidate_ids[:3])}"
+                ),
+            }
+        )
 
     missing_evidence = [
         "no_revision_locked_excerpts_for_candidate_units",
@@ -682,13 +824,27 @@ def _build_review_packet_semantic_decomposition(
         missing_evidence.append("open_questions_not_resolved_into_grounded_assertions")
     if todo_items:
         missing_evidence.append("todo_items_not_lifted_into_review_decision_graph")
+    if normalized_anchor_refs:
+        missing_evidence.append("anchor_refs_not_promoted_to_grounded_claims")
+    if split_axes or split_plan_id:
+        missing_evidence.append("split_context_not_lifted_into_semantic_decision_graph")
+
+    normalized_missing_evidence = sorted(set(missing_evidence))
+    candidate_units.extend(
+        {
+            "unit_id": f"missing_evidence:{index + 1}",
+            "unit_type": "missing_evidence_surface",
+            "text": gap,
+        }
+        for index, gap in enumerate(normalized_missing_evidence)
+    )
 
     return {
         "layer_schema_version": WIKIDATA_REVIEW_PACKET_SEMANTIC_LAYER_VERSION,
         "decomposition_state": "surface_only",
         "separate_from_parsed_page": True,
         "candidate_units": candidate_units,
-        "missing_evidence": sorted(set(missing_evidence)),
+        "missing_evidence": normalized_missing_evidence,
     }
 
 
@@ -699,6 +855,8 @@ def build_wikidata_review_packet(
     split_plan_id: str,
     source_unit_id: str | None = None,
     follow_receipts: Sequence[Mapping[str, Any]] | None = None,
+    follow_depth_source_text_by_url: Mapping[str, str] | None = None,
+    comparison_variants: Sequence[Mapping[str, Any]] | None = None,
     include_semantic_decomposition: bool = False,
 ) -> dict[str, Any]:
     source = _select_source_unit(source_unit_payload, source_unit_id=source_unit_id)
@@ -777,11 +935,72 @@ def build_wikidata_review_packet(
         ),
     }
     if include_semantic_decomposition:
-        packet["semantic_decomposition"] = _build_review_packet_semantic_decomposition(
+        auto_comparison_variants = list(comparison_variants or [])
+        if not auto_comparison_variants:
+            auto_comparison_variants = _comparison_variants_from_split_plan_payload(
+                split_plan_payload=split_plan_payload,
+                split_plan_id=split_plan_id,
+            )
+        semantic_decomposition = _build_review_packet_semantic_decomposition(
+            anchor_refs=packet["source_surface"]["anchor_refs"],
+            split_review_context=packet["split_review_context"],
             parsed_page=parsed_page,
             page_signals=page_signals,
             follow_receipts=normalized_receipts,
         )
+        semantic_decomposition["follow_depth"] = enrich_review_packet_follow_depth(
+            packet,
+            source_text_by_url=follow_depth_source_text_by_url,
+        )
+        semantic_decomposition["claim_boundaries"] = build_review_packet_claim_boundaries(
+            source_surface=packet["source_surface"],
+            split_review_context=packet["split_review_context"],
+            parsed_page=parsed_page,
+            page_signals=page_signals,
+        )
+        semantic_decomposition["cross_source_alignment"] = summarize_cross_source_alignment(
+            packet_id=packet_id,
+            wiki_surface={
+                "qid": _stringify(packet.get("review_entity_qid")),
+                "source": _stringify(packet["source_surface"]["origin"].get("source_type")),
+                "fields": list(parsed_page.get("query_rows", [])),
+                "summary": _stringify(packet["source_surface"]["origin"].get("title")),
+            },
+            query_slice={
+                "qid": _stringify(packet.get("review_entity_qid")),
+                "fields": list(parsed_page.get("query_rows", [])),
+                "summary": "query rows from parsed page",
+            },
+            split_bundle={
+                "primary_qid": _stringify(packet.get("review_entity_qid")),
+                "fields": [
+                    axis.get("property")
+                    for axis in packet["split_review_context"].get("merged_split_axes", [])
+                    if isinstance(axis, Mapping)
+                ],
+                "summary": _stringify(packet["split_review_context"].get("suggested_action")),
+            },
+        )
+        semantic_decomposition["reviewer_actions"] = (
+            build_wikidata_review_packet_reviewer_actions(packet)
+        )
+        if auto_comparison_variants:
+            semantic_decomposition["variant_comparison"] = compare_review_packet_variants(
+                primary_variant={
+                    "candidate_id": packet["split_review_context"].get("split_plan_id"),
+                    "suggested_action": packet["split_review_context"].get("suggested_action"),
+                    "merged_split_axes": packet["split_review_context"].get("merged_split_axes", []),
+                    "action": packet["split_review_context"].get("suggested_action"),
+                },
+                comparison_variants=auto_comparison_variants,
+            )
+        else:
+            semantic_decomposition["variant_comparison"] = {
+                "non_authoritative": True,
+                "diagnostic_flags": ["no_comparisons_provided"],
+                "comparisons": [],
+            }
+        packet["semantic_decomposition"] = semantic_decomposition
     return packet
 
 

--- a/src/ontology/wikidata.py
+++ b/src/ontology/wikidata.py
@@ -1209,6 +1209,150 @@ def build_nat_cohort_c_population_scan_live(
     return build_nat_cohort_c_population_scan_from_sparql_results(payload)
 
 
+def build_nat_cohort_c_operator_packet(
+    scan_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    if _stringify(scan_payload.get("cohort_id")) != "non_ghg_protocol_or_missing_p459":
+        raise ValueError("Cohort C operator packet requires the Cohort C payload")
+    summary = scan_payload.get("summary")
+    summary_payload = summary if isinstance(summary, Mapping) else {}
+    sample_candidates = [
+        {
+            "qid": _stringify(candidate.get("qid")),
+            "label": _stringify(candidate.get("label")),
+            "p459_status": _stringify(candidate.get("p459_status")),
+            "qualifier_snippet": _stringify(candidate.get("qualifier_snippet")),
+            "policy_note": _stringify(candidate.get("policy_note")),
+        }
+        for candidate in scan_payload.get("sample_candidates", [])
+        if isinstance(candidate, Mapping)
+    ]
+    scan_status = _stringify(scan_payload.get("scan_status"))
+    unavailable = scan_status == "live_population_scan_unavailable"
+    if unavailable:
+        decision_text = "hold"
+        triage_prompts = [
+            "Live query was unavailable; retry later before any cohort claim.",
+            "Do not infer migration readiness from an unavailable preview.",
+        ]
+    else:
+        decision_text = "review"
+        triage_prompts = [
+            "Review the candidate P459 status split before any cohort claim.",
+            "Check whether the missing vs non-GHG protocol buckets need different handling.",
+            "Keep the lane review-first and fail-closed.",
+        ]
+    packet_id = hashlib.sha1(
+        json.dumps(
+            {
+                "cohort_id": scan_payload.get("cohort_id"),
+                "scan_status": scan_status,
+                "candidate_count": len(sample_candidates),
+                "candidate_qids": [candidate["qid"] for candidate in sample_candidates],
+            },
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return {
+        "schema_version": WIKIDATA_REVIEW_PACKET_SCHEMA_VERSION,
+        "packet_id": f"operator-packet:{packet_id}",
+        "lane_id": _stringify(scan_payload.get("lane_id")),
+        "cohort_id": _stringify(scan_payload.get("cohort_id")),
+        "scan_status": scan_status or "unknown",
+        "decision": decision_text,
+        "triage_prompts": triage_prompts,
+        "sample_candidates": sample_candidates,
+        "summary": {
+            "candidate_count": len(sample_candidates),
+            "p459_status_counts": dict(summary_payload.get("p459_status_counts", {})),
+            "review_first": True,
+            "policy_risk": "high",
+        },
+        "governance": {
+            "automation_allowed": False,
+            "fail_closed": True,
+            "live_query_unavailable": unavailable,
+        },
+        "notes": list(scan_payload.get("notes", []))
+        if isinstance(scan_payload.get("notes"), list)
+        else [],
+    }
+
+
+def build_nat_cohort_c_operator_packet(
+    scan_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    if _stringify(scan_payload.get("cohort_id")) != "non_ghg_protocol_or_missing_p459":
+        raise ValueError("Cohort C operator packet requires the Cohort C payload")
+    sample_candidates = [
+        {
+            "qid": _stringify(candidate.get("qid")),
+            "label": _stringify(candidate.get("label")),
+            "p459_status": _stringify(candidate.get("p459_status")),
+            "qualifier_snippet": _stringify(candidate.get("qualifier_snippet")),
+            "policy_note": _stringify(candidate.get("policy_note")),
+        }
+        for candidate in scan_payload.get("sample_candidates", [])
+        if isinstance(candidate, Mapping)
+    ]
+    scan_status = _stringify(scan_payload.get("scan_status"))
+    unavailable = scan_status == "live_population_scan_unavailable"
+    if unavailable:
+        decision_text = "hold"
+        triage_prompts = [
+            "Live query was unavailable; retry later before any cohort claim.",
+            "Do not infer migration readiness from an unavailable preview.",
+        ]
+    else:
+        decision_text = "review"
+        triage_prompts = [
+            "Review the candidate P459 status split before any cohort claim.",
+            "Check whether the missing vs non-GHG protocol buckets need different handling.",
+            "Keep the lane review-first and fail-closed.",
+        ]
+    packet_id = hashlib.sha1(
+        json.dumps(
+            {
+                "cohort_id": scan_payload.get("cohort_id"),
+                "scan_status": scan_status,
+                "candidate_count": len(sample_candidates),
+                "candidate_qids": [candidate["qid"] for candidate in sample_candidates],
+            },
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return {
+        "schema_version": WIKIDATA_REVIEW_PACKET_SCHEMA_VERSION,
+        "packet_id": f"operator-packet:{packet_id}",
+        "lane_id": _stringify(scan_payload.get("lane_id")),
+        "cohort_id": _stringify(scan_payload.get("cohort_id")),
+        "scan_status": scan_status or "unknown",
+        "decision": decision_text,
+        "triage_prompts": triage_prompts,
+        "sample_candidates": sample_candidates,
+        "summary": {
+            "candidate_count": len(sample_candidates),
+            "p459_status_counts": dict(scan_payload.get("summary", {}).get("p459_status_counts", {}))
+            if isinstance(scan_payload.get("summary"), Mapping)
+            else {},
+            "review_first": True,
+            "policy_risk": "high",
+        },
+        "governance": {
+            "automation_allowed": False,
+            "fail_closed": True,
+            "live_query_unavailable": unavailable,
+        },
+        "notes": list(scan_payload.get("notes", []))
+        if isinstance(scan_payload.get("notes"), list)
+        else [],
+    }
+
+
 def _source_unit_scope_tags(source: Mapping[str, Any], *, line_text: str) -> tuple[str, ...]:
     tags = set(_extract_scope_tags_from_text(line_text))
     tags.update(_extract_scope_tags_from_text(_stringify(source.get("source_id", ""))))
@@ -3835,6 +3979,7 @@ __all__ = [
     "build_nat_cohort_c_population_scan",
     "build_nat_cohort_c_population_scan_from_sparql_results",
     "build_nat_cohort_c_population_scan_live",
+    "build_nat_cohort_c_operator_packet",
     "build_observation_claim_payload_from_source_units",
     "build_observation_claim_payload_from_revision_locked_climate_text_sources",
     "attach_wikidata_phi_text_bridge_from_source_units",

--- a/src/ontology/wikidata.py
+++ b/src/ontology/wikidata.py
@@ -1004,6 +1004,46 @@ def build_wikidata_review_packet(
     return packet
 
 
+def build_nat_cohort_c_population_scan(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    if _stringify(payload.get("cohort_id")) != "non_ghg_protocol_or_missing_p459":
+        raise ValueError("Cohort C population scan requires the Cohort C payload")
+    sample_candidates = [
+        {
+            "qid": _stringify(candidate.get("qid")),
+            "label": _stringify(candidate.get("label")),
+            "p459_status": _stringify(candidate.get("p459_status")),
+            "qualifier_snippet": _stringify(candidate.get("qualifier_snippet")),
+            "policy_note": _stringify(candidate.get("policy_note")),
+        }
+        for candidate in payload.get("sample_candidates", [])
+        if isinstance(candidate, Mapping)
+    ]
+    p459_status_counts: dict[str, int] = {}
+    for candidate in sample_candidates:
+        status = candidate["p459_status"] or "unknown"
+        p459_status_counts[status] = p459_status_counts.get(status, 0) + 1
+    return {
+        "lane_id": _stringify(payload.get("lane_id")),
+        "cohort_id": _stringify(payload.get("cohort_id")),
+        "selection_rule": _stringify(payload.get("selection_rule")),
+        "source_revision_fixture": _stringify(payload.get("source_revision_fixture")),
+        "scan_status": "review_first_population_scan_ready",
+        "next_gate": _stringify(payload.get("next_gate")),
+        "sample_candidates": sample_candidates,
+        "summary": {
+            "candidate_count": len(sample_candidates),
+            "p459_status_counts": p459_status_counts,
+            "review_first": True,
+            "policy_risk": "high",
+        },
+        "notes": list(payload.get("notes", []))
+        if isinstance(payload.get("notes"), list)
+        else [],
+    }
+
+
 def _source_unit_scope_tags(source: Mapping[str, Any], *, line_text: str) -> tuple[str, ...]:
     tags = set(_extract_scope_tags_from_text(line_text))
     tags.update(_extract_scope_tags_from_text(_stringify(source.get("source_id", ""))))

--- a/src/ontology/wikidata.py
+++ b/src/ontology/wikidata.py
@@ -1044,6 +1044,171 @@ def build_nat_cohort_c_population_scan(
     }
 
 
+def _sparql_nat_cohort_c_population_scan_query(*, row_limit: int) -> str:
+    return f"""
+SELECT ?item ?itemLabel ?statement ?p459 ?p459Label ?qualifier_pid
+WHERE {{
+  ?item p:P5991 ?statement .
+  OPTIONAL {{
+    ?statement pq:P459 ?p459 .
+    OPTIONAL {{
+      ?p459 rdfs:label ?p459Label .
+      FILTER(LANG(?p459Label) = "en")
+    }}
+  }}
+  OPTIONAL {{
+    ?statement ?pq ?qv .
+    FILTER(STRSTARTS(STR(?pq), "http://www.wikidata.org/prop/qualifier/"))
+    BIND(STRAFTER(STR(?pq), "http://www.wikidata.org/prop/qualifier/") AS ?qualifier_pid)
+  }}
+  SERVICE wikibase:label {{ bd:serviceParam wikibase:language "en". }}
+  FILTER(!BOUND(?p459) || !BOUND(?p459Label) || LCASE(STR(?p459Label)) != "ghg protocol")
+}}
+LIMIT {max(1, int(row_limit))}
+""".strip()
+
+
+def build_nat_cohort_c_population_scan_from_sparql_results(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    bindings = payload.get("results", {}).get("bindings", [])
+    if not isinstance(bindings, list):
+        raise ValueError("SPARQL payload requires a results.bindings array")
+
+    grouped: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in bindings:
+        if not isinstance(row, Mapping):
+            continue
+        item = row.get("item", {}).get("value") if isinstance(row.get("item"), Mapping) else None
+        statement = (
+            row.get("statement", {}).get("value") if isinstance(row.get("statement"), Mapping) else None
+        )
+        if not item or not statement:
+            continue
+        qid = _extract_qid(_stringify(item))
+        statement_id = _extract_qid(_stringify(statement))
+        item_label = (
+            row.get("itemLabel", {}).get("value")
+            if isinstance(row.get("itemLabel"), Mapping)
+            else None
+        )
+        p459 = row.get("p459", {}).get("value") if isinstance(row.get("p459"), Mapping) else None
+        p459_label = (
+            row.get("p459Label", {}).get("value")
+            if isinstance(row.get("p459Label"), Mapping)
+            else None
+        )
+        qualifier_pid = (
+            row.get("qualifier_pid", {}).get("value")
+            if isinstance(row.get("qualifier_pid"), Mapping)
+            else None
+        )
+        candidate = grouped.setdefault(
+            (qid, statement_id),
+            {
+                "qid": qid,
+                "label": _stringify(item_label) or qid,
+                "statement_id": statement_id,
+                "has_p459": p459 is not None,
+                "p459_label": _stringify(p459_label),
+                "qualifier_properties": set(),
+            },
+        )
+        if qualifier_pid:
+            candidate["qualifier_properties"].add(_stringify(qualifier_pid))
+
+    sample_candidates: list[dict[str, Any]] = []
+    p459_status_counts: dict[str, int] = {}
+    for (qid, statement_id), candidate in sorted(grouped.items()):
+        p459_label = _stringify(candidate.get("p459_label"))
+        p459_status = "missing" if not candidate.get("has_p459") else "non_GHG_protocol"
+        qualifier_properties = sorted(candidate.get("qualifier_properties", set()))
+        sample_candidates.append(
+            {
+                "qid": qid,
+                "label": _stringify(candidate.get("label")) or qid,
+                "statement_id": statement_id,
+                "p459_status": p459_status,
+                "p459_label": p459_label if p459_label else None,
+                "qualifier_properties": qualifier_properties,
+                "qualifier_snippet": (
+                    "determination method missing"
+                    if p459_status == "missing"
+                    else f"determination method label: {p459_label or 'unlabelled'}"
+                ),
+                "policy_note": (
+                    "live candidate lacks determination method"
+                    if p459_status == "missing"
+                    else "live candidate uses a non-GHG protocol determination method"
+                ),
+            }
+        )
+        p459_status_counts[p459_status] = p459_status_counts.get(p459_status, 0) + 1
+
+    return {
+        "lane_id": "wikidata_nat_wdu_p5991_p14143",
+        "cohort_id": "non_ghg_protocol_or_missing_p459",
+        "selection_rule": "determination method or standard (P459) is missing or not GHG protocol",
+        "source_revision_fixture": "live_query_preview",
+        "scan_status": "live_population_scan_preview",
+        "next_gate": "review_first_population_scan",
+        "sample_candidates": sample_candidates,
+        "summary": {
+            "candidate_count": len(sample_candidates),
+            "p459_status_counts": p459_status_counts,
+            "review_first": True,
+            "policy_risk": "high",
+        },
+        "notes": [
+            "This live preview stays bounded and review-first.",
+            "It is diagnostic, not a migration or promotion authority.",
+        ],
+    }
+
+
+def build_nat_cohort_c_population_scan_live(
+    *,
+    row_limit: int = 20,
+    timeout_seconds: int = 30,
+) -> dict[str, Any]:
+    query = _sparql_nat_cohort_c_population_scan_query(row_limit=row_limit)
+    try:
+        payload = _http_get_json(
+            SPARQL_ENDPOINT,
+            params={"format": "json", "query": query},
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as exc:
+        return {
+            "lane_id": "wikidata_nat_wdu_p5991_p14143",
+            "cohort_id": "non_ghg_protocol_or_missing_p459",
+            "selection_rule": "determination method or standard (P459) is missing or not GHG protocol",
+            "source_revision_fixture": "live_query_preview",
+            "scan_status": "live_population_scan_unavailable",
+            "next_gate": "review_first_population_scan",
+            "sample_candidates": [],
+            "summary": {
+                "candidate_count": 0,
+                "p459_status_counts": {},
+                "review_first": True,
+                "policy_risk": "high",
+            },
+            "failures": [
+                {
+                    "stage": "live_query",
+                    "error": _stringify(exc),
+                    "endpoint": SPARQL_ENDPOINT,
+                }
+            ],
+            "notes": [
+                "The live preview helper is fail-closed when the Wikidata query endpoint is unavailable.",
+            ],
+        }
+    if not isinstance(payload, Mapping):
+        raise ValueError("Cohort C live scan requires a JSON object payload")
+    return build_nat_cohort_c_population_scan_from_sparql_results(payload)
+
+
 def _source_unit_scope_tags(source: Mapping[str, Any], *, line_text: str) -> tuple[str, ...]:
     tags = set(_extract_scope_tags_from_text(line_text))
     tags.update(_extract_scope_tags_from_text(_stringify(source.get("source_id", ""))))
@@ -3667,6 +3832,9 @@ __all__ = [
     "WIKIDATA_REVIEW_PACKET_SCHEMA_VERSION",
     "adapt_legacy_climate_text_source_to_source_units",
     "build_wikidata_review_packet",
+    "build_nat_cohort_c_population_scan",
+    "build_nat_cohort_c_population_scan_from_sparql_results",
+    "build_nat_cohort_c_population_scan_live",
     "build_observation_claim_payload_from_source_units",
     "build_observation_claim_payload_from_revision_locked_climate_text_sources",
     "attach_wikidata_phi_text_bridge_from_source_units",

--- a/src/ontology/wikidata_cohort_c_operator_digest.py
+++ b/src/ontology/wikidata_cohort_c_operator_digest.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Any, Mapping, Sequence
+
+from .wikidata_cohort_c_operator_index import build_nat_cohort_c_operator_index
+
+DIGEST_SCHEMA_VERSION = "sl.wikidata_nat.cohort_c.operator_digest.v0_1"
+
+
+def build_nat_cohort_c_operator_digest(
+    evidence_packets: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    if not evidence_packets:
+        raise ValueError("At least one evidence packet is required")
+    aggregate_references: defaultdict[str, Counter[str]] = defaultdict(Counter)
+    aggregate_hold_reasons = Counter()
+    candidate_count = 0
+    packet_ids: list[str] = []
+    for packet in evidence_packets:
+        index = build_nat_cohort_c_operator_index(packet)
+        packet_ids.append(str(packet.get("packet_id") or ""))
+        candidate_count += index["total_candidates"]
+        aggregate_hold_reasons.update(index.get("hold_reason_summary", {}))
+        for ref, qualifiers in index.get("reference_summary", {}).items():
+            for qualifier in qualifiers:
+                aggregate_references[ref][qualifier] += 1
+    reference_summary = {
+        ref: dict(counter) for ref, counter in aggregate_references.items()
+    }
+    return {
+        "schema_version": DIGEST_SCHEMA_VERSION,
+        "packet_ids": packet_ids,
+        "candidate_count": candidate_count,
+        "hold_reason_summary": dict(aggregate_hold_reasons),
+        "reference_summary": reference_summary,
+    }

--- a/src/ontology/wikidata_cohort_c_operator_evidence.py
+++ b/src/ontology/wikidata_cohort_c_operator_evidence.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+EVIDENCE_SCHEMA_VERSION = "sl.wikidata_nat.cohort_c.operator_evidence.v0_1"
+
+
+def _as_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return " ".join(str(v).strip() for v in value if str(v).strip())
+    return str(value).strip()
+
+
+def _candidate_signature(candidate: Mapping[str, Any]) -> str:
+    qid = _as_text(candidate.get("qid"))
+    statement_id = _as_text(candidate.get("statement_id"))
+    base = {"qid": qid, "statement_id": statement_id}
+    return hashlib.sha1(json.dumps(base, sort_keys=True, ensure_ascii=False).encode("utf-8")).hexdigest()
+
+
+def build_nat_cohort_c_operator_evidence_packet(
+    scan_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    if _as_text(scan_payload.get("cohort_id")) != "non_ghg_protocol_or_missing_p459":
+        raise ValueError("Cohort C operator evidence packet requires the Cohort C payload")
+    sample_candidates = [
+        candidate
+        for candidate in scan_payload.get("sample_candidates", [])
+        if isinstance(candidate, Mapping)
+    ]
+    evidence_rows: list[dict[str, Any]] = []
+    for candidate in sorted(
+        sample_candidates,
+        key=lambda row: (_as_text(row.get("qid")), _as_text(row.get("statement_id"))),
+    ):
+        qid = _as_text(candidate.get("qid"))
+        statement_id = _as_text(candidate.get("statement_id"))
+        preview_hold_reason = _as_text(candidate.get("preview_hold_reason")) or _as_text(
+            candidate.get("policy_note")
+        )
+        qualifier_hint = candidate.get("qualifier_hint") or candidate.get("qualifier_properties") or []
+        if isinstance(qualifier_hint, Sequence) and not isinstance(qualifier_hint, (str, bytes)):
+            qualifier_hint_list = [_as_text(entry) for entry in qualifier_hint if _as_text(entry)]
+        else:
+            qualifier_hint_list = []
+        evidence_rows.append(
+            {
+                "qid": qid,
+                "statement_id": statement_id,
+                "label": _as_text(candidate.get("label")) or qid,
+                "p459_status": _as_text(candidate.get("p459_status")),
+                "preview_hold_reason": preview_hold_reason,
+                "operator_hold_reason": _as_text(candidate.get("operator_hold_reason"))
+                or (preview_hold_reason and f"Operator to confirm: {preview_hold_reason}")
+                or "Operator confirmation required.",
+                "reference_anchor": _as_text(candidate.get("reference_anchor")) or statement_id,
+                "qualifier_hint": qualifier_hint_list,
+                "promotion_guard": "hold",
+                "hold_gate": "review_first_population_scan",
+                "notes": (
+                    _as_text(candidate.get("notes"))
+                    or _as_text(candidate.get("policy_note"))
+                ),
+                "evidence_id": _candidate_signature(candidate),
+            }
+        )
+    packet_id = hashlib.sha1(
+        json.dumps(
+            {
+                "cohort_id": scan_payload.get("cohort_id"),
+                "scan_status": scan_payload.get("scan_status"),
+                "candidate_qids": [row["qid"] for row in evidence_rows],
+            },
+            sort_keys=True,
+            ensure_ascii=False,
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    summary_payload = scan_payload.get("summary")
+    p459_status_counts = {}
+    if isinstance(summary_payload, Mapping):
+        p459_status_counts = dict(summary_payload.get("p459_status_counts", {}))
+    else:
+        for row in evidence_rows:
+            status = row["p459_status"]
+            if status:
+                p459_status_counts[status] = p459_status_counts.get(status, 0) + 1
+    return {
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "packet_id": f"operator-evidence:{packet_id}",
+        "lane_id": _as_text(scan_payload.get("lane_id")),
+        "cohort_id": _as_text(scan_payload.get("cohort_id")),
+        "scan_status": _as_text(scan_payload.get("scan_status")),
+        "governance": {
+            "automation_allowed": False,
+            "fail_closed": True,
+        },
+        "summary": {
+            "candidate_count": len(evidence_rows),
+            "p459_status_counts": p459_status_counts,
+            "review_first": True,
+            "policy_risk": "high",
+        },
+        "evidence_rows": evidence_rows,
+    }

--- a/src/ontology/wikidata_cohort_c_operator_index.py
+++ b/src/ontology/wikidata_cohort_c_operator_index.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Mapping, Sequence
+
+INDEX_SCHEMA_VERSION = "sl.wikidata_nat.cohort_c.operator_index.v0_1"
+
+
+def _safe_sequence(value: Any) -> Sequence[str]:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [str(entry).strip() for entry in value if str(entry).strip()]
+    if value:
+        text = str(value).strip()
+        return [text] if text else []
+    return []
+
+
+def build_nat_cohort_c_operator_index(
+    evidence_packet: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(evidence_packet, Mapping):
+        raise ValueError("Operator index requires a mapping packet")
+    rows = evidence_packet.get("evidence_rows")
+    if not isinstance(rows, Sequence):
+        raise ValueError("Evidence packet missing evidence_rows sequence")
+
+    qualifiers_by_ref = defaultdict(set)
+    hold_reasons = defaultdict(int)
+    candidate_index = []
+
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        reference_anchor = str(row.get("reference_anchor") or "").strip()
+        qualifier_hint = _safe_sequence(row.get("qualifier_hint"))
+        for qualifier in qualifier_hint:
+            qualifiers_by_ref[reference_anchor].add(qualifier)
+        hold_reason = str(row.get("operator_hold_reason") or row.get("preview_hold_reason") or "").strip()
+        if hold_reason:
+            hold_reasons[hold_reason] += 1
+        candidate_index.append(
+            {
+                "qid": str(row.get("qid") or "").strip(),
+                "statement_id": str(row.get("statement_id") or "").strip(),
+                "reference_anchor": reference_anchor,
+                "qualifier_hint": qualifier_hint,
+                "hold_gate": str(row.get("hold_gate") or "review_first_population_scan"),
+                "promotion_guard": str(row.get("promotion_guard") or "hold"),
+            }
+        )
+
+    reference_summary = {
+        ref: sorted(set(quals)) for ref, quals in qualifiers_by_ref.items() if ref
+    }
+    return {
+        "schema_version": INDEX_SCHEMA_VERSION,
+        "packet_id": evidence_packet.get("packet_id"),
+        "cohort_id": evidence_packet.get("cohort_id"),
+        "reference_summary": reference_summary,
+        "hold_reason_summary": dict(hold_reasons),
+        "candidate_index": candidate_index,
+        "total_candidates": len(candidate_index),
+    }

--- a/src/ontology/wikidata_cohort_c_operator_report.py
+++ b/src/ontology/wikidata_cohort_c_operator_report.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Mapping
+
+REPORT_SCHEMA_VERSION = "sl.wikidata_nat.cohort_c.operator_report.v0_1"
+
+
+def _extract_hold_reason(candidate: Mapping[str, Any]) -> str:
+    reason = candidate.get("operator_hold_reason") or candidate.get("preview_hold_reason") or ""
+    return str(reason).strip()
+
+
+def build_nat_cohort_c_operator_report(
+    evidence_packet: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not isinstance(evidence_packet, Mapping):
+        raise ValueError("Operator report requires a mapping evidence packet")
+    evidence_rows = evidence_packet.get("evidence_rows")
+    if not isinstance(evidence_rows, list):
+        raise ValueError("Evidence packet missing evidence_rows list")
+    hold_reasons = Counter()
+    reference_anchors = []
+    qualifier_hint_sets = []
+    for row in evidence_rows:
+        if not isinstance(row, Mapping):
+            continue
+        reason = _extract_hold_reason(row)
+        if reason:
+            hold_reasons[reason] += 1
+        anchor = row.get("reference_anchor")
+        if isinstance(anchor, str) and anchor.strip():
+            reference_anchors.append(anchor.strip())
+        qualifier_hint = row.get("qualifier_hint")
+        if isinstance(qualifier_hint, list):
+            qualifier_hint_sets.extend(str(entry).strip() for entry in qualifier_hint if str(entry).strip())
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "packet_id": str(evidence_packet.get("packet_id", "")),
+        "lane_id": str(evidence_packet.get("lane_id", "")),
+        "cohort_id": str(evidence_packet.get("cohort_id", "")),
+        "hold_reason_summary": dict(hold_reasons),
+        "reference_anchors": sorted(set(reference_anchors)),
+        "qualifier_counts": dict(Counter(qualifier_hint_sets)),
+        "candidate_count": sum(1 for row in evidence_rows if isinstance(row, Mapping)),
+    }

--- a/src/ontology/wikidata_cohort_c_operator_report_batch.py
+++ b/src/ontology/wikidata_cohort_c_operator_report_batch.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from typing import Any, Mapping, Sequence
+
+from .wikidata_cohort_c_operator_report import (
+    build_nat_cohort_c_operator_report,
+)
+
+
+BATCH_SCHEMA_VERSION = "sl.wikidata_nat.cohort_c.operator_report_batch.v0_1"
+
+
+def _ensure_sequence(inputs: Sequence[Mapping[str, Any]]) -> Sequence[Mapping[str, Any]]:
+    if not inputs:
+        raise ValueError("At least one evidence packet is required for batch reporting")
+    return inputs
+
+
+def build_nat_cohort_c_operator_report_batch(
+    event_packets: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    packets = _ensure_sequence(event_packets)
+    hold_reasons = Counter()
+    qualifier_counts = Counter()
+    references = set()
+    packet_ids = []
+    total_candidates = 0
+    for packet in packets:
+        report = build_nat_cohort_c_operator_report(packet)
+        packet_ids.append(report["packet_id"])
+        total_candidates += report["candidate_count"]
+        hold_reasons.update(report["hold_reason_summary"])
+        qualifier_counts.update(report["qualifier_counts"])
+        references.update(report["reference_anchors"])
+    return {
+        "schema_version": BATCH_SCHEMA_VERSION,
+        "packet_ids": packet_ids,
+        "batch_candidate_count": total_candidates,
+        "hold_reason_summary": dict(hold_reasons),
+        "reference_anchors": sorted(references),
+        "qualifier_counts": dict(qualifier_counts),
+    }

--- a/src/ontology/wikidata_cohort_e_diagnostics.py
+++ b/src/ontology/wikidata_cohort_e_diagnostics.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.ontology.wikidata_review_packet_variant_compare import (
+    compare_review_packet_variants,
+)
+
+AxisCandidate = Mapping[str, Any]
+
+
+def build_cohort_e_diagnostic_report(
+    *,
+    primary_candidate: AxisCandidate,
+    reference_candidates: Sequence[AxisCandidate],
+    lane_id: str = "wikidata_nat_cohort_e_unreconciled_instanceof",
+    max_comparisons: int = 3,
+) -> dict[str, Any]:
+    """Produce a bounded diagnostics surface for Cohort E unreconciled axes."""
+    variant_surface = compare_review_packet_variants(
+        primary_variant=primary_candidate,
+        comparison_variants=reference_candidates,
+        max_variants=max_comparisons,
+    )
+    return {
+        "lane_id": lane_id,
+        "primary_candidate_id": variant_surface["primary_candidate_id"],
+        "comparisons": variant_surface["comparisons"],
+        "diagnostic_flags": variant_surface["diagnostic_flags"],
+        "hold_reason": "unreconciled instance of",
+        "non_authoritative": True,
+    }
+
+
+def summarize_cohort_e_reports(reports: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate agreement/disagreement counts across a diagnostics batch."""
+    total = len(reports)
+    agreement = disagreement = 0
+    axis_disagreements: dict[str, int] = {}
+    for report in reports:
+        for comparison in report.get("comparisons", []):
+            if comparison.get("status") == "agreement":
+                agreement += 1
+            else:
+                disagreement += 1
+                for axis in comparison.get("disagreements", []):
+                    axis_disagreements[axis] = axis_disagreements.get(axis, 0) + 1
+    return {
+        "lane_id": reports[0]["lane_id"] if reports else "wikidata_nat_cohort_e_unreconciled_instanceof",
+        "batch_size": total,
+        "agreement_rows": agreement,
+        "disagreement_rows": disagreement,
+        "axis_disagreement_counts": axis_disagreements,
+        "non_authoritative": True,
+    }
+
+
+__all__ = ["build_cohort_e_diagnostic_report", "summarize_cohort_e_reports"]

--- a/src/ontology/wikidata_cohort_e_summary_index.py
+++ b/src/ontology/wikidata_cohort_e_summary_index.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+
+def build_summary_index(summaries: Iterable[Mapping[str, object]]) -> dict[str, object]:
+    """Aggregate a sequence of Cohort E summaries into a reusable index."""
+    index: dict[str, int] = {"total_batch_runs": 0, "total_agreements": 0, "total_disagreements": 0}
+    axis_counts: dict[str, int] = {}
+    lane_id: str | None = None
+    for summary in summaries:
+        index["total_batch_runs"] += 1
+        index["total_agreements"] += int(summary.get("agreement_rows", 0))
+        index["total_disagreements"] += int(summary.get("disagreement_rows", 0))
+        if lane_id is None:
+            lane_id = summary.get("lane_id")
+        for axis, count in summary.get("axis_disagreement_counts", {}).items():
+            axis_counts[axis] = axis_counts.get(axis, 0) + int(count)
+    index["axis_disagreement_counts"] = axis_counts
+    if lane_id is not None:
+        index["lane_id"] = lane_id
+    return index
+
+
+__all__ = ["build_summary_index"]

--- a/src/ontology/wikidata_grounding_depth.py
+++ b/src/ontology/wikidata_grounding_depth.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Sequence
+
+GROUNDING_DEPTH_SCHEMA_VERSION = "sl.wikidata_review_packet.grounding_depth.v0_1"
+GROUNDING_ATTACHMENT_SCHEMA_VERSION = "sl.wikidata_review_packet.grounding_depth_attachment.v0_1"
+GROUNDING_BATCH_SCHEMA_VERSION = "sl.wikidata_review_packet.grounding_depth_batch.v0_1"
+GROUNDING_EVIDENCE_REPORT_SCHEMA_VERSION = (
+    "sl.wikidata_review_packet.grounding_depth_evidence_report.v0_1"
+)
+GROUNDING_SCORECARD_SCHEMA_VERSION = (
+    "sl.wikidata_review_packet.grounding_depth_scorecard.v0_1"
+)
+GROUNDING_ATTACHMENT_SCHEMA_VERSION = "sl.wikidata_review_packet.grounding_depth_attachment.v0_1"
+
+
+def _normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _normalize_revision_evidence(entry: Mapping[str, Any]) -> dict[str, Any]:
+    excerpt = _normalize_text(entry.get("excerpt"))
+    summary = _normalize_text(entry.get("excerpt_summary"))
+    url = _normalize_text(entry.get("follow_receipt_url"))
+    result = {
+        "follow_receipt_url": url,
+        "excerpt": excerpt,
+        "excerpt_summary": summary,
+    }
+    missing: list[str] = []
+    if not excerpt:
+        missing.append("excerpt")
+    if not summary:
+        missing.append("excerpt_summary")
+    if missing:
+        result["status"] = "incomplete"
+        result["missing_fields"] = missing
+    else:
+        result["status"] = "ok"
+    return result
+
+
+def _iter_packets(payload: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
+    for packet in payload.get("sample_packets") or []:
+        if isinstance(packet, Mapping):
+            yield packet
+
+
+def build_grounding_depth_summary(
+    *,
+    fixture: Mapping[str, Any],
+    max_packets: int | None = None,
+) -> dict[str, Any]:
+    packets: list[dict[str, Any]] = []
+    for index, sample in enumerate(_iter_packets(fixture)):
+        if max_packets is not None and index >= max_packets:
+            break
+        evidence = []
+        for entry in sample.get("revision_evidence") or []:
+            if not isinstance(entry, Mapping):
+                continue
+            evidence.append(_normalize_revision_evidence(entry))
+        status = "missing_evidence"
+        if evidence and all(item.get("status") == "ok" for item in evidence):
+            status = "grounded"
+        packets.append(
+            {
+                "packet_id": _normalize_text(sample.get("packet_id")),
+                "qid": _normalize_text(sample.get("qid")),
+                "revision_url": _normalize_text(sample.get("revision_url")),
+                "revision_locked_notes": _normalize_text(sample.get("revision_locked_notes")),
+                "grounding_status": status,
+                "revision_evidence": evidence,
+            }
+        )
+    grounded = sum(1 for packet in packets if packet["grounding_status"] == "grounded")
+    return {
+        "schema_version": GROUNDING_DEPTH_SCHEMA_VERSION,
+        "lane_id": _normalize_text(fixture.get("lane_id")),
+        "grounding_status": "partial" if grounded < len(packets) else "complete",
+        "packet_count": len(packets),
+        "grounded_packet_count": grounded,
+        "packets": packets,
+    }
+
+
+def build_grounding_depth_attachment(
+    *,
+    review_packet: Mapping[str, Any],
+    grounding_summary: Mapping[str, Any],
+) -> dict[str, Any]:
+    packet_id = _normalize_text(review_packet.get("packet_id"))
+    qid = _normalize_text(review_packet.get("review_entity_qid"))
+    packets = grounding_summary.get("packets") or []
+    matched: Mapping[str, Any] | None = None
+    for entry in packets:
+        if not isinstance(entry, Mapping):
+            continue
+        if entry.get("packet_id") == packet_id and entry.get("qid") == qid:
+            matched = entry
+            break
+    if matched is None:
+        return {
+            "schema_version": GROUNDING_ATTACHMENT_SCHEMA_VERSION,
+            "packet_id": packet_id,
+            "qid": qid,
+            "grounding_status": "no_grounding_data",
+            "evidence": [],
+            "notes": ["no grounding data matched the provided packet"],
+        }
+    return {
+        "schema_version": GROUNDING_ATTACHMENT_SCHEMA_VERSION,
+        "packet_id": packet_id,
+        "qid": qid,
+        "revision_url": matched.get("revision_url"),
+        "grounding_status": matched.get("grounding_status"),
+        "evidence": matched.get("revision_evidence"),
+        "notes": [matched.get("revision_locked_notes", "")],
+    }
+
+
+def build_grounding_depth_batch(
+    *,
+    review_packets: Sequence[Mapping[str, Any]],
+    grounding_summary: Mapping[str, Any],
+) -> dict[str, Any]:
+    attachments: list[dict[str, Any]] = []
+    for packet in review_packets:
+        if not isinstance(packet, Mapping):
+            continue
+        attachments.append(
+            build_grounding_depth_attachment(
+                review_packet=packet,
+                grounding_summary=grounding_summary,
+            )
+        )
+    return {
+        "schema_version": GROUNDING_BATCH_SCHEMA_VERSION,
+        "lane_id": _normalize_text(grounding_summary.get("lane_id")),
+        "attachment_count": len(attachments),
+        "attachments": attachments,
+    }
+
+
+def build_grounding_depth_evidence_report(
+    *, grounding_summary: Mapping[str, Any]
+) -> dict[str, Any]:
+    packets: list[dict[str, Any]] = []
+    grounded = 0
+    for entry in grounding_summary.get("packets") or []:
+        if not isinstance(entry, Mapping):
+            continue
+        evidence = entry.get("revision_evidence") or []
+        missing_fields = []
+        for item in evidence:
+            if isinstance(item, Mapping):
+                missing_fields.extend(item.get("missing_fields", []))
+        packet_record = {
+            "packet_id": _normalize_text(entry.get("packet_id")),
+            "qid": _normalize_text(entry.get("qid")),
+            "revision_url": _normalize_text(entry.get("revision_url")),
+            "grounding_status": entry.get("grounding_status"),
+            "evidence_count": len(evidence),
+            "missing_fields": sorted(set(missing_fields)),
+            "notes": [entry.get("revision_locked_notes")] if entry.get("revision_locked_notes") else [],
+        }
+        packets.append(packet_record)
+        if entry.get("grounding_status") == "grounded":
+            grounded += 1
+    return {
+        "schema_version": GROUNDING_EVIDENCE_REPORT_SCHEMA_VERSION,
+        "lane_id": _normalize_text(grounding_summary.get("lane_id")),
+        "packet_count": len(packets),
+        "grounded_packet_count": grounded,
+        "packets": packets,
+    }
+
+
+def build_grounding_depth_comparison(
+    *, batches: Sequence[Mapping[str, Any]]
+) -> dict[str, Any]:
+    comparison: list[dict[str, Any]] = []
+    for index, batch in enumerate(batches):
+        attachments = batch.get("attachments") or []
+        status_counts: dict[str, int] = {}
+        qids: list[str] = []
+        for attachment in attachments:
+            status = str(attachment.get("grounding_status") or "unknown")
+            status_counts[status] = status_counts.get(status, 0) + 1
+            qid = attachment.get("qid")
+            if isinstance(qid, str) and qid:
+                qids.append(qid)
+        comparison.append(
+            {
+                "index": index,
+                "lane_id": _normalize_text(batch.get("lane_id")),
+                "attachment_count": len(attachments),
+                "grounded_packet_count": status_counts.get("grounded", 0),
+                "qids": qids,
+                "status_counts": status_counts,
+            }
+        )
+    return {
+        "schema_version": GROUNDING_EVIDENCE_REPORT_SCHEMA_VERSION,
+        "comparison_count": len(comparison),
+        "comparison": comparison,
+    }
+
+
+def build_grounding_depth_scorecard(*, runs: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    entries: list[dict[str, Any]] = []
+    total_grounded = 0
+    total_attachments = 0
+    for run in runs:
+        run_id = _normalize_text(run.get("run_id"))
+        raw_comparison = run.get("comparison")
+        if isinstance(raw_comparison, Mapping) and "comparison" in raw_comparison:
+            comparison_list = raw_comparison.get("comparison", [])
+        elif isinstance(raw_comparison, Sequence):
+            comparison_list = raw_comparison or []
+        else:
+            comparison_list = []
+        run_grounded = sum(
+            int(entry.get("grounded_packet_count") or 0) for entry in comparison_list
+        )
+        run_attachments = sum(int(entry.get("attachment_count") or 0) for entry in comparison_list)
+        total_grounded += run_grounded
+        total_attachments += run_attachments
+        run_status_counts: dict[str, int] = {}
+        for entry in comparison_list:
+            for status, count in (entry.get("status_counts") or {}).items():
+                run_status_counts[str(status)] = (
+                    run_status_counts.get(str(status), 0) + int(count or 0)
+                )
+        entries.append(
+            {
+                "run_id": run_id,
+                "comparison_count": len(comparison_list),
+                "grounded_packet_count": run_grounded,
+                "attachment_count": run_attachments,
+                "status_counts": run_status_counts,
+            }
+        )
+    return {
+        "schema_version": GROUNDING_SCORECARD_SCHEMA_VERSION,
+        "run_count": len(entries),
+        "total_grounded_packet_count": total_grounded,
+        "total_attachment_count": total_attachments,
+        "runs": entries,
+    }

--- a/src/ontology/wikidata_nat_automation_graduation.py
+++ b/src/ontology/wikidata_nat_automation_graduation.py
@@ -1,0 +1,471 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+AUTOMATION_GRADUATION_EVAL_SCHEMA_VERSION = "sl.wikidata_nat_automation_graduation_eval.v0_1"
+AUTOMATION_GRADUATION_REPORT_SCHEMA_VERSION = "sl.wikidata_nat_automation_graduation_report.v0_1"
+AUTOMATION_GRADUATION_BATCH_REPORT_SCHEMA_VERSION = "sl.wikidata_nat_automation_graduation_batch_report.v0_1"
+AUTOMATION_GRADUATION_EVIDENCE_REPORT_SCHEMA_VERSION = "sl.wikidata_nat_automation_graduation_evidence_report.v0_1"
+AUTOMATION_GRADUATION_GOVERNANCE_INDEX_SCHEMA_VERSION = "sl.wikidata_nat_automation_graduation_governance_index.v0_1"
+AUTOMATION_GRADUATION_GOVERNANCE_SUMMARY_SCHEMA_VERSION = (
+    "sl.wikidata_nat_automation_graduation_governance_summary.v0_1"
+)
+
+
+def _as_text_set(values: Sequence[Any] | None) -> set[str]:
+    if values is None:
+        return set()
+    normalized: set[str] = set()
+    for value in values:
+        text = str(value).strip()
+        if text:
+            normalized.add(text)
+    return normalized
+
+
+def _as_text(value: Any) -> str:
+    return str(value).strip()
+
+
+def _find_gate(criteria: Mapping[str, Any], gate_id: str) -> Mapping[str, Any] | None:
+    gates = criteria.get("gates", [])
+    if not isinstance(gates, Sequence):
+        return None
+    for gate in gates:
+        if isinstance(gate, Mapping) and _as_text(gate.get("gate_id")) == gate_id:
+            return gate
+    return None
+
+
+def evaluate_nat_automation_promotion(
+    criteria: Mapping[str, Any],
+    proposal: Mapping[str, Any],
+) -> dict[str, Any]:
+    """
+    Deterministic fail-closed evaluator for Nat automation-graduation proposals.
+
+    Required proposal fields:
+    - gate_id
+    - from_level
+    - to_level
+    - gate_families_passed (list[str])
+    - evidence_signals (list[str])
+    - risk_signals (list[str])
+    - metrics (mapping[str, Any])
+    - recommendation (promote|hold|revert)
+    """
+    failed_checks: list[str] = []
+    gate_id = _as_text(proposal.get("gate_id"))
+    gate = _find_gate(criteria, gate_id)
+    if gate is None:
+        failed_checks.append("gate_not_found")
+        return {
+            "schema_version": AUTOMATION_GRADUATION_EVAL_SCHEMA_VERSION,
+            "status": "rejected",
+            "gate_id": gate_id,
+            "decision": "hold",
+            "promotion_allowed": False,
+            "failed_checks": failed_checks,
+        }
+
+    expected_from = int(gate.get("from_level", -1))
+    expected_to = int(gate.get("to_level", -1))
+    proposal_from = int(proposal.get("from_level", -1))
+    proposal_to = int(proposal.get("to_level", -1))
+    if proposal_from != expected_from or proposal_to != expected_to:
+        failed_checks.append("level_transition_mismatch")
+
+    recommendation = _as_text(proposal.get("recommendation")).lower()
+    if recommendation not in {"promote", "hold", "revert"}:
+        failed_checks.append("invalid_recommendation")
+
+    required_families = _as_text_set(criteria.get("gate_families_required"))
+    passed_families = _as_text_set(proposal.get("gate_families_passed"))
+    missing_families = sorted(required_families - passed_families)
+    if missing_families:
+        failed_checks.append("missing_required_gate_families")
+
+    must_show = _as_text_set(gate.get("must_show"))
+    evidence_signals = _as_text_set(proposal.get("evidence_signals"))
+    missing_must_show = sorted(must_show - evidence_signals)
+    if missing_must_show:
+        failed_checks.append("missing_must_show_evidence")
+
+    blocked_signals = _as_text_set(gate.get("blocked_if"))
+    risk_signals = _as_text_set(proposal.get("risk_signals"))
+    triggered_blockers = sorted(blocked_signals & risk_signals)
+    if triggered_blockers:
+        failed_checks.append("blocked_signal_triggered")
+
+    required_metrics = _as_text_set(criteria.get("metrics_required"))
+    metrics = proposal.get("metrics", {})
+    provided_metrics: set[str] = set()
+    if isinstance(metrics, Mapping):
+        provided_metrics = _as_text_set(list(metrics.keys()))
+    else:
+        failed_checks.append("metrics_not_mapping")
+    missing_metrics = sorted(required_metrics - provided_metrics)
+    if missing_metrics:
+        failed_checks.append("missing_required_metrics")
+
+    fail_closed = bool(failed_checks)
+    promotion_allowed = not fail_closed
+    status = "approved" if promotion_allowed and recommendation == "promote" else "held"
+    if fail_closed:
+        status = "rejected"
+
+    decision = "promote" if status == "approved" else "hold"
+    return {
+        "schema_version": AUTOMATION_GRADUATION_EVAL_SCHEMA_VERSION,
+        "status": status,
+        "gate_id": gate_id,
+        "from_level": proposal_from,
+        "to_level": proposal_to,
+        "decision": decision,
+        "promotion_allowed": promotion_allowed,
+        "failed_checks": sorted(set(failed_checks)),
+        "missing_gate_families": missing_families,
+        "missing_must_show": missing_must_show,
+        "triggered_blockers": triggered_blockers,
+        "missing_metrics": missing_metrics,
+    }
+
+
+def build_nat_automation_graduation_report(
+    criteria: Mapping[str, Any],
+    proposal: Mapping[str, Any],
+) -> dict[str, Any]:
+    evaluation = evaluate_nat_automation_promotion(criteria, proposal)
+    proposal_id = _as_text(proposal.get("proposal_id"))
+    lane = _as_text(criteria.get("lane"))
+    return {
+        "schema_version": AUTOMATION_GRADUATION_REPORT_SCHEMA_VERSION,
+        "lane": lane,
+        "proposal_id": proposal_id,
+        "gate_id": evaluation.get("gate_id", ""),
+        "decision": evaluation["decision"],
+        "status": evaluation["status"],
+        "promotion_allowed": evaluation["promotion_allowed"],
+        "failed_checks": evaluation["failed_checks"],
+        "summary": {
+            "missing_gate_families": evaluation.get("missing_gate_families", []),
+            "missing_must_show": evaluation.get("missing_must_show", []),
+            "triggered_blockers": evaluation.get("triggered_blockers", []),
+            "missing_metrics": evaluation.get("missing_metrics", []),
+        },
+        "evaluation": evaluation,
+    }
+
+
+def build_nat_automation_graduation_batch_report(
+    criteria: Mapping[str, Any],
+    proposal_batch: Mapping[str, Any],
+) -> dict[str, Any]:
+    proposals_raw = proposal_batch.get("proposals", [])
+    reports: list[dict[str, Any]] = []
+    if isinstance(proposals_raw, Sequence):
+        for proposal in proposals_raw:
+            if isinstance(proposal, Mapping):
+                reports.append(build_nat_automation_graduation_report(criteria, proposal))
+
+    approved_count = sum(1 for report in reports if report.get("status") == "approved")
+    held_count = sum(1 for report in reports if report.get("status") == "held")
+    rejected_count = sum(1 for report in reports if report.get("status") == "rejected")
+    fail_closed_count = sum(1 for report in reports if not bool(report.get("promotion_allowed")))
+
+    return {
+        "schema_version": AUTOMATION_GRADUATION_BATCH_REPORT_SCHEMA_VERSION,
+        "lane": _as_text(criteria.get("lane")),
+        "batch_id": _as_text(proposal_batch.get("batch_id")),
+        "proposal_count": len(reports),
+        "summary": {
+            "approved_count": approved_count,
+            "held_count": held_count,
+            "rejected_count": rejected_count,
+            "fail_closed_count": fail_closed_count,
+        },
+        "reports": reports,
+    }
+
+
+def build_nat_automation_graduation_evidence_report(
+    criteria: Mapping[str, Any],
+    proposal_batches: Mapping[str, Any],
+    *,
+    min_runs: int = 2,
+) -> dict[str, Any]:
+    raw_runs = proposal_batches.get("runs", [])
+    batch_reports: list[dict[str, Any]] = []
+    if isinstance(raw_runs, Sequence):
+        for index, run in enumerate(raw_runs):
+            if not isinstance(run, Mapping):
+                continue
+            report = build_nat_automation_graduation_batch_report(criteria, run)
+            report_with_run = dict(report)
+            report_with_run["run_id"] = _as_text(run.get("run_id")) or f"run-{index + 1}"
+            batch_reports.append(report_with_run)
+
+    run_count = len(batch_reports)
+    proposal_count = sum(int(report.get("proposal_count", 0)) for report in batch_reports)
+    approved_count = sum(int(report.get("summary", {}).get("approved_count", 0)) for report in batch_reports)
+    held_count = sum(int(report.get("summary", {}).get("held_count", 0)) for report in batch_reports)
+    rejected_count = sum(int(report.get("summary", {}).get("rejected_count", 0)) for report in batch_reports)
+    fail_closed_count = sum(int(report.get("summary", {}).get("fail_closed_count", 0)) for report in batch_reports)
+
+    all_gate_ids = {
+        _as_text(item.get("gate_id"))
+        for report in batch_reports
+        for item in report.get("reports", [])
+        if isinstance(item, Mapping) and _as_text(item.get("gate_id"))
+    }
+    consistency_gate_id = next(iter(all_gate_ids), "")
+    gate_consistent = len(all_gate_ids) <= 1
+
+    failed_reasons: list[str] = []
+    if run_count < max(int(min_runs), 1):
+        failed_reasons.append("insufficient_repeated_runs")
+    if proposal_count <= 0:
+        failed_reasons.append("no_proposals_evaluated")
+    if rejected_count > 0:
+        failed_reasons.append("rejected_proposals_present")
+    if fail_closed_count > 0:
+        failed_reasons.append("fail_closed_proposals_present")
+    if held_count > 0:
+        failed_reasons.append("held_proposals_present")
+    if not gate_consistent:
+        failed_reasons.append("mixed_gate_scope")
+
+    promotion_ready = not failed_reasons
+    decision = "promote" if promotion_ready else "hold"
+    status = "ready" if promotion_ready else "not_ready"
+
+    return {
+        "schema_version": AUTOMATION_GRADUATION_EVIDENCE_REPORT_SCHEMA_VERSION,
+        "lane": _as_text(criteria.get("lane")),
+        "evidence_batch_id": _as_text(proposal_batches.get("evidence_batch_id")),
+        "status": status,
+        "decision": decision,
+        "promotion_ready": promotion_ready,
+        "readiness_failed_reasons": sorted(set(failed_reasons)),
+        "readiness_scope": {
+            "min_runs": max(int(min_runs), 1),
+            "run_count": run_count,
+            "proposal_count": proposal_count,
+            "gate_consistent": gate_consistent,
+            "gate_id": consistency_gate_id,
+        },
+        "summary": {
+            "approved_count": approved_count,
+            "held_count": held_count,
+            "rejected_count": rejected_count,
+            "fail_closed_count": fail_closed_count,
+        },
+        "run_reports": batch_reports,
+    }
+
+
+def build_nat_automation_graduation_governance_index(
+    criteria: Mapping[str, Any],
+    evidence_snapshots: Mapping[str, Any],
+    *,
+    min_snapshots: int = 2,
+) -> dict[str, Any]:
+    raw_snapshots = evidence_snapshots.get("snapshots", [])
+    reports: list[dict[str, Any]] = []
+    if isinstance(raw_snapshots, Sequence):
+        for index, snapshot in enumerate(raw_snapshots):
+            if not isinstance(snapshot, Mapping):
+                continue
+            snapshot_id = _as_text(snapshot.get("snapshot_id")) or f"snapshot-{index + 1}"
+            if isinstance(snapshot.get("evidence_report"), Mapping):
+                report = dict(snapshot["evidence_report"])
+            elif isinstance(snapshot.get("proposal_batches"), Mapping):
+                report = build_nat_automation_graduation_evidence_report(
+                    criteria,
+                    snapshot["proposal_batches"],
+                    min_runs=int(snapshot.get("min_runs", 2)),
+                )
+            else:
+                report = {
+                    "schema_version": AUTOMATION_GRADUATION_EVIDENCE_REPORT_SCHEMA_VERSION,
+                    "status": "not_ready",
+                    "decision": "hold",
+                    "promotion_ready": False,
+                    "readiness_failed_reasons": ["snapshot_missing_evidence_payload"],
+                    "readiness_scope": {"gate_id": "", "run_count": 0},
+                    "summary": {
+                        "approved_count": 0,
+                        "held_count": 0,
+                        "rejected_count": 0,
+                        "fail_closed_count": 0,
+                    },
+                }
+            report["snapshot_id"] = snapshot_id
+            reports.append(report)
+
+    snapshot_count = len(reports)
+    ready_count = sum(1 for report in reports if bool(report.get("promotion_ready")))
+    not_ready_count = snapshot_count - ready_count
+    rejected_total = sum(int(report.get("summary", {}).get("rejected_count", 0)) for report in reports)
+    fail_closed_total = sum(int(report.get("summary", {}).get("fail_closed_count", 0)) for report in reports)
+
+    gate_ids = {
+        _as_text(report.get("readiness_scope", {}).get("gate_id"))
+        for report in reports
+        if _as_text(report.get("readiness_scope", {}).get("gate_id"))
+    }
+    gate_scope_consistent = len(gate_ids) <= 1
+    gate_id = next(iter(gate_ids), "")
+
+    failed_reasons: list[str] = []
+    if snapshot_count < max(int(min_snapshots), 1):
+        failed_reasons.append("insufficient_snapshot_count")
+    if snapshot_count <= 0:
+        failed_reasons.append("no_snapshots_evaluated")
+    if not_ready_count > 0:
+        failed_reasons.append("not_ready_snapshots_present")
+    if rejected_total > 0:
+        failed_reasons.append("rejected_proposals_present")
+    if fail_closed_total > 0:
+        failed_reasons.append("fail_closed_proposals_present")
+    if not gate_scope_consistent:
+        failed_reasons.append("mixed_gate_scope")
+
+    promotion_ready = not failed_reasons
+    decision = "promote" if promotion_ready else "hold"
+    status = "ready" if promotion_ready else "not_ready"
+
+    return {
+        "schema_version": AUTOMATION_GRADUATION_GOVERNANCE_INDEX_SCHEMA_VERSION,
+        "lane": _as_text(criteria.get("lane")),
+        "governance_batch_id": _as_text(evidence_snapshots.get("governance_batch_id")),
+        "status": status,
+        "decision": decision,
+        "promotion_ready": promotion_ready,
+        "readiness_failed_reasons": sorted(set(failed_reasons)),
+        "scope": {
+            "min_snapshots": max(int(min_snapshots), 1),
+            "snapshot_count": snapshot_count,
+            "gate_scope_consistent": gate_scope_consistent,
+            "gate_id": gate_id,
+        },
+        "summary": {
+            "ready_count": ready_count,
+            "not_ready_count": not_ready_count,
+            "rejected_count": rejected_total,
+            "fail_closed_count": fail_closed_total,
+        },
+        "snapshot_reports": reports,
+    }
+
+
+def build_nat_automation_graduation_governance_summary(
+    criteria: Mapping[str, Any],
+    governance_snapshots: Mapping[str, Any],
+    *,
+    min_indexes: int = 2,
+) -> dict[str, Any]:
+    raw_snapshots = governance_snapshots.get("snapshots", [])
+    reports: list[dict[str, Any]] = []
+    if isinstance(raw_snapshots, Sequence):
+        for index, snapshot in enumerate(raw_snapshots):
+            if not isinstance(snapshot, Mapping):
+                continue
+            snapshot_id = _as_text(snapshot.get("snapshot_id")) or f"governance-snapshot-{index + 1}"
+            if isinstance(snapshot.get("governance_index"), Mapping):
+                report = dict(snapshot["governance_index"])
+            elif isinstance(snapshot.get("evidence_snapshots"), Mapping):
+                report = build_nat_automation_graduation_governance_index(
+                    criteria,
+                    snapshot["evidence_snapshots"],
+                    min_snapshots=int(snapshot.get("min_snapshots", 2)),
+                )
+            else:
+                report = {
+                    "schema_version": AUTOMATION_GRADUATION_GOVERNANCE_INDEX_SCHEMA_VERSION,
+                    "status": "not_ready",
+                    "decision": "hold",
+                    "promotion_ready": False,
+                    "readiness_failed_reasons": ["snapshot_missing_governance_payload"],
+                    "scope": {"gate_id": "", "snapshot_count": 0},
+                    "summary": {
+                        "ready_count": 0,
+                        "not_ready_count": 0,
+                        "rejected_count": 0,
+                        "fail_closed_count": 0,
+                    },
+                }
+            report["snapshot_id"] = snapshot_id
+            reports.append(report)
+
+    index_count = len(reports)
+    ready_count = sum(1 for report in reports if bool(report.get("promotion_ready")))
+    not_ready_count = index_count - ready_count
+    rejected_total = sum(int(report.get("summary", {}).get("rejected_count", 0)) for report in reports)
+    fail_closed_total = sum(int(report.get("summary", {}).get("fail_closed_count", 0)) for report in reports)
+
+    gate_ids = {
+        _as_text(report.get("scope", {}).get("gate_id"))
+        for report in reports
+        if _as_text(report.get("scope", {}).get("gate_id"))
+    }
+    gate_scope_consistent = len(gate_ids) <= 1
+    gate_id = next(iter(gate_ids), "")
+
+    failed_reasons: list[str] = []
+    if index_count < max(int(min_indexes), 1):
+        failed_reasons.append("insufficient_governance_index_count")
+    if index_count <= 0:
+        failed_reasons.append("no_governance_indexes_evaluated")
+    if not_ready_count > 0:
+        failed_reasons.append("not_ready_governance_indexes_present")
+    if rejected_total > 0:
+        failed_reasons.append("rejected_proposals_present")
+    if fail_closed_total > 0:
+        failed_reasons.append("fail_closed_proposals_present")
+    if not gate_scope_consistent:
+        failed_reasons.append("mixed_gate_scope")
+
+    promotion_ready = not failed_reasons
+    decision = "promote" if promotion_ready else "hold"
+    status = "ready" if promotion_ready else "not_ready"
+
+    return {
+        "schema_version": AUTOMATION_GRADUATION_GOVERNANCE_SUMMARY_SCHEMA_VERSION,
+        "lane": _as_text(criteria.get("lane")),
+        "governance_summary_id": _as_text(governance_snapshots.get("governance_summary_id")),
+        "status": status,
+        "decision": decision,
+        "promotion_ready": promotion_ready,
+        "readiness_failed_reasons": sorted(set(failed_reasons)),
+        "scope": {
+            "min_indexes": max(int(min_indexes), 1),
+            "index_count": index_count,
+            "gate_scope_consistent": gate_scope_consistent,
+            "gate_id": gate_id,
+        },
+        "summary": {
+            "ready_count": ready_count,
+            "not_ready_count": not_ready_count,
+            "rejected_count": rejected_total,
+            "fail_closed_count": fail_closed_total,
+        },
+        "governance_reports": reports,
+    }
+
+
+__all__ = [
+    "AUTOMATION_GRADUATION_EVAL_SCHEMA_VERSION",
+    "AUTOMATION_GRADUATION_REPORT_SCHEMA_VERSION",
+    "AUTOMATION_GRADUATION_BATCH_REPORT_SCHEMA_VERSION",
+    "AUTOMATION_GRADUATION_EVIDENCE_REPORT_SCHEMA_VERSION",
+    "AUTOMATION_GRADUATION_GOVERNANCE_INDEX_SCHEMA_VERSION",
+    "AUTOMATION_GRADUATION_GOVERNANCE_SUMMARY_SCHEMA_VERSION",
+    "build_nat_automation_graduation_batch_report",
+    "build_nat_automation_graduation_evidence_report",
+    "build_nat_automation_graduation_governance_index",
+    "build_nat_automation_graduation_governance_summary",
+    "build_nat_automation_graduation_report",
+    "evaluate_nat_automation_promotion",
+]

--- a/src/ontology/wikidata_nat_cohort_b_operator_batch_report.py
+++ b/src/ontology/wikidata_nat_cohort_b_operator_batch_report.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Mapping, Sequence
+
+from .wikidata_nat_cohort_b_operator_queue import build_nat_cohort_b_operator_queue
+from .wikidata_nat_cohort_b_operator_report import build_nat_cohort_b_operator_report
+
+
+WIKIDATA_NAT_COHORT_B_OPERATOR_BATCH_REPORT_SCHEMA_VERSION = (
+    "sl.wikidata_nat_cohort_b_operator_batch_report.v0_1"
+)
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _normalize_case_summaries(operator_packets: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    for index, packet in enumerate(operator_packets):
+        if not isinstance(packet, Mapping):
+            continue
+        summary = packet.get("summary", {})
+        summary_map = summary if isinstance(summary, Mapping) else {}
+        cases.append(
+            {
+                "case_id": f"cohort-b-case:{index + 1}",
+                "packet_id": _stringify(packet.get("packet_id")),
+                "decision": _stringify(packet.get("decision")) or "hold",
+                "selected_row_count": int(summary_map.get("selected_row_count", 0) or 0),
+                "variance_flag_counts": dict(summary_map.get("variance_flag_counts", {}))
+                if isinstance(summary_map.get("variance_flag_counts"), Mapping)
+                else {},
+            }
+        )
+    return cases
+
+
+def _packet_decision_counts(cases: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts = Counter(_stringify(case.get("decision")) for case in cases if _stringify(case.get("decision")))
+    return {key: counts[key] for key in sorted(counts)}
+
+
+def build_nat_cohort_b_operator_batch_report(
+    operator_packets: Sequence[Mapping[str, Any]],
+    *,
+    max_queue_items: int = 100,
+    max_examples: int = 10,
+) -> dict[str, Any]:
+    if not isinstance(operator_packets, Sequence) or isinstance(
+        operator_packets, (str, bytes, bytearray)
+    ):
+        raise ValueError("operator_packets must be a sequence of Cohort B operator packet objects")
+
+    case_summaries = _normalize_case_summaries(operator_packets)
+    queue_payload = build_nat_cohort_b_operator_queue(
+        operator_packets,
+        max_queue_items=max_queue_items,
+    )
+    report_payload = build_nat_cohort_b_operator_report(
+        queue_payload,
+        max_examples=max_examples,
+    )
+
+    decision_reasons: list[str] = []
+    if len(case_summaries) < 2:
+        batch_status = "hold"
+        decision_reasons.append("requires_at_least_two_operator_cases")
+    elif queue_payload.get("queue_status") != "review_queue_ready":
+        batch_status = "hold"
+        decision_reasons.append("queue_not_ready")
+    elif report_payload.get("report_status") != "review_only_report_ready":
+        batch_status = "hold"
+        decision_reasons.append("report_not_ready")
+    else:
+        batch_status = "batch_review_ready"
+        decision_reasons.append("multi_case_operator_evidence_materialized")
+
+    return {
+        "schema_version": WIKIDATA_NAT_COHORT_B_OPERATOR_BATCH_REPORT_SCHEMA_VERSION,
+        "lane_id": _stringify(queue_payload.get("lane_id")) or "wikidata_nat_wdu_p5991_p14143",
+        "cohort_id": "cohort_b_reconciled_non_business",
+        "batch_status": batch_status,
+        "decision_reasons": sorted(set(decision_reasons)),
+        "case_summaries": case_summaries,
+        "packet_decision_counts": _packet_decision_counts(case_summaries),
+        "queue": queue_payload,
+        "report": report_payload,
+        "summary": {
+            "case_count": len(case_summaries),
+            "queue_item_count": int(queue_payload.get("summary", {}).get("queue_item_count", 0) or 0)
+            if isinstance(queue_payload.get("summary"), Mapping)
+            else 0,
+            "blocked_packet_count": int(report_payload.get("summary", {}).get("blocked_packet_count", 0) or 0)
+            if isinstance(report_payload.get("summary"), Mapping)
+            else 0,
+            "validation_error_count": int(report_payload.get("summary", {}).get("validation_error_count", 0) or 0)
+            if isinstance(report_payload.get("summary"), Mapping)
+            else 0,
+            "review_first": True,
+        },
+        "governance": {
+            "automation_allowed": False,
+            "fail_closed": True,
+            "requires_human_review": True,
+        },
+        "non_claims": [
+            "batch evidence report only",
+            "not migration execution",
+            "not cross-cohort arbitration",
+        ],
+    }
+
+
+__all__ = [
+    "WIKIDATA_NAT_COHORT_B_OPERATOR_BATCH_REPORT_SCHEMA_VERSION",
+    "build_nat_cohort_b_operator_batch_report",
+]

--- a/src/ontology/wikidata_nat_cohort_b_operator_control_summary.py
+++ b/src/ontology/wikidata_nat_cohort_b_operator_control_summary.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from typing import Any, Mapping, Sequence
+
+
+WIKIDATA_NAT_COHORT_B_OPERATOR_CONTROL_SUMMARY_SCHEMA_VERSION = (
+    "sl.wikidata_nat_cohort_b_operator_control_summary.v0_1"
+)
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _counter_dict(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+def _index_id(index_payload: Mapping[str, Any], position: int) -> str:
+    digest = hashlib.sha1(
+        json.dumps(
+            {
+                "position": position,
+                "lane_id": _stringify(index_payload.get("lane_id")),
+                "index_status": _stringify(index_payload.get("index_status")),
+                "decision_reasons": index_payload.get("decision_reasons", []),
+                "summary": index_payload.get("summary", {}),
+            },
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:12]
+    return f"cohort-b-index:{digest}"
+
+
+def build_nat_cohort_b_operator_control_summary(
+    index_payloads: Sequence[Mapping[str, Any]],
+    *,
+    min_ready_indexes: int = 2,
+) -> dict[str, Any]:
+    if not isinstance(index_payloads, Sequence) or isinstance(
+        index_payloads, (str, bytes, bytearray)
+    ):
+        raise ValueError("index_payloads must be a sequence of Cohort B evidence-index objects")
+    if min_ready_indexes < 1:
+        raise ValueError("min_ready_indexes must be at least 1")
+
+    entries: list[dict[str, Any]] = []
+    validation_errors: list[dict[str, str]] = []
+    lane_id = ""
+    for idx, payload in enumerate(index_payloads):
+        if not isinstance(payload, Mapping):
+            validation_errors.append({"index_position": str(idx), "error": "index_not_object"})
+            continue
+        lane_id = lane_id or _stringify(payload.get("lane_id"))
+        cohort_id = _stringify(payload.get("cohort_id"))
+        index_status = _stringify(payload.get("index_status"))
+        summary = payload.get("summary", {})
+        summary_map = summary if isinstance(summary, Mapping) else {}
+        if cohort_id != "cohort_b_reconciled_non_business":
+            validation_errors.append({"index_position": str(idx), "error": "index_not_cohort_b"})
+            continue
+        if index_status not in {"review_index_ready", "hold"}:
+            validation_errors.append({"index_position": str(idx), "error": "invalid_index_status"})
+            continue
+        entries.append(
+            {
+                "index_id": _index_id(payload, idx),
+                "index_position": idx,
+                "index_status": index_status,
+                "decision_reasons": [
+                    _stringify(item)
+                    for item in payload.get("decision_reasons", [])
+                    if _stringify(item)
+                ]
+                if isinstance(payload.get("decision_reasons"), list)
+                else [],
+                "ready_batch_count": int(summary_map.get("ready_batch_count", 0) or 0),
+                "hold_batch_count": int(summary_map.get("hold_batch_count", 0) or 0),
+                "validation_error_count": int(summary_map.get("validation_error_count", 0) or 0),
+            }
+        )
+
+    entries.sort(key=lambda item: (item["index_position"], item["index_id"]))
+    status_counts = Counter(entry["index_status"] for entry in entries if entry["index_status"])
+    ready_entries = [entry for entry in entries if entry["index_status"] == "review_index_ready"]
+    hold_entries = [entry for entry in entries if entry["index_status"] == "hold"]
+
+    if validation_errors:
+        control_status = "hold"
+        decision_reasons = ["validation_errors_present"]
+    elif len(ready_entries) < min_ready_indexes:
+        control_status = "hold"
+        decision_reasons = ["insufficient_ready_indexes"]
+    elif hold_entries:
+        control_status = "hold"
+        decision_reasons = ["hold_indexes_present"]
+    else:
+        control_status = "review_control_ready"
+        decision_reasons = ["ready_indexes_meet_threshold"]
+
+    return {
+        "schema_version": WIKIDATA_NAT_COHORT_B_OPERATOR_CONTROL_SUMMARY_SCHEMA_VERSION,
+        "lane_id": lane_id or "wikidata_nat_wdu_p5991_p14143",
+        "cohort_id": "cohort_b_reconciled_non_business",
+        "control_status": control_status,
+        "decision_reasons": decision_reasons,
+        "ready_index_ids": [entry["index_id"] for entry in ready_entries]
+        if control_status == "review_control_ready"
+        else [],
+        "index_entries": entries,
+        "validation_errors": validation_errors,
+        "summary": {
+            "input_index_count": len(index_payloads),
+            "valid_index_count": len(entries),
+            "ready_index_count": len(ready_entries),
+            "hold_index_count": len(hold_entries),
+            "validation_error_count": len(validation_errors),
+            "status_counts": _counter_dict(status_counts),
+            "aggregate_ready_batch_count": sum(entry["ready_batch_count"] for entry in entries),
+            "aggregate_hold_batch_count": sum(entry["hold_batch_count"] for entry in entries),
+            "review_first": True,
+        },
+        "governance": {
+            "automation_allowed": False,
+            "fail_closed": True,
+            "requires_human_review": True,
+        },
+        "non_claims": [
+            "operator control summary only",
+            "not migration execution",
+            "not cross-cohort arbitration",
+        ],
+    }
+
+
+__all__ = [
+    "WIKIDATA_NAT_COHORT_B_OPERATOR_CONTROL_SUMMARY_SCHEMA_VERSION",
+    "build_nat_cohort_b_operator_control_summary",
+]

--- a/src/ontology/wikidata_nat_cohort_b_operator_evidence_index.py
+++ b/src/ontology/wikidata_nat_cohort_b_operator_evidence_index.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from typing import Any, Mapping, Sequence
+
+
+WIKIDATA_NAT_COHORT_B_OPERATOR_EVIDENCE_INDEX_SCHEMA_VERSION = (
+    "sl.wikidata_nat_cohort_b_operator_evidence_index.v0_1"
+)
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _counter_dict(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+def _batch_id(batch: Mapping[str, Any], index: int) -> str:
+    payload = {
+        "index": index,
+        "lane_id": _stringify(batch.get("lane_id")),
+        "decision_reasons": list(batch.get("decision_reasons", []))
+        if isinstance(batch.get("decision_reasons"), list)
+        else [],
+        "packet_decision_counts": dict(batch.get("packet_decision_counts", {}))
+        if isinstance(batch.get("packet_decision_counts"), Mapping)
+        else {},
+        "summary": dict(batch.get("summary", {})) if isinstance(batch.get("summary"), Mapping) else {},
+    }
+    digest = hashlib.sha1(
+        json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:12]
+    return f"cohort-b-batch:{digest}"
+
+
+def build_nat_cohort_b_operator_evidence_index(
+    batch_reports: Sequence[Mapping[str, Any]],
+    *,
+    min_ready_batches: int = 2,
+) -> dict[str, Any]:
+    if not isinstance(batch_reports, Sequence) or isinstance(
+        batch_reports, (str, bytes, bytearray)
+    ):
+        raise ValueError("batch_reports must be a sequence of Cohort B batch-report objects")
+    if min_ready_batches < 1:
+        raise ValueError("min_ready_batches must be at least 1")
+
+    validation_errors: list[dict[str, str]] = []
+    batch_entries: list[dict[str, Any]] = []
+    lane_id = ""
+
+    for index, batch in enumerate(batch_reports):
+        if not isinstance(batch, Mapping):
+            validation_errors.append({"batch_index": str(index), "error": "batch_not_object"})
+            continue
+        lane_id = lane_id or _stringify(batch.get("lane_id"))
+        cohort_id = _stringify(batch.get("cohort_id"))
+        batch_status = _stringify(batch.get("batch_status"))
+        summary = batch.get("summary", {})
+        summary_map = summary if isinstance(summary, Mapping) else {}
+        if cohort_id != "cohort_b_reconciled_non_business":
+            validation_errors.append(
+                {"batch_index": str(index), "error": "batch_not_cohort_b"}
+            )
+            continue
+        if batch_status not in {"batch_review_ready", "hold"}:
+            validation_errors.append(
+                {"batch_index": str(index), "error": "invalid_batch_status"}
+            )
+            continue
+        batch_entries.append(
+            {
+                "batch_id": _batch_id(batch, index),
+                "batch_index": index,
+                "batch_status": batch_status,
+                "decision_reasons": [
+                    _stringify(item)
+                    for item in batch.get("decision_reasons", [])
+                    if _stringify(item)
+                ]
+                if isinstance(batch.get("decision_reasons"), list)
+                else [],
+                "case_count": int(summary_map.get("case_count", 0) or 0),
+                "queue_item_count": int(summary_map.get("queue_item_count", 0) or 0),
+                "blocked_packet_count": int(summary_map.get("blocked_packet_count", 0) or 0),
+                "validation_error_count": int(summary_map.get("validation_error_count", 0) or 0),
+            }
+        )
+
+    batch_entries.sort(key=lambda item: (item["batch_index"], item["batch_id"]))
+
+    status_counts = Counter(entry["batch_status"] for entry in batch_entries if entry["batch_status"])
+    ready_batches = [entry for entry in batch_entries if entry["batch_status"] == "batch_review_ready"]
+    hold_batches = [entry for entry in batch_entries if entry["batch_status"] == "hold"]
+
+    if validation_errors:
+        index_status = "hold"
+        decision_reasons = ["validation_errors_present"]
+    elif len(ready_batches) < min_ready_batches:
+        index_status = "hold"
+        decision_reasons = ["insufficient_ready_batches"]
+    elif hold_batches:
+        index_status = "hold"
+        decision_reasons = ["hold_batches_present"]
+    else:
+        index_status = "review_index_ready"
+        decision_reasons = ["ready_batches_meet_threshold"]
+
+    return {
+        "schema_version": WIKIDATA_NAT_COHORT_B_OPERATOR_EVIDENCE_INDEX_SCHEMA_VERSION,
+        "lane_id": lane_id or "wikidata_nat_wdu_p5991_p14143",
+        "cohort_id": "cohort_b_reconciled_non_business",
+        "index_status": index_status,
+        "decision_reasons": decision_reasons,
+        "ready_batch_ids": [entry["batch_id"] for entry in ready_batches]
+        if index_status == "review_index_ready"
+        else [],
+        "batch_entries": batch_entries,
+        "validation_errors": validation_errors,
+        "summary": {
+            "input_batch_count": len(batch_reports),
+            "valid_batch_count": len(batch_entries),
+            "ready_batch_count": len(ready_batches),
+            "hold_batch_count": len(hold_batches),
+            "validation_error_count": len(validation_errors),
+            "status_counts": _counter_dict(status_counts),
+            "review_first": True,
+        },
+        "governance": {
+            "automation_allowed": False,
+            "fail_closed": True,
+            "requires_human_review": True,
+        },
+        "non_claims": [
+            "operator evidence index only",
+            "not migration execution",
+            "not cross-cohort arbitration",
+        ],
+    }
+
+
+__all__ = [
+    "WIKIDATA_NAT_COHORT_B_OPERATOR_EVIDENCE_INDEX_SCHEMA_VERSION",
+    "build_nat_cohort_b_operator_evidence_index",
+]

--- a/src/ontology/wikidata_nat_cohort_b_operator_packet.py
+++ b/src/ontology/wikidata_nat_cohort_b_operator_packet.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+
+WIKIDATA_NAT_COHORT_B_OPERATOR_PACKET_SCHEMA_VERSION = (
+    "sl.wikidata_nat_cohort_b_operator_packet.v0_1"
+)
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return sorted({_stringify(item) for item in value if _stringify(item)})
+
+
+def _normalize_review_rows(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = payload.get("review_bucket_rows", [])
+    if not isinstance(rows, list):
+        raise ValueError("review bucket payload requires review_bucket_rows list")
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise ValueError("review bucket rows must be objects")
+        variance_flags = _string_list(row.get("variance_flags", []))
+        normalized.append(
+            {
+                "row_id": _stringify(row.get("row_id")),
+                "entity_qid": _stringify(row.get("entity_qid")),
+                "instance_of_qid": _stringify(row.get("instance_of_qid")),
+                "variance_flags": variance_flags,
+                "reviewer_questions": _string_list(row.get("reviewer_questions", [])),
+            }
+        )
+    normalized.sort(
+        key=lambda item: (-len(item["variance_flags"]), item["instance_of_qid"], item["row_id"])
+    )
+    return normalized
+
+
+def _variance_counts(rows: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for row in rows:
+        for flag in row.get("variance_flags", []):
+            key = _stringify(flag)
+            if not key:
+                continue
+            counts[key] = counts.get(key, 0) + 1
+    return {key: counts[key] for key in sorted(counts)}
+
+
+def _triage_prompts(*, decision: str, counts: Mapping[str, int], violations: Sequence[Mapping[str, Any]]) -> list[str]:
+    if decision == "hold":
+        if violations:
+            return [
+                "Payload violated the Cohort B contract; remove out-of-lane rows and retry.",
+                "Do not produce operator review packets for rows with unreconciled or business-family instance-of classes.",
+            ]
+        return [
+            "No valid Cohort B rows were available; hold and refresh bounded candidate materialization.",
+        ]
+
+    prompts = [
+        "Review highest-variance Cohort B rows first; keep lane review-only.",
+        "Confirm class-local semantics before any migration-equivalence judgment.",
+    ]
+    if counts.get("unexpected_qualifier_properties", 0) > 0:
+        prompts.append("Inspect unexpected qualifier properties as potential class-specific semantics.")
+    if counts.get("unexpected_reference_properties", 0) > 0:
+        prompts.append("Inspect unexpected reference properties for citation-shape drift.")
+    if counts.get("mixed_temporal_qualifier_resolution", 0) > 0:
+        prompts.append("Resolve temporal qualifier-mode mixing before downstream decisions.")
+    return prompts
+
+
+def build_nat_cohort_b_operator_packet(
+    review_bucket_payload: Mapping[str, Any],
+    *,
+    max_rows: int = 5,
+) -> dict[str, Any]:
+    if not isinstance(review_bucket_payload, Mapping):
+        raise ValueError("Cohort B operator packet requires review bucket payload object")
+    if _stringify(review_bucket_payload.get("cohort_id")) != "cohort_b_reconciled_non_business":
+        raise ValueError("Cohort B operator packet requires cohort_b_reconciled_non_business payload")
+
+    source_decision = _stringify(review_bucket_payload.get("decision")) or "hold"
+    if source_decision not in {"review_only", "hold"}:
+        raise ValueError("review bucket decision must be review_only or hold")
+
+    violations = [
+        {"row_id": _stringify(item.get("row_id")), "violation": _stringify(item.get("violation"))}
+        for item in review_bucket_payload.get("contract_violations", [])
+        if isinstance(item, Mapping)
+    ]
+    rows = _normalize_review_rows(review_bucket_payload)
+    if source_decision == "hold" and rows:
+        raise ValueError("hold review bucket payload must not contain review rows")
+
+    packet_decision = "review" if source_decision == "review_only" and rows else "hold"
+    if packet_decision == "hold":
+        selected_rows: list[dict[str, Any]] = []
+    else:
+        selected_rows = rows[: max(0, max_rows)]
+
+    counts = _variance_counts(selected_rows if selected_rows else rows)
+    packet_id = hashlib.sha1(
+        json.dumps(
+            {
+                "lane_id": _stringify(review_bucket_payload.get("lane_id")),
+                "cohort_id": "cohort_b_reconciled_non_business",
+                "packet_decision": packet_decision,
+                "row_ids": [row["row_id"] for row in selected_rows],
+                "violation_keys": [item["violation"] for item in violations],
+            },
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+
+    return {
+        "schema_version": WIKIDATA_NAT_COHORT_B_OPERATOR_PACKET_SCHEMA_VERSION,
+        "packet_id": f"operator-packet:{packet_id}",
+        "lane_id": _stringify(review_bucket_payload.get("lane_id")),
+        "cohort_id": "cohort_b_reconciled_non_business",
+        "decision": packet_decision,
+        "source_bucket_decision": source_decision,
+        "triage_prompts": _triage_prompts(
+            decision=packet_decision,
+            counts=counts,
+            violations=violations,
+        ),
+        "selected_rows": selected_rows,
+        "summary": {
+            "selected_row_count": len(selected_rows),
+            "source_review_row_count": len(rows),
+            "contract_violation_count": len(violations),
+            "variance_flag_counts": counts,
+            "review_first": True,
+        },
+        "governance": {
+            "automation_allowed": False,
+            "fail_closed": True,
+            "requires_human_review": True,
+        },
+        "contract_violations": violations,
+        "non_claims": [
+            "operator review packet only",
+            "not migration execution",
+            "not cross-cohort routing",
+        ],
+    }
+
+
+__all__ = [
+    "WIKIDATA_NAT_COHORT_B_OPERATOR_PACKET_SCHEMA_VERSION",
+    "build_nat_cohort_b_operator_packet",
+]

--- a/src/ontology/wikidata_nat_cohort_b_operator_queue.py
+++ b/src/ontology/wikidata_nat_cohort_b_operator_queue.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+
+WIKIDATA_NAT_COHORT_B_OPERATOR_QUEUE_SCHEMA_VERSION = (
+    "sl.wikidata_nat_cohort_b_operator_queue.v0_1"
+)
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return sorted({_stringify(item) for item in value if _stringify(item)})
+
+
+def _priority_for_variance_flags(flags: Sequence[str]) -> str:
+    count = len([flag for flag in flags if _stringify(flag)])
+    if count >= 3:
+        return "high"
+    if count >= 2:
+        return "medium"
+    return "low"
+
+
+def build_nat_cohort_b_operator_queue(
+    operator_packets: Sequence[Mapping[str, Any]],
+    *,
+    max_queue_items: int = 50,
+) -> dict[str, Any]:
+    if not isinstance(operator_packets, Sequence) or isinstance(
+        operator_packets, (str, bytes, bytearray)
+    ):
+        raise ValueError("operator_packets must be a sequence of Cohort B operator packet objects")
+
+    validation_errors: list[dict[str, str]] = []
+    review_packets: list[Mapping[str, Any]] = []
+    hold_packets: list[dict[str, str]] = []
+    lane_id = ""
+    for idx, packet in enumerate(operator_packets):
+        if not isinstance(packet, Mapping):
+            validation_errors.append({"packet_index": str(idx), "error": "packet_not_object"})
+            continue
+        packet_id = _stringify(packet.get("packet_id"))
+        cohort_id = _stringify(packet.get("cohort_id"))
+        decision = _stringify(packet.get("decision"))
+        lane_id = lane_id or _stringify(packet.get("lane_id"))
+
+        if cohort_id != "cohort_b_reconciled_non_business":
+            validation_errors.append(
+                {"packet_index": str(idx), "packet_id": packet_id, "error": "packet_not_cohort_b"}
+            )
+            continue
+        if decision == "hold":
+            hold_packets.append({"packet_id": packet_id, "reason": "packet_decision_hold"})
+            continue
+        if decision != "review":
+            validation_errors.append(
+                {
+                    "packet_index": str(idx),
+                    "packet_id": packet_id,
+                    "error": "packet_decision_must_be_review_or_hold",
+                }
+            )
+            continue
+        selected_rows = packet.get("selected_rows")
+        if not isinstance(selected_rows, list) or not selected_rows:
+            validation_errors.append(
+                {
+                    "packet_index": str(idx),
+                    "packet_id": packet_id,
+                    "error": "review_packet_missing_selected_rows",
+                }
+            )
+            continue
+        review_packets.append(packet)
+
+    queue_items: list[dict[str, Any]] = []
+    for packet in review_packets:
+        packet_id = _stringify(packet.get("packet_id"))
+        triage_prompts = _string_list(packet.get("triage_prompts", []))
+        for row in packet.get("selected_rows", []):
+            if not isinstance(row, Mapping):
+                continue
+            variance_flags = _string_list(row.get("variance_flags", []))
+            queue_items.append(
+                {
+                    "queue_item_id": (
+                        "cohort-b-queue:"
+                        + hashlib.sha1(
+                            f"{packet_id}|{_stringify(row.get('row_id'))}".encode("utf-8")
+                        ).hexdigest()[:12]
+                    ),
+                    "packet_id": packet_id,
+                    "row_id": _stringify(row.get("row_id")),
+                    "entity_qid": _stringify(row.get("entity_qid")),
+                    "instance_of_qid": _stringify(row.get("instance_of_qid")),
+                    "priority": _priority_for_variance_flags(variance_flags),
+                    "variance_flags": variance_flags,
+                    "triage_prompts": triage_prompts[:2],
+                }
+            )
+
+    queue_items.sort(
+        key=lambda item: (
+            {"high": 0, "medium": 1, "low": 2}.get(item["priority"], 3),
+            item["packet_id"],
+            item["row_id"],
+        )
+    )
+    bounded_queue_items = queue_items[: max(0, max_queue_items)]
+
+    if validation_errors or hold_packets:
+        queue_status = "hold"
+        decision_reasons = ["fail_closed_due_to_hold_or_validation_error"]
+        emitted_items: list[dict[str, Any]] = []
+    elif not bounded_queue_items:
+        queue_status = "hold"
+        decision_reasons = ["no_review_rows_available_for_queue"]
+        emitted_items = []
+    else:
+        queue_status = "review_queue_ready"
+        decision_reasons = ["validated_review_packets_materialized_to_queue"]
+        emitted_items = bounded_queue_items
+
+    return {
+        "schema_version": WIKIDATA_NAT_COHORT_B_OPERATOR_QUEUE_SCHEMA_VERSION,
+        "lane_id": lane_id or "wikidata_nat_wdu_p5991_p14143",
+        "cohort_id": "cohort_b_reconciled_non_business",
+        "queue_status": queue_status,
+        "decision_reasons": sorted(set(decision_reasons)),
+        "queue_items": emitted_items,
+        "blocked_packets": hold_packets,
+        "validation_errors": validation_errors,
+        "summary": {
+            "input_packet_count": len(operator_packets),
+            "review_packet_count": len(review_packets),
+            "hold_packet_count": len(hold_packets),
+            "validation_error_count": len(validation_errors),
+            "queue_item_count": len(emitted_items),
+            "review_first": True,
+        },
+        "governance": {
+            "automation_allowed": False,
+            "fail_closed": True,
+            "requires_human_review": True,
+        },
+        "non_claims": [
+            "queue materialization only",
+            "not migration execution",
+            "not cross-cohort arbitration",
+        ],
+    }
+
+
+__all__ = [
+    "WIKIDATA_NAT_COHORT_B_OPERATOR_QUEUE_SCHEMA_VERSION",
+    "build_nat_cohort_b_operator_queue",
+]

--- a/src/ontology/wikidata_nat_cohort_b_operator_report.py
+++ b/src/ontology/wikidata_nat_cohort_b_operator_report.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from typing import Any, Mapping, Sequence
+
+
+WIKIDATA_NAT_COHORT_B_OPERATOR_REPORT_SCHEMA_VERSION = (
+    "sl.wikidata_nat_cohort_b_operator_report.v0_1"
+)
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return sorted({_stringify(item) for item in value if _stringify(item)})
+
+
+def _priority_counts(queue_items: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts = Counter(
+        _stringify(item.get("priority")) for item in queue_items if _stringify(item.get("priority"))
+    )
+    return {key: counts[key] for key in sorted(counts)}
+
+
+def _variance_counts(queue_items: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    counts = Counter()
+    for item in queue_items:
+        for flag in _string_list(item.get("variance_flags", [])):
+            counts[flag] += 1
+    return {key: counts[key] for key in sorted(counts)}
+
+
+def _top_instance_classes(queue_items: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    counts = Counter(
+        _stringify(item.get("instance_of_qid"))
+        for item in queue_items
+        if _stringify(item.get("instance_of_qid"))
+    )
+    ordered = sorted(counts.items(), key=lambda pair: (-pair[1], pair[0]))
+    return [
+        {"instance_of_qid": instance_of_qid, "queue_row_count": count}
+        for instance_of_qid, count in ordered
+    ]
+
+
+def build_nat_cohort_b_operator_report(
+    queue_payload: Mapping[str, Any],
+    *,
+    max_examples: int = 5,
+) -> dict[str, Any]:
+    if not isinstance(queue_payload, Mapping):
+        raise ValueError("Cohort B operator report requires queue payload object")
+    if _stringify(queue_payload.get("cohort_id")) != "cohort_b_reconciled_non_business":
+        raise ValueError("Cohort B operator report requires cohort_b_reconciled_non_business queue")
+
+    queue_status = _stringify(queue_payload.get("queue_status")) or "hold"
+    queue_items_raw = queue_payload.get("queue_items", [])
+    if not isinstance(queue_items_raw, list):
+        raise ValueError("queue payload requires queue_items list")
+    queue_items = [item for item in queue_items_raw if isinstance(item, Mapping)]
+    blocked_packets = [
+        {"packet_id": _stringify(item.get("packet_id")), "reason": _stringify(item.get("reason"))}
+        for item in queue_payload.get("blocked_packets", [])
+        if isinstance(item, Mapping)
+    ]
+    validation_errors = [
+        {
+            "packet_index": _stringify(item.get("packet_index")),
+            "packet_id": _stringify(item.get("packet_id")),
+            "error": _stringify(item.get("error")),
+        }
+        for item in queue_payload.get("validation_errors", [])
+        if isinstance(item, Mapping)
+    ]
+
+    if queue_status == "review_queue_ready" and queue_items:
+        report_status = "review_only_report_ready"
+        recommendations = [
+            "Process high-priority queue rows first using bounded reviewer prompts.",
+            "Keep Cohort B lane review-only; do not execute migration from this report.",
+        ]
+    else:
+        report_status = "hold"
+        queue_items = []
+        recommendations = [
+            "Queue is not ready; resolve blocked packets or validation errors before review scheduling.",
+        ]
+
+    examples = [
+        {
+            "queue_item_id": _stringify(item.get("queue_item_id")),
+            "row_id": _stringify(item.get("row_id")),
+            "entity_qid": _stringify(item.get("entity_qid")),
+            "priority": _stringify(item.get("priority")),
+            "variance_flags": _string_list(item.get("variance_flags", [])),
+        }
+        for item in queue_items[: max(0, max_examples)]
+    ]
+    queue_digest = hashlib.sha1(
+        json.dumps(
+            {
+                "queue_status": queue_status,
+                "queue_items": [_stringify(item.get("queue_item_id")) for item in queue_items],
+                "blocked_packets": blocked_packets,
+                "validation_errors": validation_errors,
+            },
+            sort_keys=True,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+
+    return {
+        "schema_version": WIKIDATA_NAT_COHORT_B_OPERATOR_REPORT_SCHEMA_VERSION,
+        "report_id": f"cohort-b-report:{queue_digest}",
+        "lane_id": _stringify(queue_payload.get("lane_id")) or "wikidata_nat_wdu_p5991_p14143",
+        "cohort_id": "cohort_b_reconciled_non_business",
+        "report_status": report_status,
+        "queue_status": queue_status,
+        "recommendations": recommendations,
+        "examples": examples,
+        "summary": {
+            "queue_item_count": len(queue_items),
+            "blocked_packet_count": len(blocked_packets),
+            "validation_error_count": len(validation_errors),
+            "priority_counts": _priority_counts(queue_items),
+            "variance_flag_counts": _variance_counts(queue_items),
+            "top_instance_classes": _top_instance_classes(queue_items),
+            "review_first": True,
+        },
+        "blocked_packets": blocked_packets,
+        "validation_errors": validation_errors,
+        "governance": {
+            "automation_allowed": False,
+            "fail_closed": True,
+            "requires_human_review": True,
+        },
+        "non_claims": [
+            "operator report only",
+            "not migration execution",
+            "not cross-cohort arbitration",
+        ],
+    }
+
+
+__all__ = [
+    "WIKIDATA_NAT_COHORT_B_OPERATOR_REPORT_SCHEMA_VERSION",
+    "build_nat_cohort_b_operator_report",
+]

--- a/src/ontology/wikidata_nat_cohort_b_review_bucket.py
+++ b/src/ontology/wikidata_nat_cohort_b_review_bucket.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION = (
+    "sl.wikidata_nat_cohort_b_review_bucket.v0_1"
+)
+
+EXPECTED_QUALIFIER_PROPERTIES = frozenset(
+    {"P459", "P3831", "P585", "P580", "P582", "P518", "P7452"}
+)
+EXPECTED_REFERENCE_PROPERTIES = frozenset(
+    {"P854", "P1065", "P813", "P1476", "P2960"}
+)
+BUSINESS_FAMILY_INSTANCE_OF = frozenset({"Q4830453", "Q6881511", "Q891723"})
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    items = [_stringify(item) for item in value]
+    return sorted({item for item in items if item})
+
+
+def _row_variance_flags(*, qualifier_properties: Sequence[str], reference_properties: Sequence[str]) -> list[str]:
+    qualifier_set = set(qualifier_properties)
+    reference_set = set(reference_properties)
+    flags: list[str] = []
+    if qualifier_set - EXPECTED_QUALIFIER_PROPERTIES:
+        flags.append("unexpected_qualifier_properties")
+    if EXPECTED_QUALIFIER_PROPERTIES - qualifier_set:
+        flags.append("missing_expected_qualifier_properties")
+    if reference_set - EXPECTED_REFERENCE_PROPERTIES:
+        flags.append("unexpected_reference_properties")
+    if EXPECTED_REFERENCE_PROPERTIES - reference_set:
+        flags.append("missing_expected_reference_properties")
+    if {"P585", "P580", "P582"} <= qualifier_set:
+        flags.append("mixed_temporal_qualifier_resolution")
+    return sorted(set(flags))
+
+
+def _reviewer_questions(*, instance_of_qid: str, variance_flags: Sequence[str]) -> list[str]:
+    questions = [
+        f"Does class {instance_of_qid or 'unknown'} preserve semantic equivalence under P5991 -> P14143 mapping?",
+        "Are split axes sufficient to avoid claim-boundary collapse for this row?",
+    ]
+    flags = set(variance_flags)
+    if "unexpected_qualifier_properties" in flags:
+        questions.append("Do unexpected qualifier properties represent class-local semantics requiring hold?")
+    if "unexpected_reference_properties" in flags:
+        questions.append("Do unexpected reference properties change source-trust or citation-shape assumptions?")
+    if "mixed_temporal_qualifier_resolution" in flags:
+        questions.append("Should temporal qualifiers be normalized before any migration decision?")
+    return questions
+
+
+def build_nat_cohort_b_review_bucket(payload: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise ValueError("cohort B payload must be an object")
+    if _stringify(payload.get("schema_version")) != WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION:
+        raise ValueError(
+            "cohort B payload must use "
+            f"{WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION}"
+        )
+
+    rows = payload.get("candidates")
+    if not isinstance(rows, list):
+        raise ValueError("cohort B payload requires candidates list")
+
+    violations: list[dict[str, str]] = []
+    review_rows: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise ValueError("cohort B candidates must be objects")
+        row_id = _stringify(row.get("row_id"))
+        entity_qid = _stringify(row.get("entity_qid"))
+        instance_of_qid = _stringify(row.get("instance_of_qid"))
+        reconciled = bool(row.get("reconciled_instance_of"))
+
+        if not reconciled:
+            violations.append(
+                {"row_id": row_id, "violation": "unreconciled_instance_of_in_cohort_b_payload"}
+            )
+            continue
+        if instance_of_qid in BUSINESS_FAMILY_INSTANCE_OF:
+            violations.append(
+                {"row_id": row_id, "violation": "business_family_instance_of_in_cohort_b_payload"}
+            )
+            continue
+
+        qualifier_properties = _string_list(row.get("qualifier_properties", []))
+        reference_properties = _string_list(row.get("reference_properties", []))
+        variance_flags = _row_variance_flags(
+            qualifier_properties=qualifier_properties,
+            reference_properties=reference_properties,
+        )
+        review_rows.append(
+            {
+                "row_id": row_id,
+                "entity_qid": entity_qid,
+                "instance_of_qid": instance_of_qid,
+                "review_mode": "review_first",
+                "qualifier_properties": qualifier_properties,
+                "reference_properties": reference_properties,
+                "variance_flags": variance_flags,
+                "reviewer_questions": _reviewer_questions(
+                    instance_of_qid=instance_of_qid,
+                    variance_flags=variance_flags,
+                ),
+            }
+        )
+
+    decision = "review_only"
+    decision_reasons: list[str] = []
+    if violations:
+        decision = "hold"
+        decision_reasons.append("payload_contains_rows_outside_cohort_b_contract")
+    if not review_rows:
+        decision = "hold"
+        decision_reasons.append("no_valid_cohort_b_candidates")
+    if not decision_reasons:
+        decision_reasons.append("cohort_b_rows_require_reviewer_confirmation_before_migration")
+
+    return {
+        "schema_version": WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION,
+        "lane_id": _stringify(payload.get("lane_id")) or "wikidata_nat_wdu_p5991_p14143",
+        "cohort_id": "cohort_b_reconciled_non_business",
+        "decision": decision,
+        "decision_reasons": sorted(set(decision_reasons)),
+        "review_bucket_rows": review_rows if decision == "review_only" else [],
+        "contract_violations": violations,
+        "expected_shape": {
+            "qualifier_properties": sorted(EXPECTED_QUALIFIER_PROPERTIES),
+            "reference_properties": sorted(EXPECTED_REFERENCE_PROPERTIES),
+        },
+        "summary": {
+            "input_candidate_count": len(rows),
+            "valid_review_row_count": len(review_rows),
+            "contract_violation_count": len(violations),
+            "review_only_row_count": len(review_rows) if decision == "review_only" else 0,
+        },
+        "non_claims": [
+            "review-first bucket only",
+            "not migration execution",
+            "not full semantic decomposition",
+        ],
+    }
+
+
+__all__ = [
+    "WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION",
+    "build_nat_cohort_b_review_bucket",
+]

--- a/src/ontology/wikidata_nat_cohort_d_review.py
+++ b/src/ontology/wikidata_nat_cohort_d_review.py
@@ -1,0 +1,463 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+WIKIDATA_NAT_COHORT_D_TYPE_PROBING_SURFACE_SCHEMA_VERSION = (
+    "sl.wikidata_nat_cohort_d_type_probing_surface.v0_1"
+)
+WIKIDATA_NAT_COHORT_D_OPERATOR_REVIEW_SURFACE_SCHEMA_VERSION = (
+    "sl.wikidata_nat_cohort_d_operator_review_surface.v0_1"
+)
+WIKIDATA_NAT_COHORT_D_OPERATOR_REPORT_SCHEMA_VERSION = (
+    "sl.wikidata_nat_cohort_d_operator_report.v0_1"
+)
+WIKIDATA_NAT_COHORT_D_OPERATOR_REPORT_BATCH_SCHEMA_VERSION = (
+    "sl.wikidata_nat_cohort_d_operator_report_batch.v0_1"
+)
+WIKIDATA_NAT_COHORT_D_REVIEW_CONTROL_INDEX_SCHEMA_VERSION = (
+    "sl.wikidata_nat_cohort_d_review_control_index.v0_1"
+)
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [_stringify(item).strip() for item in value if _stringify(item).strip()]
+
+
+def _smallest_typing_check(packet: Mapping[str, Any]) -> str:
+    reviewer_view = packet.get("reviewer_view")
+    if not isinstance(reviewer_view, Mapping):
+        return "confirm_absence_of_instance_of"
+    decision_focus = _string_list(reviewer_view.get("decision_focus"))
+    if "resolve_page_open_questions" in decision_focus:
+        return "resolve_page_open_questions"
+    if decision_focus:
+        return decision_focus[0]
+    return "confirm_absence_of_instance_of"
+
+
+def build_wikidata_nat_cohort_d_type_probing_surface(
+    *,
+    cohort_d_review_surface: Mapping[str, Any],
+    packet_payloads: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    governance = cohort_d_review_surface.get("governance")
+    review_surface = cohort_d_review_surface.get("review_surface")
+    packet_refs = cohort_d_review_surface.get("candidate_packet_refs")
+    if not isinstance(governance, Mapping):
+        raise ValueError("cohort_d_review_surface requires governance")
+    if not isinstance(review_surface, Mapping):
+        raise ValueError("cohort_d_review_surface requires review_surface")
+    if not isinstance(packet_refs, list):
+        raise ValueError("cohort_d_review_surface requires candidate_packet_refs")
+
+    packet_by_qid: dict[str, Mapping[str, Any]] = {}
+    for packet in packet_payloads:
+        if not isinstance(packet, Mapping):
+            continue
+        qid = _stringify(packet.get("review_entity_qid", "")).strip()
+        if qid:
+            packet_by_qid[qid] = packet
+
+    probe_rows: list[dict[str, Any]] = []
+    unresolved_packet_refs: list[dict[str, str]] = []
+    for slot in packet_refs:
+        if not isinstance(slot, Mapping):
+            continue
+        qid = _stringify(slot.get("review_entity_qid", "")).strip()
+        if not qid:
+            continue
+        packet = packet_by_qid.get(qid)
+        if packet is None:
+            unresolved_packet_refs.append(
+                {
+                    "review_entity_qid": qid,
+                    "reason": "missing_packet_payload",
+                }
+            )
+            continue
+        split_context = packet.get("split_review_context")
+        reviewer_view = packet.get("reviewer_view")
+        if not isinstance(split_context, Mapping) or not isinstance(reviewer_view, Mapping):
+            unresolved_packet_refs.append(
+                {
+                    "review_entity_qid": qid,
+                    "reason": "packet_missing_required_review_fields",
+                }
+            )
+            continue
+        probe_rows.append(
+            {
+                "review_entity_qid": qid,
+                "packet_id": _stringify(packet.get("packet_id")),
+                "split_plan_id": _stringify(split_context.get("split_plan_id")),
+                "packet_status": _stringify(split_context.get("status")),
+                "recommended_next_step": _stringify(reviewer_view.get("recommended_next_step")),
+                "uncertainty_flags": _string_list(reviewer_view.get("uncertainty_flags")),
+                "smallest_typing_check": _smallest_typing_check(packet),
+                "promotion_guard": _stringify(governance.get("promotion_guard", "hold")) or "hold",
+                "execution_allowed": False,
+            }
+        )
+
+    artifact_status = "review_only_ready" if not unresolved_packet_refs else "review_only_incomplete"
+    return {
+        "schema_version": WIKIDATA_NAT_COHORT_D_TYPE_PROBING_SURFACE_SCHEMA_VERSION,
+        "lane_id": _stringify(cohort_d_review_surface.get("lane_id")),
+        "cohort_id": _stringify(cohort_d_review_surface.get("cohort_id")),
+        "artifact_status": artifact_status,
+        "current_gate_id": _stringify(review_surface.get("current_gate_id")),
+        "next_gate_id": _stringify(review_surface.get("next_gate_id")),
+        "governance": {
+            "automation_allowed": False,
+            "can_execute_edits": False,
+            "fail_closed": bool(governance.get("fail_closed", True)),
+            "promotion_guard": _stringify(governance.get("promotion_guard", "hold")) or "hold",
+        },
+        "required_reviewer_checks": [
+            {
+                "check_id": _stringify(check.get("check_id")),
+                "description": _stringify(check.get("description")),
+            }
+            for check in cohort_d_review_surface.get("required_reviewer_checks", [])
+            if isinstance(check, Mapping)
+        ],
+        "probe_rows": probe_rows,
+        "unresolved_packet_refs": unresolved_packet_refs,
+        "non_claims": [
+            "non_executing_type_probe_surface",
+            "no_direct_migration_execution",
+            "no_checked_safe_promotion_from_missing_instance_of_alone",
+        ],
+    }
+
+
+def _priority_from_probe_row(row: Mapping[str, Any]) -> str:
+    uncertainty_flags = set(_string_list(row.get("uncertainty_flags")))
+    if "page_open_questions" in uncertainty_flags:
+        return "high"
+    if _stringify(row.get("packet_status")) == "review_only":
+        return "high"
+    return "medium"
+
+
+def build_wikidata_nat_cohort_d_operator_review_surface(
+    *,
+    type_probing_surface: Mapping[str, Any],
+) -> dict[str, Any]:
+    probe_rows = type_probing_surface.get("probe_rows")
+    governance = type_probing_surface.get("governance")
+    if not isinstance(probe_rows, list):
+        raise ValueError("type_probing_surface requires probe_rows")
+    if not isinstance(governance, Mapping):
+        raise ValueError("type_probing_surface requires governance")
+
+    queue_rows: list[dict[str, Any]] = []
+    for row in probe_rows:
+        if not isinstance(row, Mapping):
+            continue
+        qid = _stringify(row.get("review_entity_qid")).strip()
+        if not qid:
+            continue
+        queue_rows.append(
+            {
+                "review_entity_qid": qid,
+                "packet_id": _stringify(row.get("packet_id")),
+                "split_plan_id": _stringify(row.get("split_plan_id")),
+                "priority": _priority_from_probe_row(row),
+                "smallest_next_check": _stringify(row.get("smallest_typing_check")),
+                "recommended_next_step": _stringify(row.get("recommended_next_step")),
+                "uncertainty_flags": _string_list(row.get("uncertainty_flags")),
+                "execution_allowed": False,
+            }
+        )
+
+    queue_rows = sorted(
+        queue_rows,
+        key=lambda row: (0 if row["priority"] == "high" else 1, row["review_entity_qid"]),
+    )
+
+    unresolved_packet_refs = type_probing_surface.get("unresolved_packet_refs")
+    unresolved_count = len(unresolved_packet_refs) if isinstance(unresolved_packet_refs, list) else 0
+    readiness = "review_queue_ready" if unresolved_count == 0 else "review_queue_incomplete"
+
+    return {
+        "schema_version": WIKIDATA_NAT_COHORT_D_OPERATOR_REVIEW_SURFACE_SCHEMA_VERSION,
+        "lane_id": _stringify(type_probing_surface.get("lane_id")),
+        "cohort_id": _stringify(type_probing_surface.get("cohort_id")),
+        "readiness": readiness,
+        "queue_size": len(queue_rows),
+        "unresolved_packet_ref_count": unresolved_count,
+        "operator_queue": queue_rows,
+        "required_checklist": [
+            "confirm_absence_of_instance_of",
+            "collect_typing_candidates",
+            "record_reconcile_or_hold_decision",
+        ],
+        "governance": {
+            "automation_allowed": False,
+            "can_execute_edits": False,
+            "fail_closed": bool(governance.get("fail_closed", True)),
+            "promotion_guard": _stringify(governance.get("promotion_guard", "hold")) or "hold",
+        },
+        "non_claims": [
+            "non_executing_operator_review_surface",
+            "no_direct_migration_execution",
+            "no_checked_safe_promotion_from_missing_instance_of_alone",
+        ],
+    }
+
+
+def build_wikidata_nat_cohort_d_operator_report(
+    operator_review_surface: Mapping[str, Any],
+) -> dict[str, Any]:
+    operator_queue = operator_review_surface.get("operator_queue")
+    governance = operator_review_surface.get("governance")
+    if not isinstance(operator_queue, list):
+        raise ValueError("operator_review_surface requires operator_queue")
+    if not isinstance(governance, Mapping):
+        raise ValueError("operator_review_surface requires governance")
+
+    high_priority_count = sum(
+        1 for row in operator_queue
+        if isinstance(row, Mapping) and _stringify(row.get("priority")) == "high"
+    )
+    medium_priority_count = sum(
+        1 for row in operator_queue
+        if isinstance(row, Mapping) and _stringify(row.get("priority")) == "medium"
+    )
+    unresolved_packet_ref_count = int(operator_review_surface.get("unresolved_packet_ref_count", 0) or 0)
+    readiness = _stringify(operator_review_surface.get("readiness"))
+
+    queue_preview: list[dict[str, Any]] = []
+    triage_prompts: list[str] = []
+    for row in operator_queue:
+        if not isinstance(row, Mapping):
+            continue
+        qid = _stringify(row.get("review_entity_qid")).strip()
+        if not qid:
+            continue
+        next_check = _stringify(row.get("smallest_next_check")).strip()
+        priority = _stringify(row.get("priority")).strip() or "medium"
+        queue_preview.append(
+            {
+                "review_entity_qid": qid,
+                "priority": priority,
+                "smallest_next_check": next_check,
+                "recommended_next_step": _stringify(row.get("recommended_next_step")),
+            }
+        )
+        triage_prompts.append(
+            f"Review {qid} as {priority} priority; start with {next_check or 'confirm_absence_of_instance_of'}."
+        )
+
+    blocked_signals: list[str] = []
+    if unresolved_packet_ref_count > 0:
+        blocked_signals.append("unresolved_packet_refs_present")
+    if readiness != "review_queue_ready":
+        blocked_signals.append("operator_review_surface_not_ready")
+
+    return {
+        "schema_version": WIKIDATA_NAT_COHORT_D_OPERATOR_REPORT_SCHEMA_VERSION,
+        "lane_id": _stringify(operator_review_surface.get("lane_id")),
+        "cohort_id": _stringify(operator_review_surface.get("cohort_id")),
+        "readiness": readiness,
+        "decision": "review",
+        "promotion_allowed": False,
+        "summary": {
+            "queue_size": len(queue_preview),
+            "high_priority_count": high_priority_count,
+            "medium_priority_count": medium_priority_count,
+            "unresolved_packet_ref_count": unresolved_packet_ref_count,
+        },
+        "queue_preview": queue_preview,
+        "triage_prompts": triage_prompts,
+        "blocked_signals": blocked_signals,
+        "governance": {
+            "automation_allowed": False,
+            "can_execute_edits": False,
+            "fail_closed": bool(governance.get("fail_closed", True)),
+            "promotion_guard": _stringify(governance.get("promotion_guard", "hold")) or "hold",
+        },
+        "non_claims": [
+            "report_only_surface",
+            "no_direct_migration_execution",
+            "no_checked_safe_promotion_from_missing_instance_of_alone",
+        ],
+    }
+
+
+def build_wikidata_nat_cohort_d_operator_report_batch(
+    *,
+    operator_review_surfaces: Sequence[Mapping[str, Any]],
+    batch_id: str | None = None,
+) -> dict[str, Any]:
+    if not operator_review_surfaces:
+        raise ValueError("operator_review_surfaces requires at least one surface")
+
+    case_reports: list[dict[str, Any]] = []
+    readiness_counts = {"review_queue_ready": 0, "review_queue_incomplete": 0}
+    total_queue_size = 0
+    total_high_priority = 0
+    total_unresolved_packet_refs = 0
+    blocked_signals: set[str] = set()
+
+    for index, surface in enumerate(operator_review_surfaces, start=1):
+        if not isinstance(surface, Mapping):
+            continue
+        report = build_wikidata_nat_cohort_d_operator_report(surface)
+        case_id = _stringify(surface.get("case_id")).strip() or f"cohort_d_case_{index}"
+        readiness = _stringify(report.get("readiness"))
+        if readiness == "review_queue_ready":
+            readiness_counts["review_queue_ready"] += 1
+        else:
+            readiness_counts["review_queue_incomplete"] += 1
+        summary = report.get("summary", {})
+        queue_size = int(summary.get("queue_size", 0) or 0)
+        high_priority_count = int(summary.get("high_priority_count", 0) or 0)
+        unresolved_count = int(summary.get("unresolved_packet_ref_count", 0) or 0)
+        total_queue_size += queue_size
+        total_high_priority += high_priority_count
+        total_unresolved_packet_refs += unresolved_count
+        blocked_signals.update(_string_list(report.get("blocked_signals")))
+        case_reports.append(
+            {
+                "case_id": case_id,
+                "lane_id": _stringify(report.get("lane_id")),
+                "cohort_id": _stringify(report.get("cohort_id")),
+                "readiness": readiness,
+                "queue_size": queue_size,
+                "high_priority_count": high_priority_count,
+                "unresolved_packet_ref_count": unresolved_count,
+                "decision": _stringify(report.get("decision")),
+                "promotion_allowed": bool(report.get("promotion_allowed", False)),
+            }
+        )
+
+    case_reports = sorted(case_reports, key=lambda case: case["case_id"])
+    all_ready = readiness_counts["review_queue_incomplete"] == 0
+    return {
+        "schema_version": WIKIDATA_NAT_COHORT_D_OPERATOR_REPORT_BATCH_SCHEMA_VERSION,
+        "batch_id": batch_id or "cohort_d_operator_report_batch",
+        "decision": "review",
+        "promotion_allowed": False,
+        "summary": {
+            "case_count": len(case_reports),
+            "readiness_counts": readiness_counts,
+            "total_queue_size": total_queue_size,
+            "total_high_priority_count": total_high_priority,
+            "total_unresolved_packet_ref_count": total_unresolved_packet_refs,
+            "all_cases_ready": all_ready,
+        },
+        "case_reports": case_reports,
+        "blocked_signals": sorted(blocked_signals),
+        "non_claims": [
+            "batch_report_only_surface",
+            "no_direct_migration_execution",
+            "no_checked_safe_promotion_from_missing_instance_of_alone",
+        ],
+    }
+
+
+def build_wikidata_nat_cohort_d_review_control_index(
+    *,
+    batch_reports: Sequence[Mapping[str, Any]],
+    index_id: str | None = None,
+) -> dict[str, Any]:
+    if not batch_reports:
+        raise ValueError("batch_reports requires at least one batch report")
+
+    batch_entries: list[dict[str, Any]] = []
+    readiness_counts = {"review_queue_ready": 0, "review_queue_incomplete": 0}
+    total_case_count = 0
+    total_queue_size = 0
+    total_unresolved_packet_ref_count = 0
+    blocked_signals: set[str] = set()
+
+    for index, batch in enumerate(batch_reports, start=1):
+        if not isinstance(batch, Mapping):
+            continue
+        summary = batch.get("summary", {})
+        if not isinstance(summary, Mapping):
+            summary = {}
+        batch_id = _stringify(batch.get("batch_id")).strip() or f"cohort_d_batch_{index}"
+        batch_case_count = int(summary.get("case_count", 0) or 0)
+        batch_queue_size = int(summary.get("total_queue_size", 0) or 0)
+        batch_unresolved = int(summary.get("total_unresolved_packet_ref_count", 0) or 0)
+        batch_all_ready = bool(summary.get("all_cases_ready", False))
+        batch_readiness = "review_queue_ready" if batch_all_ready else "review_queue_incomplete"
+
+        readiness_counts[batch_readiness] += 1
+        total_case_count += batch_case_count
+        total_queue_size += batch_queue_size
+        total_unresolved_packet_ref_count += batch_unresolved
+        blocked_signals.update(_string_list(batch.get("blocked_signals")))
+        if not batch_all_ready:
+            blocked_signals.add("batch_not_all_cases_ready")
+
+        batch_entries.append(
+            {
+                "batch_id": batch_id,
+                "readiness": batch_readiness,
+                "case_count": batch_case_count,
+                "queue_size": batch_queue_size,
+                "unresolved_packet_ref_count": batch_unresolved,
+                "decision": _stringify(batch.get("decision")) or "review",
+                "promotion_allowed": bool(batch.get("promotion_allowed", False)),
+            }
+        )
+
+    batch_entries = sorted(batch_entries, key=lambda row: row["batch_id"])
+    all_batches_ready = readiness_counts["review_queue_incomplete"] == 0
+    hold_signals = ["promotion_guard_hold_enforced"]
+    if not all_batches_ready:
+        hold_signals.append("incomplete_batch_present")
+    if total_unresolved_packet_ref_count > 0:
+        hold_signals.append("unresolved_packet_refs_present")
+
+    return {
+        "schema_version": WIKIDATA_NAT_COHORT_D_REVIEW_CONTROL_INDEX_SCHEMA_VERSION,
+        "index_id": index_id or "cohort_d_review_control_index",
+        "decision": "review",
+        "promotion_allowed": False,
+        "summary": {
+            "batch_count": len(batch_entries),
+            "case_count": total_case_count,
+            "total_queue_size": total_queue_size,
+            "total_unresolved_packet_ref_count": total_unresolved_packet_ref_count,
+            "readiness_counts": readiness_counts,
+            "all_batches_ready": all_batches_ready,
+        },
+        "batch_entries": batch_entries,
+        "blocked_signals": sorted(blocked_signals),
+        "hold_signals": hold_signals,
+        "non_claims": [
+            "control_index_only_surface",
+            "no_direct_migration_execution",
+            "no_checked_safe_promotion_from_missing_instance_of_alone",
+        ],
+    }
+
+
+__all__ = [
+    "WIKIDATA_NAT_COHORT_D_OPERATOR_REPORT_BATCH_SCHEMA_VERSION",
+    "WIKIDATA_NAT_COHORT_D_REVIEW_CONTROL_INDEX_SCHEMA_VERSION",
+    "WIKIDATA_NAT_COHORT_D_OPERATOR_REVIEW_SURFACE_SCHEMA_VERSION",
+    "WIKIDATA_NAT_COHORT_D_OPERATOR_REPORT_SCHEMA_VERSION",
+    "WIKIDATA_NAT_COHORT_D_TYPE_PROBING_SURFACE_SCHEMA_VERSION",
+    "build_wikidata_nat_cohort_d_operator_report_batch",
+    "build_wikidata_nat_cohort_d_review_control_index",
+    "build_wikidata_nat_cohort_d_operator_report",
+    "build_wikidata_nat_cohort_d_operator_review_surface",
+    "build_wikidata_nat_cohort_d_type_probing_surface",
+]

--- a/src/ontology/wikidata_review_packet_claim_boundaries.py
+++ b/src/ontology/wikidata_review_packet_claim_boundaries.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+WIKIDATA_REVIEW_PACKET_CLAIM_BOUNDARY_SCHEMA_VERSION = (
+    "sl.wikidata_review_packet.claim_boundaries.v0_1"
+)
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _normalize_anchor_refs(source_surface: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw = source_surface.get("anchor_refs", [])
+    if not isinstance(raw, list):
+        raise ValueError("source_surface.anchor_refs must be a list")
+    anchors: list[dict[str, Any]] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, Mapping):
+            raise ValueError("each anchor ref must be an object")
+        start = int(item.get("start", 0) or 0)
+        end = int(item.get("end", 0) or 0)
+        anchor_id = _stringify(item.get("anchor_id", f"anchor:{index + 1}")).strip()
+        label = _stringify(item.get("label")).strip()
+        text_excerpt = _stringify(item.get("text_excerpt")).strip()
+        anchors.append(
+            {
+                "anchor_id": anchor_id or f"anchor:{index + 1}",
+                "start": max(start, 0),
+                "end": max(end, 0),
+                "label": label,
+                "text_excerpt": text_excerpt,
+            }
+        )
+    anchors.sort(key=lambda item: (item["start"], item["end"], item["anchor_id"]))
+    return anchors
+
+
+def _normalize_split_axes(split_review_context: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw = split_review_context.get("merged_split_axes", [])
+    if not isinstance(raw, list):
+        raise ValueError("split_review_context.merged_split_axes must be a list")
+    axes: list[dict[str, Any]] = []
+    for index, axis in enumerate(raw):
+        if not isinstance(axis, Mapping):
+            raise ValueError("each merged split axis must be an object")
+        prop = _stringify(axis.get("property")).strip()
+        source = _stringify(axis.get("source")).strip()
+        reason = _stringify(axis.get("reason")).strip()
+        cardinality = int(axis.get("cardinality", 0) or 0)
+        if not prop:
+            prop = f"axis_property:{index + 1}"
+        axes.append(
+            {
+                "axis_id": f"axis:{index + 1}",
+                "property": prop,
+                "source": source,
+                "reason": reason,
+                "cardinality": max(cardinality, 0),
+            }
+        )
+    axes.sort(key=lambda item: (item["property"], item["source"], item["reason"], item["axis_id"]))
+    return axes
+
+
+def _candidate_missing_evidence(
+    *,
+    has_anchor_text: bool,
+    has_axes: bool,
+    has_page_question: bool,
+) -> list[str]:
+    missing = [
+        "no_clause_level_segmentation",
+        "no_grounded_claim_assertion",
+        "no_cross_source_alignment",
+    ]
+    if not has_anchor_text:
+        missing.append("anchor_excerpt_missing_or_empty")
+    if not has_axes:
+        missing.append("split_axes_missing")
+    if has_page_question:
+        missing.append("open_questions_unresolved")
+    return sorted(set(missing))
+
+
+def _review_prompt(*, anchor_label: str, axis_properties: Sequence[str]) -> str:
+    if anchor_label and axis_properties:
+        return f"Check whether anchor '{anchor_label}' expresses one claim boundary per axis: {', '.join(axis_properties)}."
+    if anchor_label:
+        return f"Check whether anchor '{anchor_label}' contains one or multiple candidate claim boundaries."
+    if axis_properties:
+        return f"Check whether split axes ({', '.join(axis_properties)}) imply multiple claim boundaries absent anchor coverage."
+    return "Check whether any bounded claim boundary can be justified from the packet surface."
+
+
+def build_review_packet_claim_boundaries(
+    *,
+    source_surface: Mapping[str, Any],
+    split_review_context: Mapping[str, Any],
+    parsed_page: Mapping[str, Any] | None = None,
+    page_signals: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(source_surface, Mapping):
+        raise ValueError("source_surface must be an object")
+    if not isinstance(split_review_context, Mapping):
+        raise ValueError("split_review_context must be an object")
+    if parsed_page is not None and not isinstance(parsed_page, Mapping):
+        raise ValueError("parsed_page must be an object when provided")
+    if page_signals is not None and not isinstance(page_signals, Mapping):
+        raise ValueError("page_signals must be an object when provided")
+
+    anchors = _normalize_anchor_refs(source_surface)
+    axes = _normalize_split_axes(split_review_context)
+    unresolved_questions = []
+    if isinstance(page_signals, Mapping):
+        raw_questions = page_signals.get("unresolved_questions", [])
+        if isinstance(raw_questions, list):
+            unresolved_questions = [
+                _stringify(item).strip() for item in raw_questions if _stringify(item).strip()
+            ]
+
+    boundaries: list[dict[str, Any]] = []
+    axis_properties = [axis["property"] for axis in axes]
+
+    if anchors:
+        for index, anchor in enumerate(anchors):
+            boundaries.append(
+                {
+                    "boundary_id": f"boundary:{index + 1}",
+                    "boundary_state": "candidate_only",
+                    "anchor_ref": {
+                        "anchor_id": anchor["anchor_id"],
+                        "start": anchor["start"],
+                        "end": anchor["end"],
+                        "label": anchor["label"] or None,
+                    },
+                    "axis_signals": [dict(axis) for axis in axes],
+                    "candidate_claim_text": anchor["text_excerpt"],
+                    "review_prompt": _review_prompt(
+                        anchor_label=anchor["label"],
+                        axis_properties=axis_properties,
+                    ),
+                    "missing_evidence": _candidate_missing_evidence(
+                        has_anchor_text=bool(anchor["text_excerpt"]),
+                        has_axes=bool(axes),
+                        has_page_question=bool(unresolved_questions),
+                    ),
+                }
+            )
+    elif axes:
+        boundaries.append(
+            {
+                "boundary_id": "boundary:axis-only:1",
+                "boundary_state": "candidate_only",
+                "anchor_ref": None,
+                "axis_signals": [dict(axis) for axis in axes],
+                "candidate_claim_text": "",
+                "review_prompt": _review_prompt(
+                    anchor_label="",
+                    axis_properties=axis_properties,
+                ),
+                "missing_evidence": sorted(
+                    set(
+                        _candidate_missing_evidence(
+                            has_anchor_text=False,
+                            has_axes=True,
+                            has_page_question=bool(unresolved_questions),
+                        )
+                        + ["no_anchor_refs_for_axis_mapping"]
+                    )
+                ),
+            }
+        )
+
+    return {
+        "schema_version": WIKIDATA_REVIEW_PACKET_CLAIM_BOUNDARY_SCHEMA_VERSION,
+        "decomposition_state": "candidate_only",
+        "non_claims": [
+            "not_full_semantic_decomposition",
+            "not_claim_truth_evaluation",
+            "not_execution_ready_migration_logic",
+        ],
+        "candidate_claim_boundaries": boundaries,
+        "summary": {
+            "anchor_count": len(anchors),
+            "axis_count": len(axes),
+            "candidate_boundary_count": len(boundaries),
+            "unresolved_question_count": len(unresolved_questions),
+        },
+    }
+
+
+__all__ = [
+    "WIKIDATA_REVIEW_PACKET_CLAIM_BOUNDARY_SCHEMA_VERSION",
+    "build_review_packet_claim_boundaries",
+]

--- a/src/ontology/wikidata_review_packet_cross_source_alignment.py
+++ b/src/ontology/wikidata_review_packet_cross_source_alignment.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+from typing import Any, Mapping, Sequence
+
+CROSS_SOURCE_ALIGNMENT_SCHEMA_VERSION = "sl.wikidata_review_packet.cross_source_alignment.v0_1"
+
+
+def _as_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return " ".join(str(value).split())
+
+
+def _bounded_statement(text: str, *, max_chars: int) -> str:
+    normalized = _as_text(text)
+    if len(normalized) <= max_chars:
+        return normalized
+    clipped = normalized[: max_chars - 3].rstrip()
+    return f"{clipped}..."
+
+
+def _extract_identity(source: Mapping[str, Any]) -> str:
+    identity_fields = ("qid", "entity_id", "item_id", "primary_qid", "candidate_id")
+    for field in identity_fields:
+        candidate = source.get(field)
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+        if isinstance(candidate, Sequence) and not isinstance(candidate, (str, bytes)):
+            for inner in candidate:
+                normalized = _as_text(inner)
+                if normalized:
+                    return normalized
+    return ""
+
+
+def _extract_field_signature(source: Mapping[str, Any]) -> list[str]:
+    raw_fields = source.get("fields")
+    if not isinstance(raw_fields, Sequence) or isinstance(raw_fields, (str, bytes)):
+        return []
+    normalized = []
+    for field in raw_fields:
+        text = _as_text(field)
+        if text:
+            normalized.append(text)
+    return sorted(set(normalized))
+
+
+def _build_source_profile(
+    label: str,
+    source: Mapping[str, Any] | None,
+    *,
+    max_summary_chars: int,
+) -> dict[str, Any]:
+    safe_source = source if isinstance(source, Mapping) else {}
+    identity = _extract_identity(safe_source)
+    summary_candidates = (
+        safe_source.get("summary"),
+        safe_source.get("description"),
+        safe_source.get("note"),
+        safe_source.get("why"),
+    )
+    summary_text = ""
+    for candidate in summary_candidates:
+        if candidate:
+            summary_text = _bounded_statement(candidate, max_chars=max_summary_chars)
+            break
+    return {
+        "label": label,
+        "source_tag": _as_text(safe_source.get("source")),
+        "identity": identity,
+        "key_signature": sorted(_as_text(key) for key in safe_source.keys()),
+        "field_signature": _extract_field_signature(safe_source),
+        "summary": summary_text,
+    }
+
+
+def _pairwise_signature(
+    left: dict[str, Any],
+    right: dict[str, Any],
+) -> dict[str, Any]:
+    left_label = left["label"]
+    right_label = right["label"]
+    left_keys = set(left["key_signature"])
+    right_keys = set(right["key_signature"])
+    left_fields = set(left["field_signature"])
+    right_fields = set(right["field_signature"])
+    return {
+        "pair": f"{left_label} vs {right_label}",
+        "shared_keys": sorted(left_keys & right_keys),
+        "only_in_left": sorted(left_keys - right_keys),
+        "only_in_right": sorted(right_keys - left_keys),
+        "field_overlap": sorted(left_fields & right_fields),
+    }
+
+
+def _determine_consensus(identity_values: Sequence[str]) -> tuple[str, str, int]:
+    non_empty = [value for value in identity_values if value]
+    if not non_empty:
+        return "no_consensus", "", 0
+    counts = Counter(non_empty)
+    identity, max_count = counts.most_common(1)[0]
+    if max_count >= len(non_empty) and len(non_empty) >= 2:
+        return "full_consensus", identity, max_count
+    if max_count >= 2:
+        return "partial_consensus", identity, max_count
+    return "no_consensus", "", max_count
+
+
+def summarize_cross_source_alignment(
+    *,
+    packet_id: str | None = None,
+    wiki_surface: Mapping[str, Any] | None = None,
+    query_slice: Mapping[str, Any] | None = None,
+    split_bundle: Mapping[str, Any] | None = None,
+    max_summary_chars: int = 200,
+) -> dict[str, Any]:
+    sources = [
+        ("wiki_surface", wiki_surface),
+        ("query_slice", query_slice),
+        ("split_bundle", split_bundle),
+    ]
+    profiles = {
+        label: _build_source_profile(label, source, max_summary_chars=max_summary_chars)
+        for label, source in sources
+    }
+    identity_sequence = [profile["identity"] for profile in profiles.values()]
+    consensus_level, consensus_identity, consensus_count = _determine_consensus(identity_sequence)
+
+    agreements: list[str] = []
+    disagreements: list[str] = []
+    if consensus_identity:
+        agreements.append(
+            f"Shared entity id {consensus_identity} appears in {consensus_count} source(s)."
+        )
+    elif sum(1 for value in identity_sequence if value) >= 2:
+        disagreements.append("No consistent entity identifier spans the reviewed surfaces.")
+
+    field_sets = [set(profile["field_signature"]) for profile in profiles.values() if profile["field_signature"]]
+    if len(field_sets) >= 2:
+        common_fields = set.intersection(*field_sets)
+        if common_fields:
+            agreements.append(
+                f"Shared field(s) {sorted(common_fields)} appear across the recorded surfaces."
+            )
+        else:
+            disagreements.append(
+                "Fields documented on each surface do not overlap, so reviewers should cross-check."
+            )
+    else:
+        common_fields = []
+    pairwise_signatures = [
+        _pairwise_signature(profiles[left], profiles[right])
+        for left, right in combinations(profiles.keys(), 2)
+    ]
+
+    return {
+        "schema_version": CROSS_SOURCE_ALIGNMENT_SCHEMA_VERSION,
+        "packet_id": _as_text(packet_id),
+        "consensus_level": consensus_level,
+        "consensus_identity": consensus_identity,
+        "common_fields": sorted(common_fields) if common_fields else [],
+        "agreements": agreements,
+        "disagreements": disagreements,
+        "profiles": profiles,
+        "pairwise_signatures": pairwise_signatures,
+    }

--- a/src/ontology/wikidata_review_packet_follow_depth.py
+++ b/src/ontology/wikidata_review_packet_follow_depth.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+FOLLOW_DEPTH_SCHEMA_VERSION = "sl.wikidata_review_packet.follow_depth.v0_1"
+
+
+def _as_text_list(values: Sequence[Any] | None) -> list[str]:
+    if values is None:
+        return []
+    normalized: list[str] = []
+    for value in values:
+        text = str(value).strip()
+        if text:
+            normalized.append(text)
+    return normalized
+
+
+def _bounded_excerpt(text: str, *, max_excerpt_chars: int) -> str:
+    normalized = " ".join(text.split())
+    if len(normalized) <= max_excerpt_chars:
+        return normalized
+    clipped = normalized[: max_excerpt_chars - 1].rstrip()
+    return f"{clipped}..."
+
+
+def enrich_follow_receipt_with_depth(
+    follow_receipt: Mapping[str, Any],
+    *,
+    source_text: str | None = None,
+    max_excerpt_chars: int = 240,
+) -> dict[str, Any]:
+    """
+    Build a bounded follow-depth view for one follow receipt.
+
+    This is fail-closed: if no bounded excerpt can be produced, the result
+    explicitly reports `no_excerpt_available` and does not fabricate evidence.
+    """
+    receipt_id = str(follow_receipt.get("receipt_id", "")).strip()
+    url = str(follow_receipt.get("url", "")).strip()
+    evidence = _as_text_list(follow_receipt.get("extracted_evidence"))
+    unresolved = _as_text_list(follow_receipt.get("unresolved_uncertainty"))
+
+    result: dict[str, Any] = {
+        "receipt_id": receipt_id,
+        "url": url,
+        "unresolved_uncertainty": unresolved,
+    }
+    if evidence:
+        result["status"] = "enriched"
+        result["excerpt_source"] = "extracted_evidence"
+        result["evidence_excerpt"] = _bounded_excerpt(
+            evidence[0],
+            max_excerpt_chars=max_excerpt_chars,
+        )
+        if len(evidence) > 1:
+            result["evidence_summary"] = "; ".join(evidence[:2])
+        return result
+
+    source_text_normalized = (source_text or "").strip()
+    if source_text_normalized:
+        result["status"] = "enriched"
+        result["excerpt_source"] = "source_text"
+        result["evidence_excerpt"] = _bounded_excerpt(
+            source_text_normalized,
+            max_excerpt_chars=max_excerpt_chars,
+        )
+        result["evidence_summary"] = "derived_from_bounded_source_text"
+        result["unresolved_uncertainty"] = sorted(
+            set(unresolved + ["excerpt_derived_without_explicit_extracted_evidence"])
+        )
+        return result
+
+    result["status"] = "no_excerpt_available"
+    result["failure_reason"] = "no_extracted_evidence_or_source_text"
+    return result
+
+
+def enrich_review_packet_follow_depth(
+    review_packet: Mapping[str, Any],
+    *,
+    source_text_by_url: Mapping[str, str] | None = None,
+    max_excerpt_chars: int = 240,
+) -> dict[str, Any]:
+    source_lookup = source_text_by_url or {}
+    follow_receipts = review_packet.get("follow_receipts")
+    if not isinstance(follow_receipts, Sequence):
+        follow_receipts = []
+
+    enriched_receipts: list[dict[str, Any]] = []
+    for raw_receipt in follow_receipts:
+        if not isinstance(raw_receipt, Mapping):
+            continue
+        url = str(raw_receipt.get("url", "")).strip()
+        source_text = source_lookup.get(url)
+        enriched_receipts.append(
+            enrich_follow_receipt_with_depth(
+                raw_receipt,
+                source_text=source_text,
+                max_excerpt_chars=max_excerpt_chars,
+            )
+        )
+
+    enriched_count = sum(1 for receipt in enriched_receipts if receipt.get("status") == "enriched")
+    no_excerpt_count = sum(
+        1 for receipt in enriched_receipts if receipt.get("status") == "no_excerpt_available"
+    )
+    return {
+        "schema_version": FOLLOW_DEPTH_SCHEMA_VERSION,
+        "packet_id": str(review_packet.get("packet_id", "")).strip(),
+        "receipt_count": len(enriched_receipts),
+        "enriched_count": enriched_count,
+        "no_excerpt_count": no_excerpt_count,
+        "receipts": enriched_receipts,
+    }
+

--- a/src/ontology/wikidata_review_packet_reviewer_actions.py
+++ b/src/ontology/wikidata_review_packet_reviewer_actions.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+WIKIDATA_REVIEW_PACKET_REVIEWER_ACTIONS_SCHEMA_VERSION = (
+    "sl.wikidata_review_packet.reviewer_actions.v0_1"
+)
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [_stringify(item).strip() for item in value if _stringify(item).strip()]
+
+
+def _smallest_next_check(
+    *,
+    uncertainty_flags: Sequence[str],
+    merged_split_axes: Sequence[Mapping[str, Any]],
+) -> dict[str, str]:
+    flags = set(_string_list(uncertainty_flags))
+    if "reference_propagation_requires_review" in flags:
+        return {
+            "check_id": "check_reference_propagation",
+            "rationale": "reference propagation is not exact and should be verified first",
+        }
+    if "qualifier_propagation_requires_review" in flags:
+        return {
+            "check_id": "check_qualifier_propagation",
+            "rationale": "qualifier propagation is not exact and should be verified first",
+        }
+    if merged_split_axes:
+        axis = merged_split_axes[0]
+        return {
+            "check_id": "confirm_first_split_axis",
+            "rationale": (
+                "split plan is axis-driven; confirm first axis "
+                f"property={_stringify(axis.get('property'))} "
+                f"cardinality={_stringify(axis.get('cardinality'))}"
+            ).strip(),
+        }
+    if "page_open_questions" in flags:
+        return {
+            "check_id": "resolve_one_page_question",
+            "rationale": "open page questions remain unresolved",
+        }
+    if "no_follow_receipts" in flags:
+        return {
+            "check_id": "establish_one_bounded_follow_receipt",
+            "rationale": "packet has no follow receipt evidence yet",
+        }
+    return {
+        "check_id": "spot_check_first_candidate",
+        "rationale": "no higher-priority uncertainty flag was detected",
+    }
+
+
+def build_wikidata_review_packet_reviewer_actions(packet: Mapping[str, Any]) -> dict[str, Any]:
+    split_review_context = packet.get("split_review_context")
+    reviewer_view = packet.get("reviewer_view")
+    if not isinstance(split_review_context, Mapping):
+        raise ValueError("packet requires split_review_context")
+    if not isinstance(reviewer_view, Mapping):
+        raise ValueError("packet requires reviewer_view")
+
+    uncertainty_flags = _string_list(reviewer_view.get("uncertainty_flags"))
+    decision_focus = _string_list(reviewer_view.get("decision_focus"))
+    likely_decision = (
+        _stringify(reviewer_view.get("recommended_next_step")).strip()
+        or _stringify(split_review_context.get("suggested_action")).strip()
+        or "review_only"
+    )
+
+    merged_split_axes = [
+        axis for axis in split_review_context.get("merged_split_axes", [])
+        if isinstance(axis, Mapping)
+    ]
+    reasons: list[str] = []
+    status = _stringify(split_review_context.get("status")).strip()
+    if status:
+        reasons.append(f"split_status={status}")
+    if bool(split_review_context.get("review_required")):
+        reasons.append("split_plan_requires_review")
+    if merged_split_axes:
+        reasons.append(f"split_axes_detected={len(merged_split_axes)}")
+    if uncertainty_flags:
+        reasons.extend(f"uncertainty={flag}" for flag in uncertainty_flags)
+
+    return {
+        "schema_version": WIKIDATA_REVIEW_PACKET_REVIEWER_ACTIONS_SCHEMA_VERSION,
+        "packet_id": _stringify(packet.get("packet_id")).strip(),
+        "review_entity_qid": _stringify(packet.get("review_entity_qid")).strip(),
+        "likely_decision": likely_decision,
+        "smallest_next_check": _smallest_next_check(
+            uncertainty_flags=uncertainty_flags,
+            merged_split_axes=merged_split_axes,
+        ),
+        "why_this_row_is_in_review": reasons,
+        "decision_focus": decision_focus,
+        "uncertainty_flags": uncertainty_flags,
+        "can_execute_edits": False,
+        "non_claims": [
+            "review aid only",
+            "does not execute edits",
+            "does not resolve uncertainty automatically",
+        ],
+    }
+
+
+__all__ = [
+    "WIKIDATA_REVIEW_PACKET_REVIEWER_ACTIONS_SCHEMA_VERSION",
+    "build_wikidata_review_packet_reviewer_actions",
+]

--- a/src/ontology/wikidata_review_packet_variant_compare.py
+++ b/src/ontology/wikidata_review_packet_variant_compare.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Sequence
+
+Variant = Mapping[str, Any]
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _normalize_axes(variant: Variant) -> Mapping[str, Mapping[str, Any]]:
+    axes = variant.get("merged_split_axes") or variant.get("split_axes") or []
+    normalized: dict[str, dict[str, Any]] = {}
+    for axis in axes:
+        if not isinstance(axis, Mapping):
+            continue
+        prop = _stringify(axis.get("property"))
+        if not prop:
+            continue
+        normalized[prop] = {
+            "property": prop,
+            "cardinality": int(axis.get("cardinality", 0) or 0),
+            "reason": _stringify(axis.get("reason")),
+            "source": _stringify(axis.get("source")),
+        }
+    return normalized
+
+
+def _compare_axes(primary_axes: Mapping[str, Mapping[str, Any]],
+                  comparison_axes: Mapping[str, Mapping[str, Any]]) -> tuple[list[str], list[str]]:
+    agreements: list[str] = []
+    disagreements: list[str] = []
+    all_props = set(primary_axes) | set(comparison_axes)
+    for prop in sorted(all_props):
+        primary = primary_axes.get(prop)
+        comparison = comparison_axes.get(prop)
+        if primary and comparison:
+            if primary["cardinality"] == comparison["cardinality"] and primary["reason"] == comparison["reason"]:
+                agreements.append(prop)
+            else:
+                disagreements.append(prop)
+        else:
+            disagreements.append(prop)
+    return agreements, disagreements
+
+
+def compare_review_packet_variants(
+    *,
+    primary_variant: Variant,
+    comparison_variants: Sequence[Variant],
+    max_variants: int = 3,
+) -> dict[str, Any]:
+    """Produce a lightweight agreement/disagreement surface for split-review variants."""
+    primary_axes = _normalize_axes(primary_variant)
+    diagnostics: list[str] = []
+    if not primary_axes:
+        diagnostics.append("primary_variant_missing_axes")
+    primary_id = _stringify(primary_variant.get("candidate_id"))
+    comparisons: list[dict[str, Any]] = []
+    for variant in comparison_variants[:max_variants]:
+        comparison_id = _stringify(variant.get("candidate_id"))
+        comparison_axes = _normalize_axes(variant)
+        agreements, disagreements = _compare_axes(primary_axes, comparison_axes)
+        status = "agreement" if disagreements == [] and agreements else "disagreement"
+        comparisons.append(
+            {
+                "comparison_id": comparison_id,
+                "status": status,
+                "primary_action": _stringify(primary_variant.get("suggested_action") or primary_variant.get("action")),
+                "comparison_action": _stringify(variant.get("suggested_action") or variant.get("action")),
+                "agreements": agreements,
+                "disagreements": disagreements,
+                "notes": diagnostics.copy() if status == "disagreement" else [],
+            }
+        )
+    if not comparisons:
+        diagnostics.append("no_comparisons_provided")
+    return {
+        "primary_candidate_id": primary_id,
+        "comparisons": comparisons,
+        "diagnostic_flags": sorted(set(diagnostics)),
+        "non_authoritative": True,
+    }
+
+
+__all__ = ["compare_review_packet_variants"]

--- a/tests/fixtures/wikidata/wikidata_nat_automation_evidence_snapshots_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_automation_evidence_snapshots_20260402.json
@@ -1,0 +1,296 @@
+{
+  "governance_batch_id": "nat-grad-governance-v1",
+  "snapshots": [
+    {
+      "snapshot_id": "snapshot-2026-04-02a",
+      "min_runs": 2,
+      "proposal_batches": {
+        "evidence_batch_id": "nat-grad-evidence-v1",
+        "runs": [
+          {
+            "run_id": "run-2026-04-02a",
+            "batch_id": "nat-grad-batch-v1",
+            "proposals": [
+              {
+                "proposal_id": "nat-gate-a-promote-v1",
+                "gate_id": "A",
+                "from_level": 0,
+                "to_level": 1,
+                "gate_families_passed": [
+                  "evidence_grounding",
+                  "claim_boundary_reliability",
+                  "verification_quality",
+                  "policy_risk_containment",
+                  "operational_control_and_rollback"
+                ],
+                "evidence_signals": [
+                  "reviewer_packets_for_representative_split_shapes",
+                  "bounded_follow_depth_present_and_fail_closed",
+                  "split_plan_verification_on_representative_reviewed_plans",
+                  "uncertainty_flags_preserved"
+                ],
+                "risk_signals": [],
+                "metrics": {
+                  "direct_safe_yield_by_family": {"observed": 0.2},
+                  "split_required_rate_by_family": {"observed": 0.8},
+                  "hold_abstain_rate_and_reason_distribution": {"observed": 0.1},
+                  "after_state_verification_pass_rate": {"observed": 1.0},
+                  "false_positive_rate_and_severity": {"observed": 0.0},
+                  "rollback_invocation_and_recovery_success": {"observed": 1.0},
+                  "receipt_completeness_coverage": {"observed": 1.0}
+                },
+                "recommendation": "promote"
+              },
+              {
+                "proposal_id": "nat-gate-b-hold-v1",
+                "gate_id": "B",
+                "from_level": 1,
+                "to_level": 2,
+                "gate_families_passed": [
+                  "evidence_grounding",
+                  "claim_boundary_reliability",
+                  "verification_quality",
+                  "policy_risk_containment",
+                  "operational_control_and_rollback"
+                ],
+                "evidence_signals": [
+                  "repeated_family_scoped_direct_safe_behavior",
+                  "stable_after_state_verification_across_repeated_tranches",
+                  "false_positive_rate_within_family_budget",
+                  "hold_and_abstain_paths_effective"
+                ],
+                "risk_signals": [
+                  "repeated_tranches_revert_to_split_required_majority"
+                ],
+                "metrics": {
+                  "direct_safe_yield_by_family": {"observed": 0.05},
+                  "split_required_rate_by_family": {"observed": 0.95},
+                  "hold_abstain_rate_and_reason_distribution": {"observed": 0.3},
+                  "after_state_verification_pass_rate": {"observed": 1.0},
+                  "false_positive_rate_and_severity": {"observed": 0.0},
+                  "rollback_invocation_and_recovery_success": {"observed": 1.0},
+                  "receipt_completeness_coverage": {"observed": 1.0}
+                },
+                "recommendation": "promote"
+              }
+            ]
+          },
+          {
+            "run_id": "run-2026-04-02b",
+            "batch_id": "nat-grad-batch-v2",
+            "proposals": [
+              {
+                "proposal_id": "nat-gate-a-promote-v2",
+                "gate_id": "A",
+                "from_level": 0,
+                "to_level": 1,
+                "gate_families_passed": [
+                  "evidence_grounding",
+                  "claim_boundary_reliability",
+                  "verification_quality",
+                  "policy_risk_containment",
+                  "operational_control_and_rollback"
+                ],
+                "evidence_signals": [
+                  "reviewer_packets_for_representative_split_shapes",
+                  "bounded_follow_depth_present_and_fail_closed",
+                  "split_plan_verification_on_representative_reviewed_plans",
+                  "uncertainty_flags_preserved"
+                ],
+                "risk_signals": [],
+                "metrics": {
+                  "direct_safe_yield_by_family": {"observed": 0.22},
+                  "split_required_rate_by_family": {"observed": 0.78},
+                  "hold_abstain_rate_and_reason_distribution": {"observed": 0.09},
+                  "after_state_verification_pass_rate": {"observed": 1.0},
+                  "false_positive_rate_and_severity": {"observed": 0.0},
+                  "rollback_invocation_and_recovery_success": {"observed": 1.0},
+                  "receipt_completeness_coverage": {"observed": 1.0}
+                },
+                "recommendation": "promote"
+              },
+              {
+                "proposal_id": "nat-gate-b-hold-v2",
+                "gate_id": "B",
+                "from_level": 1,
+                "to_level": 2,
+                "gate_families_passed": [
+                  "evidence_grounding",
+                  "claim_boundary_reliability",
+                  "verification_quality",
+                  "policy_risk_containment",
+                  "operational_control_and_rollback"
+                ],
+                "evidence_signals": [
+                  "repeated_family_scoped_direct_safe_behavior",
+                  "stable_after_state_verification_across_repeated_tranches",
+                  "false_positive_rate_within_family_budget",
+                  "hold_and_abstain_paths_effective"
+                ],
+                "risk_signals": [
+                  "repeated_tranches_revert_to_split_required_majority"
+                ],
+                "metrics": {
+                  "direct_safe_yield_by_family": {"observed": 0.04},
+                  "split_required_rate_by_family": {"observed": 0.96},
+                  "hold_abstain_rate_and_reason_distribution": {"observed": 0.31},
+                  "after_state_verification_pass_rate": {"observed": 1.0},
+                  "false_positive_rate_and_severity": {"observed": 0.0},
+                  "rollback_invocation_and_recovery_success": {"observed": 1.0},
+                  "receipt_completeness_coverage": {"observed": 1.0}
+                },
+                "recommendation": "promote"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "snapshot_id": "snapshot-2026-04-02b",
+      "min_runs": 2,
+      "proposal_batches": {
+        "evidence_batch_id": "nat-grad-evidence-v1",
+        "runs": [
+          {
+            "run_id": "run-2026-04-02a",
+            "batch_id": "nat-grad-batch-v1",
+            "proposals": [
+              {
+                "proposal_id": "nat-gate-a-promote-v1",
+                "gate_id": "A",
+                "from_level": 0,
+                "to_level": 1,
+                "gate_families_passed": [
+                  "evidence_grounding",
+                  "claim_boundary_reliability",
+                  "verification_quality",
+                  "policy_risk_containment",
+                  "operational_control_and_rollback"
+                ],
+                "evidence_signals": [
+                  "reviewer_packets_for_representative_split_shapes",
+                  "bounded_follow_depth_present_and_fail_closed",
+                  "split_plan_verification_on_representative_reviewed_plans",
+                  "uncertainty_flags_preserved"
+                ],
+                "risk_signals": [],
+                "metrics": {
+                  "direct_safe_yield_by_family": {"observed": 0.2},
+                  "split_required_rate_by_family": {"observed": 0.8},
+                  "hold_abstain_rate_and_reason_distribution": {"observed": 0.1},
+                  "after_state_verification_pass_rate": {"observed": 1.0},
+                  "false_positive_rate_and_severity": {"observed": 0.0},
+                  "rollback_invocation_and_recovery_success": {"observed": 1.0},
+                  "receipt_completeness_coverage": {"observed": 1.0}
+                },
+                "recommendation": "promote"
+              },
+              {
+                "proposal_id": "nat-gate-b-hold-v1",
+                "gate_id": "B",
+                "from_level": 1,
+                "to_level": 2,
+                "gate_families_passed": [
+                  "evidence_grounding",
+                  "claim_boundary_reliability",
+                  "verification_quality",
+                  "policy_risk_containment",
+                  "operational_control_and_rollback"
+                ],
+                "evidence_signals": [
+                  "repeated_family_scoped_direct_safe_behavior",
+                  "stable_after_state_verification_across_repeated_tranches",
+                  "false_positive_rate_within_family_budget",
+                  "hold_and_abstain_paths_effective"
+                ],
+                "risk_signals": [
+                  "repeated_tranches_revert_to_split_required_majority"
+                ],
+                "metrics": {
+                  "direct_safe_yield_by_family": {"observed": 0.05},
+                  "split_required_rate_by_family": {"observed": 0.95},
+                  "hold_abstain_rate_and_reason_distribution": {"observed": 0.3},
+                  "after_state_verification_pass_rate": {"observed": 1.0},
+                  "false_positive_rate_and_severity": {"observed": 0.0},
+                  "rollback_invocation_and_recovery_success": {"observed": 1.0},
+                  "receipt_completeness_coverage": {"observed": 1.0}
+                },
+                "recommendation": "promote"
+              }
+            ]
+          },
+          {
+            "run_id": "run-2026-04-02b",
+            "batch_id": "nat-grad-batch-v2",
+            "proposals": [
+              {
+                "proposal_id": "nat-gate-a-promote-v2",
+                "gate_id": "A",
+                "from_level": 0,
+                "to_level": 1,
+                "gate_families_passed": [
+                  "evidence_grounding",
+                  "claim_boundary_reliability",
+                  "verification_quality",
+                  "policy_risk_containment",
+                  "operational_control_and_rollback"
+                ],
+                "evidence_signals": [
+                  "reviewer_packets_for_representative_split_shapes",
+                  "bounded_follow_depth_present_and_fail_closed",
+                  "split_plan_verification_on_representative_reviewed_plans",
+                  "uncertainty_flags_preserved"
+                ],
+                "risk_signals": [],
+                "metrics": {
+                  "direct_safe_yield_by_family": {"observed": 0.22},
+                  "split_required_rate_by_family": {"observed": 0.78},
+                  "hold_abstain_rate_and_reason_distribution": {"observed": 0.09},
+                  "after_state_verification_pass_rate": {"observed": 1.0},
+                  "false_positive_rate_and_severity": {"observed": 0.0},
+                  "rollback_invocation_and_recovery_success": {"observed": 1.0},
+                  "receipt_completeness_coverage": {"observed": 1.0}
+                },
+                "recommendation": "promote"
+              },
+              {
+                "proposal_id": "nat-gate-b-hold-v2",
+                "gate_id": "B",
+                "from_level": 1,
+                "to_level": 2,
+                "gate_families_passed": [
+                  "evidence_grounding",
+                  "claim_boundary_reliability",
+                  "verification_quality",
+                  "policy_risk_containment",
+                  "operational_control_and_rollback"
+                ],
+                "evidence_signals": [
+                  "repeated_family_scoped_direct_safe_behavior",
+                  "stable_after_state_verification_across_repeated_tranches",
+                  "false_positive_rate_within_family_budget",
+                  "hold_and_abstain_paths_effective"
+                ],
+                "risk_signals": [
+                  "repeated_tranches_revert_to_split_required_majority"
+                ],
+                "metrics": {
+                  "direct_safe_yield_by_family": {"observed": 0.04},
+                  "split_required_rate_by_family": {"observed": 0.96},
+                  "hold_abstain_rate_and_reason_distribution": {"observed": 0.31},
+                  "after_state_verification_pass_rate": {"observed": 1.0},
+                  "false_positive_rate_and_severity": {"observed": 0.0},
+                  "rollback_invocation_and_recovery_success": {"observed": 1.0},
+                  "receipt_completeness_coverage": {"observed": 1.0}
+                },
+                "recommendation": "promote"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+

--- a/tests/fixtures/wikidata/wikidata_nat_automation_governance_snapshots_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_automation_governance_snapshots_20260402.json
@@ -1,0 +1,61 @@
+{
+  "governance_summary_id": "nat-grad-governance-summary-v1",
+  "snapshots": [
+    {
+      "snapshot_id": "gov-s1",
+      "governance_index": {
+        "schema_version": "sl.wikidata_nat_automation_graduation_governance_index.v0_1",
+        "lane": "wikidata_nat_automation_graduation",
+        "governance_batch_id": "nat-grad-governance-v1",
+        "status": "not_ready",
+        "decision": "hold",
+        "promotion_ready": false,
+        "readiness_failed_reasons": [
+          "not_ready_snapshots_present",
+          "rejected_proposals_present",
+          "fail_closed_proposals_present"
+        ],
+        "scope": {
+          "min_snapshots": 2,
+          "snapshot_count": 2,
+          "gate_scope_consistent": true,
+          "gate_id": "B"
+        },
+        "summary": {
+          "ready_count": 0,
+          "not_ready_count": 2,
+          "rejected_count": 2,
+          "fail_closed_count": 2
+        }
+      }
+    },
+    {
+      "snapshot_id": "gov-s2",
+      "governance_index": {
+        "schema_version": "sl.wikidata_nat_automation_graduation_governance_index.v0_1",
+        "lane": "wikidata_nat_automation_graduation",
+        "governance_batch_id": "nat-grad-governance-v2",
+        "status": "not_ready",
+        "decision": "hold",
+        "promotion_ready": false,
+        "readiness_failed_reasons": [
+          "not_ready_snapshots_present",
+          "rejected_proposals_present",
+          "fail_closed_proposals_present"
+        ],
+        "scope": {
+          "min_snapshots": 2,
+          "snapshot_count": 2,
+          "gate_scope_consistent": true,
+          "gate_id": "B"
+        },
+        "summary": {
+          "ready_count": 1,
+          "not_ready_count": 1,
+          "rejected_count": 1,
+          "fail_closed_count": 1
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_automation_graduation_criteria_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_automation_graduation_criteria_20260402.json
@@ -1,0 +1,118 @@
+{
+  "schema_version": "sl.wikidata_nat_automation_graduation.v0_1",
+  "lane": "nat_p5991_to_p14143",
+  "as_of": "2026-04-02",
+  "levels": [
+    {
+      "level": 0,
+      "name": "review_first_only"
+    },
+    {
+      "level": 1,
+      "name": "reviewer_assisted_split_execution"
+    },
+    {
+      "level": 2,
+      "name": "family_scoped_measured_automation"
+    },
+    {
+      "level": 3,
+      "name": "broad_automation_with_strict_holds"
+    },
+    {
+      "level": 4,
+      "name": "moonshot_blind_migration_bot"
+    }
+  ],
+  "gate_families_required": [
+    "evidence_grounding",
+    "claim_boundary_reliability",
+    "verification_quality",
+    "policy_risk_containment",
+    "operational_control_and_rollback"
+  ],
+  "gates": [
+    {
+      "gate_id": "A",
+      "from_level": 0,
+      "to_level": 1,
+      "must_show": [
+        "reviewer_packets_for_representative_split_shapes",
+        "bounded_follow_depth_present_and_fail_closed",
+        "split_plan_verification_on_representative_reviewed_plans",
+        "uncertainty_flags_preserved"
+      ],
+      "blocked_if": [
+        "evidence_unanchored_to_revision_locked_surface",
+        "split_verification_only_one_narrow_shape"
+      ]
+    },
+    {
+      "gate_id": "B",
+      "from_level": 1,
+      "to_level": 2,
+      "must_show": [
+        "repeated_family_scoped_direct_safe_behavior",
+        "stable_after_state_verification_across_repeated_tranches",
+        "false_positive_rate_within_family_budget",
+        "hold_and_abstain_paths_effective"
+      ],
+      "blocked_if": [
+        "direct_safe_yield_unstable_between_tranches",
+        "repeated_tranches_revert_to_split_required_majority"
+      ]
+    },
+    {
+      "gate_id": "C",
+      "from_level": 2,
+      "to_level": 3,
+      "must_show": [
+        "automation_success_across_multiple_structural_families",
+        "policy_risk_cohorts_separated_and_governed",
+        "cross_source_disagreement_handling_deterministic",
+        "rollback_and_replay_validated_end_to_end"
+      ],
+      "blocked_if": [
+        "automation_gain_depends_on_disabling_hold_or_abstain",
+        "verification_receipts_incomplete_or_nonreplayable"
+      ]
+    },
+    {
+      "gate_id": "D",
+      "from_level": 3,
+      "to_level": 4,
+      "must_show": [
+        "broad_coverage_under_bounded_risk_with_sustained_quality",
+        "blind_execution_safer_than_reviewer_gated_execution_for_promoted_families",
+        "full_auditability_of_source_split_and_after_state",
+        "killswitch_and_rollback_controls_proven"
+      ],
+      "blocked_if": [
+        "material_policy_risk_families_unresolved",
+        "audit_trails_depend_on_manual_reconstruction"
+      ]
+    }
+  ],
+  "metrics_required": [
+    "direct_safe_yield_by_family",
+    "split_required_rate_by_family",
+    "hold_abstain_rate_and_reason_distribution",
+    "after_state_verification_pass_rate",
+    "false_positive_rate_and_severity",
+    "rollback_invocation_and_recovery_success",
+    "receipt_completeness_coverage"
+  ],
+  "current_state": {
+    "current_level": 1,
+    "highest_gate_cleared": "A",
+    "next_gate": "B",
+    "promotion_recommendation": "hold",
+    "rationale": [
+      "review_first_controls_strong",
+      "split_verification_real",
+      "packet_and_follow_depth_support_real",
+      "broad_measured_direct_safe_stability_not_demonstrated"
+    ]
+  }
+}
+

--- a/tests/fixtures/wikidata/wikidata_nat_automation_promotion_proposal_batch_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_automation_promotion_proposal_batch_20260402.json
@@ -1,0 +1,68 @@
+{
+  "batch_id": "nat-grad-batch-v1",
+  "proposals": [
+    {
+      "proposal_id": "nat-gate-a-promote-v1",
+      "gate_id": "A",
+      "from_level": 0,
+      "to_level": 1,
+      "gate_families_passed": [
+        "evidence_grounding",
+        "claim_boundary_reliability",
+        "verification_quality",
+        "policy_risk_containment",
+        "operational_control_and_rollback"
+      ],
+      "evidence_signals": [
+        "reviewer_packets_for_representative_split_shapes",
+        "bounded_follow_depth_present_and_fail_closed",
+        "split_plan_verification_on_representative_reviewed_plans",
+        "uncertainty_flags_preserved"
+      ],
+      "risk_signals": [],
+      "metrics": {
+        "direct_safe_yield_by_family": {"observed": 0.2},
+        "split_required_rate_by_family": {"observed": 0.8},
+        "hold_abstain_rate_and_reason_distribution": {"observed": 0.1},
+        "after_state_verification_pass_rate": {"observed": 1.0},
+        "false_positive_rate_and_severity": {"observed": 0.0},
+        "rollback_invocation_and_recovery_success": {"observed": 1.0},
+        "receipt_completeness_coverage": {"observed": 1.0}
+      },
+      "recommendation": "promote"
+    },
+    {
+      "proposal_id": "nat-gate-b-hold-v1",
+      "gate_id": "B",
+      "from_level": 1,
+      "to_level": 2,
+      "gate_families_passed": [
+        "evidence_grounding",
+        "claim_boundary_reliability",
+        "verification_quality",
+        "policy_risk_containment",
+        "operational_control_and_rollback"
+      ],
+      "evidence_signals": [
+        "repeated_family_scoped_direct_safe_behavior",
+        "stable_after_state_verification_across_repeated_tranches",
+        "false_positive_rate_within_family_budget",
+        "hold_and_abstain_paths_effective"
+      ],
+      "risk_signals": [
+        "repeated_tranches_revert_to_split_required_majority"
+      ],
+      "metrics": {
+        "direct_safe_yield_by_family": {"observed": 0.05},
+        "split_required_rate_by_family": {"observed": 0.95},
+        "hold_abstain_rate_and_reason_distribution": {"observed": 0.3},
+        "after_state_verification_pass_rate": {"observed": 1.0},
+        "false_positive_rate_and_severity": {"observed": 0.0},
+        "rollback_invocation_and_recovery_success": {"observed": 1.0},
+        "receipt_completeness_coverage": {"observed": 1.0}
+      },
+      "recommendation": "promote"
+    }
+  ]
+}
+

--- a/tests/fixtures/wikidata/wikidata_nat_automation_promotion_proposal_batches_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_automation_promotion_proposal_batches_20260402.json
@@ -1,0 +1,142 @@
+{
+  "evidence_batch_id": "nat-grad-evidence-v1",
+  "runs": [
+    {
+      "run_id": "run-2026-04-02a",
+      "batch_id": "nat-grad-batch-v1",
+      "proposals": [
+        {
+          "proposal_id": "nat-gate-a-promote-v1",
+          "gate_id": "A",
+          "from_level": 0,
+          "to_level": 1,
+          "gate_families_passed": [
+            "evidence_grounding",
+            "claim_boundary_reliability",
+            "verification_quality",
+            "policy_risk_containment",
+            "operational_control_and_rollback"
+          ],
+          "evidence_signals": [
+            "reviewer_packets_for_representative_split_shapes",
+            "bounded_follow_depth_present_and_fail_closed",
+            "split_plan_verification_on_representative_reviewed_plans",
+            "uncertainty_flags_preserved"
+          ],
+          "risk_signals": [],
+          "metrics": {
+            "direct_safe_yield_by_family": {"observed": 0.2},
+            "split_required_rate_by_family": {"observed": 0.8},
+            "hold_abstain_rate_and_reason_distribution": {"observed": 0.1},
+            "after_state_verification_pass_rate": {"observed": 1.0},
+            "false_positive_rate_and_severity": {"observed": 0.0},
+            "rollback_invocation_and_recovery_success": {"observed": 1.0},
+            "receipt_completeness_coverage": {"observed": 1.0}
+          },
+          "recommendation": "promote"
+        },
+        {
+          "proposal_id": "nat-gate-b-hold-v1",
+          "gate_id": "B",
+          "from_level": 1,
+          "to_level": 2,
+          "gate_families_passed": [
+            "evidence_grounding",
+            "claim_boundary_reliability",
+            "verification_quality",
+            "policy_risk_containment",
+            "operational_control_and_rollback"
+          ],
+          "evidence_signals": [
+            "repeated_family_scoped_direct_safe_behavior",
+            "stable_after_state_verification_across_repeated_tranches",
+            "false_positive_rate_within_family_budget",
+            "hold_and_abstain_paths_effective"
+          ],
+          "risk_signals": [
+            "repeated_tranches_revert_to_split_required_majority"
+          ],
+          "metrics": {
+            "direct_safe_yield_by_family": {"observed": 0.05},
+            "split_required_rate_by_family": {"observed": 0.95},
+            "hold_abstain_rate_and_reason_distribution": {"observed": 0.3},
+            "after_state_verification_pass_rate": {"observed": 1.0},
+            "false_positive_rate_and_severity": {"observed": 0.0},
+            "rollback_invocation_and_recovery_success": {"observed": 1.0},
+            "receipt_completeness_coverage": {"observed": 1.0}
+          },
+          "recommendation": "promote"
+        }
+      ]
+    },
+    {
+      "run_id": "run-2026-04-02b",
+      "batch_id": "nat-grad-batch-v2",
+      "proposals": [
+        {
+          "proposal_id": "nat-gate-a-promote-v2",
+          "gate_id": "A",
+          "from_level": 0,
+          "to_level": 1,
+          "gate_families_passed": [
+            "evidence_grounding",
+            "claim_boundary_reliability",
+            "verification_quality",
+            "policy_risk_containment",
+            "operational_control_and_rollback"
+          ],
+          "evidence_signals": [
+            "reviewer_packets_for_representative_split_shapes",
+            "bounded_follow_depth_present_and_fail_closed",
+            "split_plan_verification_on_representative_reviewed_plans",
+            "uncertainty_flags_preserved"
+          ],
+          "risk_signals": [],
+          "metrics": {
+            "direct_safe_yield_by_family": {"observed": 0.22},
+            "split_required_rate_by_family": {"observed": 0.78},
+            "hold_abstain_rate_and_reason_distribution": {"observed": 0.09},
+            "after_state_verification_pass_rate": {"observed": 1.0},
+            "false_positive_rate_and_severity": {"observed": 0.0},
+            "rollback_invocation_and_recovery_success": {"observed": 1.0},
+            "receipt_completeness_coverage": {"observed": 1.0}
+          },
+          "recommendation": "promote"
+        },
+        {
+          "proposal_id": "nat-gate-b-hold-v2",
+          "gate_id": "B",
+          "from_level": 1,
+          "to_level": 2,
+          "gate_families_passed": [
+            "evidence_grounding",
+            "claim_boundary_reliability",
+            "verification_quality",
+            "policy_risk_containment",
+            "operational_control_and_rollback"
+          ],
+          "evidence_signals": [
+            "repeated_family_scoped_direct_safe_behavior",
+            "stable_after_state_verification_across_repeated_tranches",
+            "false_positive_rate_within_family_budget",
+            "hold_and_abstain_paths_effective"
+          ],
+          "risk_signals": [
+            "repeated_tranches_revert_to_split_required_majority"
+          ],
+          "metrics": {
+            "direct_safe_yield_by_family": {"observed": 0.04},
+            "split_required_rate_by_family": {"observed": 0.96},
+            "hold_abstain_rate_and_reason_distribution": {"observed": 0.31},
+            "after_state_verification_pass_rate": {"observed": 1.0},
+            "false_positive_rate_and_severity": {"observed": 0.0},
+            "rollback_invocation_and_recovery_success": {"observed": 1.0},
+            "receipt_completeness_coverage": {"observed": 1.0}
+          },
+          "recommendation": "promote"
+        }
+      ]
+    }
+  ]
+}
+

--- a/tests/fixtures/wikidata/wikidata_nat_automation_promotion_proposal_gate_a_promote_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_automation_promotion_proposal_gate_a_promote_20260402.json
@@ -1,0 +1,31 @@
+{
+  "proposal_id": "nat-gate-a-promote-v1",
+  "gate_id": "A",
+  "from_level": 0,
+  "to_level": 1,
+  "gate_families_passed": [
+    "evidence_grounding",
+    "claim_boundary_reliability",
+    "verification_quality",
+    "policy_risk_containment",
+    "operational_control_and_rollback"
+  ],
+  "evidence_signals": [
+    "reviewer_packets_for_representative_split_shapes",
+    "bounded_follow_depth_present_and_fail_closed",
+    "split_plan_verification_on_representative_reviewed_plans",
+    "uncertainty_flags_preserved"
+  ],
+  "risk_signals": [],
+  "metrics": {
+    "direct_safe_yield_by_family": {"observed": 0.2},
+    "split_required_rate_by_family": {"observed": 0.8},
+    "hold_abstain_rate_and_reason_distribution": {"observed": 0.1},
+    "after_state_verification_pass_rate": {"observed": 1.0},
+    "false_positive_rate_and_severity": {"observed": 0.0},
+    "rollback_invocation_and_recovery_success": {"observed": 1.0},
+    "receipt_completeness_coverage": {"observed": 1.0}
+  },
+  "recommendation": "promote"
+}
+

--- a/tests/fixtures/wikidata/wikidata_nat_automation_promotion_proposal_gate_b_hold_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_automation_promotion_proposal_gate_b_hold_20260402.json
@@ -1,0 +1,33 @@
+{
+  "proposal_id": "nat-gate-b-hold-v1",
+  "gate_id": "B",
+  "from_level": 1,
+  "to_level": 2,
+  "gate_families_passed": [
+    "evidence_grounding",
+    "claim_boundary_reliability",
+    "verification_quality",
+    "policy_risk_containment",
+    "operational_control_and_rollback"
+  ],
+  "evidence_signals": [
+    "repeated_family_scoped_direct_safe_behavior",
+    "stable_after_state_verification_across_repeated_tranches",
+    "false_positive_rate_within_family_budget",
+    "hold_and_abstain_paths_effective"
+  ],
+  "risk_signals": [
+    "repeated_tranches_revert_to_split_required_majority"
+  ],
+  "metrics": {
+    "direct_safe_yield_by_family": {"observed": 0.05},
+    "split_required_rate_by_family": {"observed": 0.95},
+    "hold_abstain_rate_and_reason_distribution": {"observed": 0.3},
+    "after_state_verification_pass_rate": {"observed": 1.0},
+    "false_positive_rate_and_severity": {"observed": 0.0},
+    "rollback_invocation_and_recovery_success": {"observed": 1.0},
+    "receipt_completeness_coverage": {"observed": 1.0}
+  },
+  "recommendation": "promote"
+}
+

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_batch_report_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_batch_report_20260402.json
@@ -1,0 +1,219 @@
+{
+  "batch_status": "batch_review_ready",
+  "case_summaries": [
+    {
+      "case_id": "cohort-b-case:1",
+      "decision": "review",
+      "packet_id": "operator-packet:3f271cffeb066067",
+      "selected_row_count": 2,
+      "variance_flag_counts": {
+        "missing_expected_qualifier_properties": 2,
+        "missing_expected_reference_properties": 1,
+        "unexpected_qualifier_properties": 1,
+        "unexpected_reference_properties": 1
+      }
+    },
+    {
+      "case_id": "cohort-b-case:2",
+      "decision": "review",
+      "packet_id": "operator-packet:7c8a99e19425124e",
+      "selected_row_count": 1,
+      "variance_flag_counts": {
+        "missing_expected_qualifier_properties": 1,
+        "unexpected_qualifier_properties": 1,
+        "unexpected_reference_properties": 1
+      }
+    }
+  ],
+  "cohort_id": "cohort_b_reconciled_non_business",
+  "decision_reasons": [
+    "multi_case_operator_evidence_materialized"
+  ],
+  "governance": {
+    "automation_allowed": false,
+    "fail_closed": true,
+    "requires_human_review": true
+  },
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "non_claims": [
+    "batch evidence report only",
+    "not migration execution",
+    "not cross-cohort arbitration"
+  ],
+  "packet_decision_counts": {
+    "review": 2
+  },
+  "queue": {
+    "blocked_packets": [],
+    "cohort_id": "cohort_b_reconciled_non_business",
+    "decision_reasons": [
+      "validated_review_packets_materialized_to_queue"
+    ],
+    "governance": {
+      "automation_allowed": false,
+      "fail_closed": true,
+      "requires_human_review": true
+    },
+    "lane_id": "wikidata_nat_wdu_p5991_p14143",
+    "non_claims": [
+      "queue materialization only",
+      "not migration execution",
+      "not cross-cohort arbitration"
+    ],
+    "queue_items": [
+      {
+        "entity_qid": "Q8646",
+        "instance_of_qid": "Q43229",
+        "packet_id": "operator-packet:3f271cffeb066067",
+        "priority": "high",
+        "queue_item_id": "cohort-b-queue:fc07935a9e84",
+        "row_id": "Q8646|P5991|4",
+        "triage_prompts": [
+          "Confirm class-local semantics before any migration-equivalence judgment.",
+          "Inspect unexpected qualifier properties as potential class-specific semantics."
+        ],
+        "variance_flags": [
+          "missing_expected_qualifier_properties",
+          "unexpected_qualifier_properties",
+          "unexpected_reference_properties"
+        ]
+      },
+      {
+        "entity_qid": "Q8646",
+        "instance_of_qid": "Q43229",
+        "packet_id": "operator-packet:7c8a99e19425124e",
+        "priority": "high",
+        "queue_item_id": "cohort-b-queue:d63ba7035f36",
+        "row_id": "Q8646|P5991|4",
+        "triage_prompts": [
+          "Confirm class-local semantics before any migration-equivalence judgment.",
+          "Inspect unexpected qualifier properties as potential class-specific semantics."
+        ],
+        "variance_flags": [
+          "missing_expected_qualifier_properties",
+          "unexpected_qualifier_properties",
+          "unexpected_reference_properties"
+        ]
+      },
+      {
+        "entity_qid": "Q11661",
+        "instance_of_qid": "Q13442814",
+        "packet_id": "operator-packet:3f271cffeb066067",
+        "priority": "medium",
+        "queue_item_id": "cohort-b-queue:c9ec83c4f421",
+        "row_id": "Q11661|P5991|1",
+        "triage_prompts": [
+          "Confirm class-local semantics before any migration-equivalence judgment.",
+          "Inspect unexpected qualifier properties as potential class-specific semantics."
+        ],
+        "variance_flags": [
+          "missing_expected_qualifier_properties",
+          "missing_expected_reference_properties"
+        ]
+      }
+    ],
+    "queue_status": "review_queue_ready",
+    "schema_version": "sl.wikidata_nat_cohort_b_operator_queue.v0_1",
+    "summary": {
+      "hold_packet_count": 0,
+      "input_packet_count": 2,
+      "queue_item_count": 3,
+      "review_first": true,
+      "review_packet_count": 2,
+      "validation_error_count": 0
+    },
+    "validation_errors": []
+  },
+  "report": {
+    "blocked_packets": [],
+    "cohort_id": "cohort_b_reconciled_non_business",
+    "examples": [
+      {
+        "entity_qid": "Q8646",
+        "priority": "high",
+        "queue_item_id": "cohort-b-queue:fc07935a9e84",
+        "row_id": "Q8646|P5991|4",
+        "variance_flags": [
+          "missing_expected_qualifier_properties",
+          "unexpected_qualifier_properties",
+          "unexpected_reference_properties"
+        ]
+      },
+      {
+        "entity_qid": "Q8646",
+        "priority": "high",
+        "queue_item_id": "cohort-b-queue:d63ba7035f36",
+        "row_id": "Q8646|P5991|4",
+        "variance_flags": [
+          "missing_expected_qualifier_properties",
+          "unexpected_qualifier_properties",
+          "unexpected_reference_properties"
+        ]
+      },
+      {
+        "entity_qid": "Q11661",
+        "priority": "medium",
+        "queue_item_id": "cohort-b-queue:c9ec83c4f421",
+        "row_id": "Q11661|P5991|1",
+        "variance_flags": [
+          "missing_expected_qualifier_properties",
+          "missing_expected_reference_properties"
+        ]
+      }
+    ],
+    "governance": {
+      "automation_allowed": false,
+      "fail_closed": true,
+      "requires_human_review": true
+    },
+    "lane_id": "wikidata_nat_wdu_p5991_p14143",
+    "non_claims": [
+      "operator report only",
+      "not migration execution",
+      "not cross-cohort arbitration"
+    ],
+    "queue_status": "review_queue_ready",
+    "recommendations": [
+      "Process high-priority queue rows first using bounded reviewer prompts.",
+      "Keep Cohort B lane review-only; do not execute migration from this report."
+    ],
+    "report_id": "cohort-b-report:3440d06f609e9d47",
+    "report_status": "review_only_report_ready",
+    "schema_version": "sl.wikidata_nat_cohort_b_operator_report.v0_1",
+    "summary": {
+      "blocked_packet_count": 0,
+      "priority_counts": {
+        "high": 2,
+        "medium": 1
+      },
+      "queue_item_count": 3,
+      "review_first": true,
+      "top_instance_classes": [
+        {
+          "instance_of_qid": "Q43229",
+          "queue_row_count": 2
+        },
+        {
+          "instance_of_qid": "Q13442814",
+          "queue_row_count": 1
+        }
+      ],
+      "validation_error_count": 0,
+      "variance_flag_counts": {
+        "missing_expected_qualifier_properties": 3,
+        "missing_expected_reference_properties": 1,
+        "unexpected_qualifier_properties": 2,
+        "unexpected_reference_properties": 2
+      }
+    },
+    "validation_errors": []
+  },
+  "schema_version": "sl.wikidata_nat_cohort_b_operator_batch_report.v0_1",
+  "summary": {
+    "blocked_packet_count": 0,
+    "case_count": 2,
+    "queue_item_count": 3,
+    "review_first": true,
+    "validation_error_count": 0
+  }
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_batch_report_case2_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_batch_report_case2_20260402.json
@@ -1,0 +1,187 @@
+{
+  "batch_status": "batch_review_ready",
+  "case_summaries": [
+    {
+      "case_id": "cohort-b-case:1",
+      "decision": "review",
+      "packet_id": "operator-packet:7c8a99e19425124e",
+      "selected_row_count": 1,
+      "variance_flag_counts": {
+        "missing_expected_qualifier_properties": 1,
+        "unexpected_qualifier_properties": 1,
+        "unexpected_reference_properties": 1
+      }
+    },
+    {
+      "case_id": "cohort-b-case:2",
+      "decision": "review",
+      "packet_id": "operator-packet:3f271cffeb066067",
+      "selected_row_count": 2,
+      "variance_flag_counts": {
+        "missing_expected_qualifier_properties": 2,
+        "missing_expected_reference_properties": 1,
+        "unexpected_qualifier_properties": 1,
+        "unexpected_reference_properties": 1
+      }
+    }
+  ],
+  "cohort_id": "cohort_b_reconciled_non_business",
+  "decision_reasons": [
+    "multi_case_operator_evidence_materialized"
+  ],
+  "governance": {
+    "automation_allowed": false,
+    "fail_closed": true,
+    "requires_human_review": true
+  },
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "non_claims": [
+    "batch evidence report only",
+    "not migration execution",
+    "not cross-cohort arbitration"
+  ],
+  "packet_decision_counts": {
+    "review": 2
+  },
+  "queue": {
+    "blocked_packets": [],
+    "cohort_id": "cohort_b_reconciled_non_business",
+    "decision_reasons": [
+      "validated_review_packets_materialized_to_queue"
+    ],
+    "governance": {
+      "automation_allowed": false,
+      "fail_closed": true,
+      "requires_human_review": true
+    },
+    "lane_id": "wikidata_nat_wdu_p5991_p14143",
+    "non_claims": [
+      "queue materialization only",
+      "not migration execution",
+      "not cross-cohort arbitration"
+    ],
+    "queue_items": [
+      {
+        "entity_qid": "Q8646",
+        "instance_of_qid": "Q43229",
+        "packet_id": "operator-packet:3f271cffeb066067",
+        "priority": "high",
+        "queue_item_id": "cohort-b-queue:fc07935a9e84",
+        "row_id": "Q8646|P5991|4",
+        "triage_prompts": [
+          "Confirm class-local semantics before any migration-equivalence judgment.",
+          "Inspect unexpected qualifier properties as potential class-specific semantics."
+        ],
+        "variance_flags": [
+          "missing_expected_qualifier_properties",
+          "unexpected_qualifier_properties",
+          "unexpected_reference_properties"
+        ]
+      },
+      {
+        "entity_qid": "Q8646",
+        "instance_of_qid": "Q43229",
+        "packet_id": "operator-packet:7c8a99e19425124e",
+        "priority": "high",
+        "queue_item_id": "cohort-b-queue:d63ba7035f36",
+        "row_id": "Q8646|P5991|4",
+        "triage_prompts": [
+          "Confirm class-local semantics before any migration-equivalence judgment.",
+          "Inspect unexpected qualifier properties as potential class-specific semantics."
+        ],
+        "variance_flags": [
+          "missing_expected_qualifier_properties",
+          "unexpected_qualifier_properties",
+          "unexpected_reference_properties"
+        ]
+      }
+    ],
+    "queue_status": "review_queue_ready",
+    "schema_version": "sl.wikidata_nat_cohort_b_operator_queue.v0_1",
+    "summary": {
+      "hold_packet_count": 0,
+      "input_packet_count": 2,
+      "queue_item_count": 2,
+      "review_first": true,
+      "review_packet_count": 2,
+      "validation_error_count": 0
+    },
+    "validation_errors": []
+  },
+  "report": {
+    "blocked_packets": [],
+    "cohort_id": "cohort_b_reconciled_non_business",
+    "examples": [
+      {
+        "entity_qid": "Q8646",
+        "priority": "high",
+        "queue_item_id": "cohort-b-queue:fc07935a9e84",
+        "row_id": "Q8646|P5991|4",
+        "variance_flags": [
+          "missing_expected_qualifier_properties",
+          "unexpected_qualifier_properties",
+          "unexpected_reference_properties"
+        ]
+      },
+      {
+        "entity_qid": "Q8646",
+        "priority": "high",
+        "queue_item_id": "cohort-b-queue:d63ba7035f36",
+        "row_id": "Q8646|P5991|4",
+        "variance_flags": [
+          "missing_expected_qualifier_properties",
+          "unexpected_qualifier_properties",
+          "unexpected_reference_properties"
+        ]
+      }
+    ],
+    "governance": {
+      "automation_allowed": false,
+      "fail_closed": true,
+      "requires_human_review": true
+    },
+    "lane_id": "wikidata_nat_wdu_p5991_p14143",
+    "non_claims": [
+      "operator report only",
+      "not migration execution",
+      "not cross-cohort arbitration"
+    ],
+    "queue_status": "review_queue_ready",
+    "recommendations": [
+      "Process high-priority queue rows first using bounded reviewer prompts.",
+      "Keep Cohort B lane review-only; do not execute migration from this report."
+    ],
+    "report_id": "cohort-b-report:943c7b2e0995d0b2",
+    "report_status": "review_only_report_ready",
+    "schema_version": "sl.wikidata_nat_cohort_b_operator_report.v0_1",
+    "summary": {
+      "blocked_packet_count": 0,
+      "priority_counts": {
+        "high": 2
+      },
+      "queue_item_count": 2,
+      "review_first": true,
+      "top_instance_classes": [
+        {
+          "instance_of_qid": "Q43229",
+          "queue_row_count": 2
+        }
+      ],
+      "validation_error_count": 0,
+      "variance_flag_counts": {
+        "missing_expected_qualifier_properties": 2,
+        "unexpected_qualifier_properties": 2,
+        "unexpected_reference_properties": 2
+      }
+    },
+    "validation_errors": []
+  },
+  "schema_version": "sl.wikidata_nat_cohort_b_operator_batch_report.v0_1",
+  "summary": {
+    "blocked_packet_count": 0,
+    "case_count": 2,
+    "queue_item_count": 2,
+    "review_first": true,
+    "validation_error_count": 0
+  }
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_control_summary_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_control_summary_20260402.json
@@ -1,0 +1,61 @@
+{
+  "cohort_id": "cohort_b_reconciled_non_business",
+  "control_status": "review_control_ready",
+  "decision_reasons": [
+    "ready_indexes_meet_threshold"
+  ],
+  "governance": {
+    "automation_allowed": false,
+    "fail_closed": true,
+    "requires_human_review": true
+  },
+  "index_entries": [
+    {
+      "decision_reasons": [
+        "ready_batches_meet_threshold"
+      ],
+      "hold_batch_count": 0,
+      "index_id": "cohort-b-index:b4fdccf33628",
+      "index_position": 0,
+      "index_status": "review_index_ready",
+      "ready_batch_count": 2,
+      "validation_error_count": 0
+    },
+    {
+      "decision_reasons": [
+        "ready_batches_meet_threshold"
+      ],
+      "hold_batch_count": 0,
+      "index_id": "cohort-b-index:ed37bab7fef9",
+      "index_position": 1,
+      "index_status": "review_index_ready",
+      "ready_batch_count": 1,
+      "validation_error_count": 0
+    }
+  ],
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "non_claims": [
+    "operator control summary only",
+    "not migration execution",
+    "not cross-cohort arbitration"
+  ],
+  "ready_index_ids": [
+    "cohort-b-index:b4fdccf33628",
+    "cohort-b-index:ed37bab7fef9"
+  ],
+  "schema_version": "sl.wikidata_nat_cohort_b_operator_control_summary.v0_1",
+  "summary": {
+    "aggregate_hold_batch_count": 0,
+    "aggregate_ready_batch_count": 3,
+    "hold_index_count": 0,
+    "input_index_count": 2,
+    "ready_index_count": 2,
+    "review_first": true,
+    "status_counts": {
+      "review_index_ready": 2
+    },
+    "valid_index_count": 2,
+    "validation_error_count": 0
+  },
+  "validation_errors": []
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_evidence_index_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_evidence_index_20260402.json
@@ -1,0 +1,61 @@
+{
+  "batch_entries": [
+    {
+      "batch_id": "cohort-b-batch:024f7f4543c0",
+      "batch_index": 0,
+      "batch_status": "batch_review_ready",
+      "blocked_packet_count": 0,
+      "case_count": 2,
+      "decision_reasons": [
+        "multi_case_operator_evidence_materialized"
+      ],
+      "queue_item_count": 3,
+      "validation_error_count": 0
+    },
+    {
+      "batch_id": "cohort-b-batch:8686d3806ef7",
+      "batch_index": 1,
+      "batch_status": "batch_review_ready",
+      "blocked_packet_count": 0,
+      "case_count": 2,
+      "decision_reasons": [
+        "multi_case_operator_evidence_materialized"
+      ],
+      "queue_item_count": 2,
+      "validation_error_count": 0
+    }
+  ],
+  "cohort_id": "cohort_b_reconciled_non_business",
+  "decision_reasons": [
+    "ready_batches_meet_threshold"
+  ],
+  "governance": {
+    "automation_allowed": false,
+    "fail_closed": true,
+    "requires_human_review": true
+  },
+  "index_status": "review_index_ready",
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "non_claims": [
+    "operator evidence index only",
+    "not migration execution",
+    "not cross-cohort arbitration"
+  ],
+  "ready_batch_ids": [
+    "cohort-b-batch:024f7f4543c0",
+    "cohort-b-batch:8686d3806ef7"
+  ],
+  "schema_version": "sl.wikidata_nat_cohort_b_operator_evidence_index.v0_1",
+  "summary": {
+    "hold_batch_count": 0,
+    "input_batch_count": 2,
+    "ready_batch_count": 2,
+    "review_first": true,
+    "status_counts": {
+      "batch_review_ready": 2
+    },
+    "valid_batch_count": 2,
+    "validation_error_count": 0
+  },
+  "validation_errors": []
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_evidence_index_case2_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_evidence_index_case2_20260402.json
@@ -1,0 +1,48 @@
+{
+  "batch_entries": [
+    {
+      "batch_id": "cohort-b-batch:bbcc448e2824",
+      "batch_index": 0,
+      "batch_status": "batch_review_ready",
+      "blocked_packet_count": 0,
+      "case_count": 2,
+      "decision_reasons": [
+        "multi_case_operator_evidence_materialized"
+      ],
+      "queue_item_count": 2,
+      "validation_error_count": 0
+    }
+  ],
+  "cohort_id": "cohort_b_reconciled_non_business",
+  "decision_reasons": [
+    "ready_batches_meet_threshold"
+  ],
+  "governance": {
+    "automation_allowed": false,
+    "fail_closed": true,
+    "requires_human_review": true
+  },
+  "index_status": "review_index_ready",
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "non_claims": [
+    "operator evidence index only",
+    "not migration execution",
+    "not cross-cohort arbitration"
+  ],
+  "ready_batch_ids": [
+    "cohort-b-batch:bbcc448e2824"
+  ],
+  "schema_version": "sl.wikidata_nat_cohort_b_operator_evidence_index.v0_1",
+  "summary": {
+    "hold_batch_count": 0,
+    "input_batch_count": 1,
+    "ready_batch_count": 1,
+    "review_first": true,
+    "status_counts": {
+      "batch_review_ready": 1
+    },
+    "valid_batch_count": 1,
+    "validation_error_count": 0
+  },
+  "validation_errors": []
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_packet_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_packet_20260402.json
@@ -1,0 +1,65 @@
+{
+  "cohort_id": "cohort_b_reconciled_non_business",
+  "contract_violations": [],
+  "decision": "review",
+  "governance": {
+    "automation_allowed": false,
+    "fail_closed": true,
+    "requires_human_review": true
+  },
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "non_claims": [
+    "operator review packet only",
+    "not migration execution",
+    "not cross-cohort routing"
+  ],
+  "packet_id": "operator-packet:3f271cffeb066067",
+  "schema_version": "sl.wikidata_nat_cohort_b_operator_packet.v0_1",
+  "selected_rows": [
+    {
+      "entity_qid": "Q8646",
+      "instance_of_qid": "Q43229",
+      "reviewer_questions": [
+        "Does class Q43229 preserve semantic equivalence under P5991 -> P14143 mapping?"
+      ],
+      "row_id": "Q8646|P5991|4",
+      "variance_flags": [
+        "missing_expected_qualifier_properties",
+        "unexpected_qualifier_properties",
+        "unexpected_reference_properties"
+      ]
+    },
+    {
+      "entity_qid": "Q11661",
+      "instance_of_qid": "Q13442814",
+      "reviewer_questions": [
+        "Are split axes sufficient to avoid claim-boundary collapse for this row?",
+        "Does class Q13442814 preserve semantic equivalence under P5991 -> P14143 mapping?"
+      ],
+      "row_id": "Q11661|P5991|1",
+      "variance_flags": [
+        "missing_expected_qualifier_properties",
+        "missing_expected_reference_properties"
+      ]
+    }
+  ],
+  "source_bucket_decision": "review_only",
+  "summary": {
+    "contract_violation_count": 0,
+    "review_first": true,
+    "selected_row_count": 2,
+    "source_review_row_count": 2,
+    "variance_flag_counts": {
+      "missing_expected_qualifier_properties": 2,
+      "missing_expected_reference_properties": 1,
+      "unexpected_qualifier_properties": 1,
+      "unexpected_reference_properties": 1
+    }
+  },
+  "triage_prompts": [
+    "Review highest-variance Cohort B rows first; keep lane review-only.",
+    "Confirm class-local semantics before any migration-equivalence judgment.",
+    "Inspect unexpected qualifier properties as potential class-specific semantics.",
+    "Inspect unexpected reference properties for citation-shape drift."
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_packet_case2_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_packet_case2_20260402.json
@@ -1,0 +1,51 @@
+{
+  "cohort_id": "cohort_b_reconciled_non_business",
+  "contract_violations": [],
+  "decision": "review",
+  "governance": {
+    "automation_allowed": false,
+    "fail_closed": true,
+    "requires_human_review": true
+  },
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "non_claims": [
+    "operator review packet only",
+    "not migration execution",
+    "not cross-cohort routing"
+  ],
+  "packet_id": "operator-packet:7c8a99e19425124e",
+  "schema_version": "sl.wikidata_nat_cohort_b_operator_packet.v0_1",
+  "selected_rows": [
+    {
+      "entity_qid": "Q8646",
+      "instance_of_qid": "Q43229",
+      "reviewer_questions": [
+        "Does class Q43229 preserve semantic equivalence under P5991 -> P14143 mapping?"
+      ],
+      "row_id": "Q8646|P5991|4",
+      "variance_flags": [
+        "missing_expected_qualifier_properties",
+        "unexpected_qualifier_properties",
+        "unexpected_reference_properties"
+      ]
+    }
+  ],
+  "source_bucket_decision": "review_only",
+  "summary": {
+    "contract_violation_count": 0,
+    "review_first": true,
+    "selected_row_count": 1,
+    "source_review_row_count": 2,
+    "variance_flag_counts": {
+      "missing_expected_qualifier_properties": 1,
+      "unexpected_qualifier_properties": 1,
+      "unexpected_reference_properties": 1
+    }
+  },
+  "triage_prompts": [
+    "Review highest-variance Cohort B rows first; keep lane review-only.",
+    "Confirm class-local semantics before any migration-equivalence judgment.",
+    "Inspect unexpected qualifier properties as potential class-specific semantics.",
+    "Inspect unexpected reference properties for citation-shape drift."
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_packet_input_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_packet_input_20260402.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "sl.wikidata_nat_cohort_b_review_bucket.v0_1",
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "cohort_id": "cohort_b_reconciled_non_business",
+  "decision": "review_only",
+  "decision_reasons": [
+    "cohort_b_rows_require_reviewer_confirmation_before_migration"
+  ],
+  "review_bucket_rows": [
+    {
+      "row_id": "Q11661|P5991|1",
+      "entity_qid": "Q11661",
+      "instance_of_qid": "Q13442814",
+      "review_mode": "review_first",
+      "qualifier_properties": ["P3831", "P459", "P518", "P585"],
+      "reference_properties": ["P813", "P854", "P1476"],
+      "variance_flags": ["missing_expected_qualifier_properties", "missing_expected_reference_properties"],
+      "reviewer_questions": [
+        "Does class Q13442814 preserve semantic equivalence under P5991 -> P14143 mapping?",
+        "Are split axes sufficient to avoid claim-boundary collapse for this row?"
+      ]
+    },
+    {
+      "row_id": "Q8646|P5991|4",
+      "entity_qid": "Q8646",
+      "instance_of_qid": "Q43229",
+      "review_mode": "review_first",
+      "qualifier_properties": ["P459", "P518", "P580", "P582", "P9999"],
+      "reference_properties": ["P813", "P854", "P1065", "P1476", "P2960", "P1234"],
+      "variance_flags": ["missing_expected_qualifier_properties", "unexpected_qualifier_properties", "unexpected_reference_properties"],
+      "reviewer_questions": [
+        "Does class Q43229 preserve semantic equivalence under P5991 -> P14143 mapping?"
+      ]
+    }
+  ],
+  "contract_violations": [],
+  "expected_shape": {
+    "qualifier_properties": ["P3831", "P459", "P518", "P580", "P582", "P585", "P7452"],
+    "reference_properties": ["P1065", "P1476", "P2960", "P813", "P854"]
+  },
+  "summary": {
+    "input_candidate_count": 2,
+    "valid_review_row_count": 2,
+    "contract_violation_count": 0,
+    "review_only_row_count": 2
+  },
+  "non_claims": [
+    "review-first bucket only",
+    "not migration execution",
+    "not full semantic decomposition"
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_queue_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_queue_20260402.json
@@ -1,0 +1,64 @@
+{
+  "blocked_packets": [],
+  "cohort_id": "cohort_b_reconciled_non_business",
+  "decision_reasons": [
+    "validated_review_packets_materialized_to_queue"
+  ],
+  "governance": {
+    "automation_allowed": false,
+    "fail_closed": true,
+    "requires_human_review": true
+  },
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "non_claims": [
+    "queue materialization only",
+    "not migration execution",
+    "not cross-cohort arbitration"
+  ],
+  "queue_items": [
+    {
+      "entity_qid": "Q8646",
+      "instance_of_qid": "Q43229",
+      "packet_id": "operator-packet:3f271cffeb066067",
+      "priority": "high",
+      "queue_item_id": "cohort-b-queue:fc07935a9e84",
+      "row_id": "Q8646|P5991|4",
+      "triage_prompts": [
+        "Confirm class-local semantics before any migration-equivalence judgment.",
+        "Inspect unexpected qualifier properties as potential class-specific semantics."
+      ],
+      "variance_flags": [
+        "missing_expected_qualifier_properties",
+        "unexpected_qualifier_properties",
+        "unexpected_reference_properties"
+      ]
+    },
+    {
+      "entity_qid": "Q11661",
+      "instance_of_qid": "Q13442814",
+      "packet_id": "operator-packet:3f271cffeb066067",
+      "priority": "medium",
+      "queue_item_id": "cohort-b-queue:c9ec83c4f421",
+      "row_id": "Q11661|P5991|1",
+      "triage_prompts": [
+        "Confirm class-local semantics before any migration-equivalence judgment.",
+        "Inspect unexpected qualifier properties as potential class-specific semantics."
+      ],
+      "variance_flags": [
+        "missing_expected_qualifier_properties",
+        "missing_expected_reference_properties"
+      ]
+    }
+  ],
+  "queue_status": "review_queue_ready",
+  "schema_version": "sl.wikidata_nat_cohort_b_operator_queue.v0_1",
+  "summary": {
+    "hold_packet_count": 0,
+    "input_packet_count": 1,
+    "queue_item_count": 2,
+    "review_first": true,
+    "review_packet_count": 1,
+    "validation_error_count": 0
+  },
+  "validation_errors": []
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_report_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_b_operator_report_20260402.json
@@ -1,0 +1,73 @@
+{
+  "blocked_packets": [],
+  "cohort_id": "cohort_b_reconciled_non_business",
+  "examples": [
+    {
+      "entity_qid": "Q8646",
+      "priority": "high",
+      "queue_item_id": "cohort-b-queue:fc07935a9e84",
+      "row_id": "Q8646|P5991|4",
+      "variance_flags": [
+        "missing_expected_qualifier_properties",
+        "unexpected_qualifier_properties",
+        "unexpected_reference_properties"
+      ]
+    },
+    {
+      "entity_qid": "Q11661",
+      "priority": "medium",
+      "queue_item_id": "cohort-b-queue:c9ec83c4f421",
+      "row_id": "Q11661|P5991|1",
+      "variance_flags": [
+        "missing_expected_qualifier_properties",
+        "missing_expected_reference_properties"
+      ]
+    }
+  ],
+  "governance": {
+    "automation_allowed": false,
+    "fail_closed": true,
+    "requires_human_review": true
+  },
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "non_claims": [
+    "operator report only",
+    "not migration execution",
+    "not cross-cohort arbitration"
+  ],
+  "queue_status": "review_queue_ready",
+  "recommendations": [
+    "Process high-priority queue rows first using bounded reviewer prompts.",
+    "Keep Cohort B lane review-only; do not execute migration from this report."
+  ],
+  "report_id": "cohort-b-report:8ca3d0ccc0cf6965",
+  "report_status": "review_only_report_ready",
+  "schema_version": "sl.wikidata_nat_cohort_b_operator_report.v0_1",
+  "summary": {
+    "blocked_packet_count": 0,
+    "priority_counts": {
+      "high": 1,
+      "medium": 1
+    },
+    "queue_item_count": 2,
+    "review_first": true,
+    "top_instance_classes": [
+      {
+        "instance_of_qid": "Q13442814",
+        "queue_row_count": 1
+      },
+      {
+        "instance_of_qid": "Q43229",
+        "queue_row_count": 1
+      }
+    ],
+    "validation_error_count": 0,
+    "variance_flag_counts": {
+      "missing_expected_qualifier_properties": 2,
+      "missing_expected_reference_properties": 1,
+      "unexpected_qualifier_properties": 1,
+      "unexpected_reference_properties": 1
+    }
+  },
+  "validation_errors": []
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_b_review_bucket_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_b_review_bucket_20260402.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "sl.wikidata_nat_cohort_b_review_bucket.v0_1",
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "candidates": [
+    {
+      "row_id": "Q11661|P5991|1",
+      "entity_qid": "Q11661",
+      "instance_of_qid": "Q13442814",
+      "reconciled_instance_of": true,
+      "qualifier_properties": ["P459", "P3831", "P585", "P518"],
+      "reference_properties": ["P854", "P813", "P1476"]
+    },
+    {
+      "row_id": "Q8646|P5991|4",
+      "entity_qid": "Q8646",
+      "instance_of_qid": "Q43229",
+      "reconciled_instance_of": true,
+      "qualifier_properties": ["P459", "P580", "P582", "P518", "P9999"],
+      "reference_properties": ["P854", "P813", "P1476", "P1065", "P2960", "P1234"]
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_c_live_preview_extension_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_c_live_preview_extension_20260402.json
@@ -1,0 +1,22 @@
+[
+  {
+    "qid": "Q314159",
+    "label": "Sample company without P459",
+    "p459_status": "missing",
+    "preview_hold_reason": "Typeless subject; no `instance of` and P459 absent, policy risk.",
+    "qualifier_shape": ["P585", "P3831"],
+    "reference_snapshot": "https://www.wikidata.org/wiki/Q314159",
+    "hold_gate": "review_first_population_scan",
+    "notes": "Proxy qualifiers cite GHG timeline but no determination method."
+  },
+  {
+    "qid": "Q271828",
+    "label": "GHG non-protocol subject",
+    "p459_status": "non-ghg-protocol",
+    "preview_hold_reason": "P459 present but flagged as non-GHG protocol; requires policy confirmation.",
+    "qualifier_shape": ["P585", "P518"],
+    "reference_snapshot": "https://www.wikidata.org/wiki/Q271828",
+    "hold_gate": "review_first_population_scan",
+    "notes": "Reference track shows `P3831` signifying role in emissions, but P459 diverges."
+  }
+]

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_c_operator_evidence_packet_20260404.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_c_operator_evidence_packet_20260404.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "sl.wikidata_nat.cohort_c.operator_evidence.v0_1",
+  "packet_id": "operator-evidence:fixture-20260404",
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "cohort_id": "non_ghg_protocol_or_missing_p459",
+  "scan_status": "live_population_scan_preview",
+  "evidence_rows": [
+    {
+      "qid": "Q1000001",
+      "statement_id": "Q1000001-1",
+      "label": "Policy-risk entity alpha",
+      "p459_status": "missing",
+      "preview_hold_reason": "No determination method, subgroup flagged for policy review.",
+      "operator_hold_reason": "Awaiting qualifier reference check plus governance confirmation.",
+      "reference_anchor": "P854 https://www.wikidata.org/wiki/Q1000001",
+      "qualifier_hint": ["P585", "P3831"],
+      "hold_gate": "review_first_population_scan",
+      "notes": "Reference family indicates GHG conversation but lacks P459.",
+      "promotion_guard": "hold",
+      "notes_summary": "Policy risk hold"
+    },
+    {
+      "qid": "Q1000002",
+      "statement_id": "Q1000002-1",
+      "label": "Policy-risk entity beta",
+      "p459_status": "non-ghg-protocol",
+      "preview_hold_reason": "P459 present but outside expected protocol.",
+      "operator_hold_reason": "Need policy lead buy-in before classification.",
+      "reference_anchor": "P854 https://www.wikidata.org/wiki/Q1000002",
+      "qualifier_hint": ["P518", "P2834"],
+      "hold_gate": "review_first_population_scan",
+      "notes": "Qualifiers reflect exceptional context; hold reason is documented.",
+      "promotion_guard": "hold",
+      "notes_summary": "Policy risk hold"
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_c_operator_packet_extension_20260403.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_c_operator_packet_extension_20260403.json
@@ -1,0 +1,35 @@
+[
+  {
+    "qid": "Q1000001",
+    "label": "Policy-risk entity alpha",
+    "p459_status": "missing",
+    "preview_hold_reason": "No determination method, subgroup flagged for policy review.",
+    "operator_hold_reason": "Awaiting qualifier reference check plus governance confirmation.",
+    "reference_anchor": "P854 https://www.wikidata.org/wiki/Q1000001",
+    "qualifier_hint": ["P585", "P3831"],
+    "hold_gate": "review_first_population_scan",
+    "notes": "Reference family indicates GHG conversation but lacks P459."
+  },
+  {
+    "qid": "Q1000002",
+    "label": "Policy-risk entity beta",
+    "p459_status": "non-ghg-protocol",
+    "preview_hold_reason": "P459 present but outside expected protocol.",
+    "operator_hold_reason": "Need policy lead buy-in before classification.",
+    "reference_anchor": "P854 https://www.wikidata.org/wiki/Q1000002",
+    "qualifier_hint": ["P518", "P2834"],
+    "hold_gate": "review_first_population_scan",
+    "notes": "Qualifiers reflect exceptional context; hold reason is documented."
+  },
+  {
+    "qid": "Q1000003",
+    "label": "Policy-risk entity gamma",
+    "p459_status": "missing",
+    "preview_hold_reason": "Historic statement without P459, flagged to keep policy oversight.",
+    "operator_hold_reason": "References need manual resolution before further steps.",
+    "reference_anchor": "P248 https://www.wikidata.org/wiki/Q1000003",
+    "qualifier_hint": ["P585", "P518", "P7469"],
+    "hold_gate": "review_first_population_scan",
+    "notes": "Candidate is in high-impact namespace; hold until references confirmed."
+  }
+]

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_c_population_scan_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_c_population_scan_20260402.json
@@ -1,0 +1,35 @@
+{
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "selection_rule": "determination method or standard (P459) is missing or not GHG protocol",
+  "cohort_id": "non_ghg_protocol_or_missing_p459",
+  "source_revision_fixture": "wiki_revision_nat_wdu_sandbox_p5991_p14143_20260401.json",
+  "scan_status": "planned",
+  "next_gate": "review_first_population_scan",
+  "sample_candidates": [
+    {
+      "qid": "Q30938280",
+      "label": "Essity",
+      "p459_status": "missing",
+      "qualifier_snippet": "mentions start and end times without a determination method",
+      "policy_note": "lives in wider-online tranche but fails the GHG-protocol filter"
+    },
+    {
+      "qid": "Q731938",
+      "label": "AstraZeneca",
+      "p459_status": "non_GHG_protocol",
+      "qualifier_snippet": "determination method references an alternative standard",
+      "policy_note": "policy review needed before deciding whether to migrate"
+    },
+    {
+      "qid": "Q1785637",
+      "label": "Novozymes",
+      "p459_status": "missing",
+      "qualifier_snippet": "point-in-time qualifiers present but no determination method",
+      "policy_note": "represents the policy-risk mass because the subject is a public company"
+    }
+  ],
+  "notes": [
+    "This fixture mirrors the non-GHG / missing P459 branch state and stays review-first.",
+    "The sample set stays intentionally small so reviewers can spot-check qualifier shapes before a broader scan."
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_c_ptolemy_evidence_sample_20260405.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_c_ptolemy_evidence_sample_20260405.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "sl.wikidata_nat.cohort_c.operator_evidence.v0_1",
+  "packet_id": "operator-evidence:ptolemy-20260405",
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "cohort_id": "non_ghg_protocol_or_missing_p459",
+  "scan_status": "live_population_scan_preview",
+  "evidence_rows": [
+    {
+      "qid": "Q4000001",
+      "statement_id": "Q4000001-1",
+      "label": "Ptolemy entity alpha",
+      "p459_status": "missing",
+      "preview_hold_reason": "Historic statement without P459; candidate is policy-sensitive.",
+      "operator_hold_reason": "Need qualifier/reference reconciliation before any decision.",
+      "reference_anchor": "P854 https://www.wikidata.org/wiki/Q4000001",
+      "qualifier_hint": ["P585", "P3831", "P518"],
+      "hold_gate": "review_first_population_scan",
+      "promotion_guard": "hold",
+      "notes": "Candidate touches the same namespace as other held statements."
+    },
+    {
+      "qid": "Q4000002",
+      "statement_id": "Q4000002-1",
+      "label": "Ptolemy entity beta",
+      "p459_status": "non-ghg-protocol",
+      "preview_hold_reason": "Non-GHG determination method flagged for review.",
+      "operator_hold_reason": "Governance review requested due to qualifier spread.",
+      "reference_anchor": "P248 https://www.wikidata.org/wiki/Q4000002",
+      "qualifier_hint": ["P518", "P459"],
+      "hold_gate": "review_first_population_scan",
+      "promotion_guard": "hold",
+      "notes": "Qualifiers indicate multi-asset context."
+    },
+    {
+      "qid": "Q4000003",
+      "statement_id": "Q4000003-1",
+      "label": "Ptolemy entity gamma",
+      "p459_status": "missing",
+      "preview_hold_reason": "Candidate lacks determination method and has high-impact references.",
+      "operator_hold_reason": "Need governance lead confirmation on references.",
+      "reference_anchor": "P854 https://www.wikidata.org/wiki/Q4000003",
+      "qualifier_hint": ["P3853", "P518"],
+      "hold_gate": "review_first_population_scan",
+      "promotion_guard": "hold",
+      "notes": "References involve climate monitoring reports."
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_report_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_report_20260402.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": "sl.wikidata_nat_cohort_d_operator_report.v0_1",
+  "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+  "cohort_id": "cohort_d_no_instance_of",
+  "readiness": "review_queue_ready",
+  "decision": "review",
+  "promotion_allowed": false,
+  "summary": {
+    "queue_size": 2,
+    "high_priority_count": 2,
+    "medium_priority_count": 0,
+    "unresolved_packet_ref_count": 0
+  },
+  "queue_preview": [
+    {
+      "review_entity_qid": "Q1785637",
+      "priority": "high",
+      "smallest_next_check": "resolve_page_open_questions",
+      "recommended_next_step": "review_structured_split"
+    },
+    {
+      "review_entity_qid": "Q738421",
+      "priority": "high",
+      "smallest_next_check": "resolve_page_open_questions",
+      "recommended_next_step": "review_structured_split"
+    }
+  ],
+  "triage_prompts": [
+    "Review Q1785637 as high priority; start with resolve_page_open_questions.",
+    "Review Q738421 as high priority; start with resolve_page_open_questions."
+  ],
+  "blocked_signals": [],
+  "governance": {
+    "automation_allowed": false,
+    "can_execute_edits": false,
+    "fail_closed": true,
+    "promotion_guard": "hold"
+  },
+  "non_claims": [
+    "report_only_surface",
+    "no_direct_migration_execution",
+    "no_checked_safe_promotion_from_missing_instance_of_alone"
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_report_batch_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_report_batch_20260402.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": "sl.wikidata_nat_cohort_d_operator_report_batch.v0_1",
+  "batch_id": "cohort_d_operator_batch_20260402",
+  "decision": "review",
+  "promotion_allowed": false,
+  "summary": {
+    "case_count": 2,
+    "readiness_counts": {
+      "review_queue_ready": 1,
+      "review_queue_incomplete": 1
+    },
+    "total_queue_size": 4,
+    "total_high_priority_count": 3,
+    "total_unresolved_packet_ref_count": 1,
+    "all_cases_ready": false
+  },
+  "case_reports": [
+    {
+      "case_id": "cohort_d_case_incomplete",
+      "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+      "cohort_id": "cohort_d_no_instance_of",
+      "readiness": "review_queue_incomplete",
+      "queue_size": 2,
+      "high_priority_count": 1,
+      "unresolved_packet_ref_count": 1,
+      "decision": "review",
+      "promotion_allowed": false
+    },
+    {
+      "case_id": "cohort_d_case_ready",
+      "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+      "cohort_id": "cohort_d_no_instance_of",
+      "readiness": "review_queue_ready",
+      "queue_size": 2,
+      "high_priority_count": 2,
+      "unresolved_packet_ref_count": 0,
+      "decision": "review",
+      "promotion_allowed": false
+    }
+  ],
+  "blocked_signals": [
+    "operator_review_surface_not_ready",
+    "unresolved_packet_refs_present"
+  ],
+  "non_claims": [
+    "batch_report_only_surface",
+    "no_direct_migration_execution",
+    "no_checked_safe_promotion_from_missing_instance_of_alone"
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_report_batch_input_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_report_batch_input_20260402.json
@@ -1,0 +1,105 @@
+{
+  "batch_id": "cohort_d_operator_batch_20260402",
+  "operator_review_surfaces": [
+    {
+      "schema_version": "sl.wikidata_nat_cohort_d_operator_review_surface.v0_1",
+      "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+      "cohort_id": "cohort_d_no_instance_of",
+      "readiness": "review_queue_ready",
+      "queue_size": 2,
+      "unresolved_packet_ref_count": 0,
+      "operator_queue": [
+        {
+          "review_entity_qid": "Q1785637",
+          "packet_id": "review-packet:f451ac11e012b114",
+          "split_plan_id": "split://Q1785637|P5991",
+          "priority": "high",
+          "smallest_next_check": "resolve_page_open_questions",
+          "recommended_next_step": "review_structured_split",
+          "uncertainty_flags": [
+            "page_open_questions"
+          ],
+          "execution_allowed": false
+        },
+        {
+          "review_entity_qid": "Q738421",
+          "packet_id": "review-packet:041f7506c2efdeca",
+          "split_plan_id": "split://Q738421|P5991",
+          "priority": "high",
+          "smallest_next_check": "resolve_page_open_questions",
+          "recommended_next_step": "review_structured_split",
+          "uncertainty_flags": [
+            "page_open_questions"
+          ],
+          "execution_allowed": false
+        }
+      ],
+      "required_checklist": [
+        "confirm_absence_of_instance_of",
+        "collect_typing_candidates",
+        "record_reconcile_or_hold_decision"
+      ],
+      "governance": {
+        "automation_allowed": false,
+        "can_execute_edits": false,
+        "fail_closed": true,
+        "promotion_guard": "hold"
+      },
+      "non_claims": [
+        "non_executing_operator_review_surface",
+        "no_direct_migration_execution",
+        "no_checked_safe_promotion_from_missing_instance_of_alone"
+      ],
+      "case_id": "cohort_d_case_ready"
+    },
+    {
+      "schema_version": "sl.wikidata_nat_cohort_d_operator_review_surface.v0_1",
+      "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+      "cohort_id": "cohort_d_no_instance_of",
+      "readiness": "review_queue_incomplete",
+      "queue_size": 2,
+      "unresolved_packet_ref_count": 1,
+      "operator_queue": [
+        {
+          "review_entity_qid": "Q1785637",
+          "packet_id": "review-packet:f451ac11e012b114",
+          "split_plan_id": "split://Q1785637|P5991",
+          "priority": "medium",
+          "smallest_next_check": "resolve_page_open_questions",
+          "recommended_next_step": "review_structured_split",
+          "uncertainty_flags": [],
+          "execution_allowed": false
+        },
+        {
+          "review_entity_qid": "Q738421",
+          "packet_id": "review-packet:041f7506c2efdeca",
+          "split_plan_id": "split://Q738421|P5991",
+          "priority": "high",
+          "smallest_next_check": "resolve_page_open_questions",
+          "recommended_next_step": "review_structured_split",
+          "uncertainty_flags": [
+            "page_open_questions"
+          ],
+          "execution_allowed": false
+        }
+      ],
+      "required_checklist": [
+        "confirm_absence_of_instance_of",
+        "collect_typing_candidates",
+        "record_reconcile_or_hold_decision"
+      ],
+      "governance": {
+        "automation_allowed": false,
+        "can_execute_edits": false,
+        "fail_closed": true,
+        "promotion_guard": "hold"
+      },
+      "non_claims": [
+        "non_executing_operator_review_surface",
+        "no_direct_migration_execution",
+        "no_checked_safe_promotion_from_missing_instance_of_alone"
+      ],
+      "case_id": "cohort_d_case_incomplete"
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_report_batch_ready_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_report_batch_ready_20260402.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "sl.wikidata_nat_cohort_d_operator_report_batch.v0_1",
+  "batch_id": "cohort_d_operator_batch_ready_20260402",
+  "decision": "review",
+  "promotion_allowed": false,
+  "summary": {
+    "case_count": 2,
+    "readiness_counts": {
+      "review_queue_ready": 2,
+      "review_queue_incomplete": 0
+    },
+    "total_queue_size": 4,
+    "total_high_priority_count": 3,
+    "total_unresolved_packet_ref_count": 0,
+    "all_cases_ready": true
+  },
+  "case_reports": [
+    {
+      "case_id": "cohort_d_case_incomplete",
+      "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+      "cohort_id": "cohort_d_no_instance_of",
+      "readiness": "review_queue_ready",
+      "queue_size": 2,
+      "high_priority_count": 1,
+      "unresolved_packet_ref_count": 0,
+      "decision": "review",
+      "promotion_allowed": false
+    },
+    {
+      "case_id": "cohort_d_case_ready",
+      "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+      "cohort_id": "cohort_d_no_instance_of",
+      "readiness": "review_queue_ready",
+      "queue_size": 2,
+      "high_priority_count": 2,
+      "unresolved_packet_ref_count": 0,
+      "decision": "review",
+      "promotion_allowed": false
+    }
+  ],
+  "blocked_signals": [],
+  "non_claims": [
+    "batch_report_only_surface",
+    "no_direct_migration_execution",
+    "no_checked_safe_promotion_from_missing_instance_of_alone"
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_review_surface_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_d_operator_review_surface_20260402.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": "sl.wikidata_nat_cohort_d_operator_review_surface.v0_1",
+  "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+  "cohort_id": "cohort_d_no_instance_of",
+  "readiness": "review_queue_ready",
+  "queue_size": 2,
+  "unresolved_packet_ref_count": 0,
+  "operator_queue": [
+    {
+      "review_entity_qid": "Q1785637",
+      "packet_id": "review-packet:f451ac11e012b114",
+      "split_plan_id": "split://Q1785637|P5991",
+      "priority": "high",
+      "smallest_next_check": "resolve_page_open_questions",
+      "recommended_next_step": "review_structured_split",
+      "uncertainty_flags": [
+        "page_open_questions"
+      ],
+      "execution_allowed": false
+    },
+    {
+      "review_entity_qid": "Q738421",
+      "packet_id": "review-packet:041f7506c2efdeca",
+      "split_plan_id": "split://Q738421|P5991",
+      "priority": "high",
+      "smallest_next_check": "resolve_page_open_questions",
+      "recommended_next_step": "review_structured_split",
+      "uncertainty_flags": [
+        "page_open_questions"
+      ],
+      "execution_allowed": false
+    }
+  ],
+  "required_checklist": [
+    "confirm_absence_of_instance_of",
+    "collect_typing_candidates",
+    "record_reconcile_or_hold_decision"
+  ],
+  "governance": {
+    "automation_allowed": false,
+    "can_execute_edits": false,
+    "fail_closed": true,
+    "promotion_guard": "hold"
+  },
+  "non_claims": [
+    "non_executing_operator_review_surface",
+    "no_direct_migration_execution",
+    "no_checked_safe_promotion_from_missing_instance_of_alone"
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_d_review_control_index_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_d_review_control_index_20260402.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "sl.wikidata_nat_cohort_d_review_control_index.v0_1",
+  "index_id": "cohort_d_review_control_index_20260402",
+  "decision": "review",
+  "promotion_allowed": false,
+  "summary": {
+    "batch_count": 2,
+    "case_count": 4,
+    "total_queue_size": 8,
+    "total_unresolved_packet_ref_count": 1,
+    "readiness_counts": {
+      "review_queue_ready": 1,
+      "review_queue_incomplete": 1
+    },
+    "all_batches_ready": false
+  },
+  "batch_entries": [
+    {
+      "batch_id": "cohort_d_operator_batch_20260402",
+      "readiness": "review_queue_incomplete",
+      "case_count": 2,
+      "queue_size": 4,
+      "unresolved_packet_ref_count": 1,
+      "decision": "review",
+      "promotion_allowed": false
+    },
+    {
+      "batch_id": "cohort_d_operator_batch_ready_20260402",
+      "readiness": "review_queue_ready",
+      "case_count": 2,
+      "queue_size": 4,
+      "unresolved_packet_ref_count": 0,
+      "decision": "review",
+      "promotion_allowed": false
+    }
+  ],
+  "blocked_signals": [
+    "batch_not_all_cases_ready",
+    "operator_review_surface_not_ready",
+    "unresolved_packet_refs_present"
+  ],
+  "hold_signals": [
+    "promotion_guard_hold_enforced",
+    "incomplete_batch_present",
+    "unresolved_packet_refs_present"
+  ],
+  "non_claims": [
+    "control_index_only_surface",
+    "no_direct_migration_execution",
+    "no_checked_safe_promotion_from_missing_instance_of_alone"
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_d_review_control_index_input_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_d_review_control_index_input_20260402.json
@@ -1,0 +1,102 @@
+{
+  "index_id": "cohort_d_review_control_index_20260402",
+  "batch_reports": [
+    {
+      "schema_version": "sl.wikidata_nat_cohort_d_operator_report_batch.v0_1",
+      "batch_id": "cohort_d_operator_batch_20260402",
+      "decision": "review",
+      "promotion_allowed": false,
+      "summary": {
+        "case_count": 2,
+        "readiness_counts": {
+          "review_queue_ready": 1,
+          "review_queue_incomplete": 1
+        },
+        "total_queue_size": 4,
+        "total_high_priority_count": 3,
+        "total_unresolved_packet_ref_count": 1,
+        "all_cases_ready": false
+      },
+      "case_reports": [
+        {
+          "case_id": "cohort_d_case_incomplete",
+          "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+          "cohort_id": "cohort_d_no_instance_of",
+          "readiness": "review_queue_incomplete",
+          "queue_size": 2,
+          "high_priority_count": 1,
+          "unresolved_packet_ref_count": 1,
+          "decision": "review",
+          "promotion_allowed": false
+        },
+        {
+          "case_id": "cohort_d_case_ready",
+          "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+          "cohort_id": "cohort_d_no_instance_of",
+          "readiness": "review_queue_ready",
+          "queue_size": 2,
+          "high_priority_count": 2,
+          "unresolved_packet_ref_count": 0,
+          "decision": "review",
+          "promotion_allowed": false
+        }
+      ],
+      "blocked_signals": [
+        "operator_review_surface_not_ready",
+        "unresolved_packet_refs_present"
+      ],
+      "non_claims": [
+        "batch_report_only_surface",
+        "no_direct_migration_execution",
+        "no_checked_safe_promotion_from_missing_instance_of_alone"
+      ]
+    },
+    {
+      "schema_version": "sl.wikidata_nat_cohort_d_operator_report_batch.v0_1",
+      "batch_id": "cohort_d_operator_batch_ready_20260402",
+      "decision": "review",
+      "promotion_allowed": false,
+      "summary": {
+        "case_count": 2,
+        "readiness_counts": {
+          "review_queue_ready": 2,
+          "review_queue_incomplete": 0
+        },
+        "total_queue_size": 4,
+        "total_high_priority_count": 3,
+        "total_unresolved_packet_ref_count": 0,
+        "all_cases_ready": true
+      },
+      "case_reports": [
+        {
+          "case_id": "cohort_d_case_incomplete",
+          "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+          "cohort_id": "cohort_d_no_instance_of",
+          "readiness": "review_queue_ready",
+          "queue_size": 2,
+          "high_priority_count": 1,
+          "unresolved_packet_ref_count": 0,
+          "decision": "review",
+          "promotion_allowed": false
+        },
+        {
+          "case_id": "cohort_d_case_ready",
+          "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+          "cohort_id": "cohort_d_no_instance_of",
+          "readiness": "review_queue_ready",
+          "queue_size": 2,
+          "high_priority_count": 2,
+          "unresolved_packet_ref_count": 0,
+          "decision": "review",
+          "promotion_allowed": false
+        }
+      ],
+      "blocked_signals": [],
+      "non_claims": [
+        "batch_report_only_surface",
+        "no_direct_migration_execution",
+        "no_checked_safe_promotion_from_missing_instance_of_alone"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_d_review_surface_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_d_review_surface_20260402.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "sl.wikidata_nat_cohort_d_review_surface.v0_1",
+  "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+  "cohort_id": "cohort_d_no_instance_of",
+  "source_mapping_ref": "SensibLaw/docs/planning/wikidata_nat_wdu_sandbox_migration_mapping_20260401.md",
+  "cohort_bucket_summary": {
+    "sandbox_claimed_statement_count": 1395,
+    "bucket_reason": "subject_lacks_instance_of"
+  },
+  "governance": {
+    "bucket_type": "typing_deficit_review_only",
+    "automation_allowed": false,
+    "can_execute_edits": false,
+    "promotion_guard": "hold",
+    "fail_closed": true
+  },
+  "review_surface": {
+    "current_gate_id": "review_first_typing_resolution_scan",
+    "current_gate_status": "open_review",
+    "next_gate_id": "type_probing_scan_review_only",
+    "progress_claim": "reviewable_surface_only"
+  },
+  "required_reviewer_checks": [
+    {
+      "check_id": "confirm_absence_of_instance_of",
+      "description": "Confirm the subject still has no instance of statement in the reviewed slice."
+    },
+    {
+      "check_id": "collect_typing_candidates",
+      "description": "Document at least one plausible typing candidate with source anchor."
+    },
+    {
+      "check_id": "record_reconcile_or_hold_decision",
+      "description": "Mark each reviewed row as either candidate-for-reconciliation or explicit hold."
+    }
+  ],
+  "candidate_packet_refs": [
+    {
+      "review_entity_qid": "Q738421",
+      "packet_ref": "SensibLaw/tests/fixtures/wikidata/wikidata_nat_review_packet_Q738421_sidecar_20260402.json",
+      "packet_role": "cohort_d_typing_deficit_probe"
+    },
+    {
+      "review_entity_qid": "Q1785637",
+      "packet_ref": "SensibLaw/tests/fixtures/wikidata/wikidata_nat_review_packet_Q1785637_sidecar_20260402.json",
+      "packet_role": "cohort_d_typing_deficit_probe"
+    }
+  ],
+  "exit_conditions": [
+    "reconciled_typing_candidate_documented_or_explicit_hold",
+    "no_unreviewed_row_claimed_checked_safe"
+  ],
+  "non_claims": [
+    "no_direct_migration_execution",
+    "no_checked_safe_promotion_from_missing_instance_of_alone"
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_d_type_probing_surface_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_d_type_probing_surface_20260402.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": "sl.wikidata_nat_cohort_d_type_probing_surface.v0_1",
+  "lane_id": "wikidata_nat_cohort_d_no_instance_of",
+  "cohort_id": "cohort_d_no_instance_of",
+  "artifact_status": "review_only_ready",
+  "current_gate_id": "review_first_typing_resolution_scan",
+  "next_gate_id": "type_probing_scan_review_only",
+  "governance": {
+    "automation_allowed": false,
+    "can_execute_edits": false,
+    "fail_closed": true,
+    "promotion_guard": "hold"
+  },
+  "required_reviewer_checks": [
+    {
+      "check_id": "confirm_absence_of_instance_of",
+      "description": "Confirm the subject still has no instance of statement in the reviewed slice."
+    },
+    {
+      "check_id": "collect_typing_candidates",
+      "description": "Document at least one plausible typing candidate with source anchor."
+    },
+    {
+      "check_id": "record_reconcile_or_hold_decision",
+      "description": "Mark each reviewed row as either candidate-for-reconciliation or explicit hold."
+    }
+  ],
+  "probe_rows": [
+    {
+      "review_entity_qid": "Q738421",
+      "packet_id": "review-packet:041f7506c2efdeca",
+      "split_plan_id": "split://Q738421|P5991",
+      "packet_status": "structurally_decomposable",
+      "recommended_next_step": "review_structured_split",
+      "uncertainty_flags": [
+        "page_open_questions"
+      ],
+      "smallest_typing_check": "resolve_page_open_questions",
+      "promotion_guard": "hold",
+      "execution_allowed": false
+    },
+    {
+      "review_entity_qid": "Q1785637",
+      "packet_id": "review-packet:f451ac11e012b114",
+      "split_plan_id": "split://Q1785637|P5991",
+      "packet_status": "structurally_decomposable",
+      "recommended_next_step": "review_structured_split",
+      "uncertainty_flags": [
+        "page_open_questions"
+      ],
+      "smallest_typing_check": "resolve_page_open_questions",
+      "promotion_guard": "hold",
+      "execution_allowed": false
+    }
+  ],
+  "unresolved_packet_refs": [],
+  "non_claims": [
+    "non_executing_type_probe_surface",
+    "no_direct_migration_execution",
+    "no_checked_safe_promotion_from_missing_instance_of_alone"
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_e_diagnostic_batch_report_20260403.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_e_diagnostic_batch_report_20260403.json
@@ -1,0 +1,46 @@
+[
+  {
+    "lane_id": "wikidata_nat_cohort_e_unreconciled_instanceof",
+    "primary_candidate_id": "Q10422059|P5991|5",
+    "comparisons": [
+      {
+        "comparison_id": "Q10403939|P5991|12",
+        "status": "disagreement",
+        "primary_action": "review_structured_split",
+        "comparison_action": "review_only",
+        "agreements": [],
+        "disagreements": [
+          "P3831",
+          "P459",
+          "__value__"
+        ],
+        "notes": []
+      }
+    ],
+    "diagnostic_flags": [],
+    "hold_reason": "unreconciled instance of",
+    "non_authoritative": true
+  },
+  {
+    "lane_id": "wikidata_nat_cohort_e_unreconciled_instanceof",
+    "primary_candidate_id": "Q10403939|P5991|12",
+    "comparisons": [
+      {
+        "comparison_id": "Q10651551|P5991|1",
+        "status": "disagreement",
+        "primary_action": "review_only",
+        "comparison_action": "review_only",
+        "agreements": [],
+        "disagreements": [
+          "P459",
+          "P585",
+          "__value__"
+        ],
+        "notes": []
+      }
+    ],
+    "diagnostic_flags": [],
+    "hold_reason": "unreconciled instance of",
+    "non_authoritative": true
+  }
+]

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_e_diagnostic_report_20260403.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_e_diagnostic_report_20260403.json
@@ -1,0 +1,22 @@
+{
+  "lane_id": "wikidata_nat_cohort_e_unreconciled_instanceof",
+  "primary_candidate_id": "Q10422059|P5991|5",
+  "comparisons": [
+    {
+      "comparison_id": "Q10403939|P5991|12",
+      "status": "disagreement",
+      "primary_action": "review_structured_split",
+      "comparison_action": "review_only",
+      "agreements": [],
+      "disagreements": [
+        "P3831",
+        "P459",
+        "__value__"
+      ],
+      "notes": []
+    }
+  ],
+  "diagnostic_flags": [],
+  "hold_reason": "unreconciled instance of",
+  "non_authoritative": true
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_e_diagnostic_summary_20260403.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_e_diagnostic_summary_20260403.json
@@ -1,0 +1,13 @@
+{
+  "lane_id": "wikidata_nat_cohort_e_unreconciled_instanceof",
+  "batch_size": 2,
+  "agreement_rows": 0,
+  "disagreement_rows": 2,
+  "axis_disagreement_counts": {
+    "P3831": 1,
+    "P459": 2,
+    "P585": 1,
+    "__value__": 2
+  },
+  "non_authoritative": true
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_e_split_axis_batch_sample_20260403.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_e_split_axis_batch_sample_20260403.json
@@ -1,0 +1,28 @@
+{
+  "samples": [
+    {
+      "candidate_id": "Q10422059|P5991|5",
+      "merged_split_axes": [
+        {"property": "__value__", "cardinality": 3, "reason": "multi_value_slot", "source": "slot"},
+        {"property": "P3831", "cardinality": 1, "reason": "role", "source": "slot"}
+      ],
+      "suggested_action": "review_structured_split"
+    },
+    {
+      "candidate_id": "Q10403939|P5991|12",
+      "merged_split_axes": [
+        {"property": "__value__", "cardinality": 2, "reason": "multi_value_slot", "source": "slot"},
+        {"property": "P459", "cardinality": 1, "reason": "standard", "source": "signal"}
+      ],
+      "suggested_action": "review_only"
+    },
+    {
+      "candidate_id": "Q10651551|P5991|1",
+      "merged_split_axes": [
+        {"property": "__value__", "cardinality": 1, "reason": "single_value", "source": "slot"},
+        {"property": "P585", "cardinality": 1, "reason": "date", "source": "signal"}
+      ],
+      "suggested_action": "review_only"
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_e_split_axis_sample_20260403.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_e_split_axis_sample_20260403.json
@@ -1,0 +1,21 @@
+{
+  "lane_id": "wikidata_nat_cohort_e_unreconciled_instanceof",
+  "samples": [
+    {
+      "candidate_id": "Q10422059|P5991|5",
+      "merged_split_axes": [
+        {"property": "__value__", "cardinality": 3, "reason": "multi_value_slot", "source": "slot"},
+        {"property": "P3831", "cardinality": 1, "reason": "role", "source": "slot"}
+      ],
+      "suggested_action": "review_structured_split"
+    },
+    {
+      "candidate_id": "Q10403939|P5991|12",
+      "merged_split_axes": [
+        {"property": "__value__", "cardinality": 2, "reason": "multi_value_slot", "source": "slot"},
+        {"property": "P459", "cardinality": 1, "reason": "standard", "source": "signal"}
+      ],
+      "suggested_action": "review_only"
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_cohort_e_summary_index_20260403.json
+++ b/tests/fixtures/wikidata/wikidata_nat_cohort_e_summary_index_20260403.json
@@ -1,0 +1,10 @@
+{
+  "total_batch_runs": 2,
+  "total_agreements": 0,
+  "total_disagreements": 2,
+  "axis_disagreement_counts": {
+    "P3831": 2,
+    "P459": 2,
+    "__value__": 2
+  }
+}

--- a/tests/fixtures/wikidata/wikidata_nat_grounding_depth_batch_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_grounding_depth_batch_20260402.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "sl.wikidata_review_packet.grounding_depth_batch.v0_1",
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "attachment_count": 2,
+  "attachments": [
+    {
+      "schema_version": "sl.wikidata_review_packet.grounding_depth_attachment.v0_1",
+      "packet_id": "review-packet:5bae90b4fcb444f6",
+      "qid": "Q10403939",
+      "revision_url": "https://www.wikidata.org/w/index.php?title=Q10403939&oldid=2474420124",
+      "grounding_status": "grounded",
+      "evidence": [
+        {
+          "follow_receipt_url": "https://w.wiki/KR5d",
+          "excerpt": "query_row: https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th",
+          "excerpt_summary": "Follow receipt confirms the exact query that anchored the migration discussion.",
+          "status": "ok"
+        }
+      ],
+      "notes": [
+        "Original pinned packet, used as baseline reference for qualification."
+      ]
+    },
+    {
+      "schema_version": "sl.wikidata_review_packet.grounding_depth_attachment.v0_1",
+      "packet_id": "review-packet:c52b8308fdbdd5e3",
+      "qid": "Q731938",
+      "revision_url": "https://www.wikidata.org/wiki/User:Nat_(WDU)/Sandbox/Fossil_fuel_industries/Migrate_from_carbon_footprint_to_GHG_emissions",
+      "grounding_status": "grounded",
+      "evidence": [
+        {
+          "follow_receipt_url": "https://w.wiki/KR5d",
+          "excerpt": "capture all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find",
+          "excerpt_summary": "Highlights the qualifier families used in policy-risk review.",
+          "status": "ok"
+        },
+        {
+          "follow_receipt_url": "https://w.wiki/KR5d",
+          "excerpt": "is it necesary to add the rank?",
+          "excerpt_summary": "Revision question that appears in follow-receipt uncertainty.",
+          "status": "ok"
+        }
+      ],
+      "notes": [
+        "Live-tranche sample flagged for non-GHG `P459` evidence."
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_grounding_depth_batch_single_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_grounding_depth_batch_single_20260402.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": "sl.wikidata_review_packet.grounding_depth_batch.v0_1",
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "attachment_count": 1,
+  "attachments": [
+    {
+      "schema_version": "sl.wikidata_review_packet.grounding_depth_attachment.v0_1",
+      "packet_id": "review-packet:atrium-ljungberg-20260401",
+      "qid": "Q10422059",
+      "revision_url": "https://www.wikidata.org/wiki/User:Nat_(WDU)/Sandbox/Fossil_fuel_industries/Migrate_from_carbon_footprint_to_GHG_emissions",
+      "grounding_status": "grounded",
+      "evidence": [
+        {
+          "follow_receipt_url": "https://w.wiki/KR5d",
+          "excerpt": "evaluate migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)",
+          "excerpt_summary": "Grounds the qualifier-level expectation for the split axes.",
+          "status": "ok"
+        }
+      ],
+      "notes": [
+        "Held split row now packetized; evidence snippet highlights policy questions."
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_grounding_depth_comparison_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_grounding_depth_comparison_20260402.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "sl.wikidata_review_packet.grounding_depth_evidence_report.v0_1",
+  "comparison_count": 2,
+  "comparison": [
+    {
+      "index": 0,
+      "lane_id": "wikidata_nat_wdu_p5991_p14143",
+      "attachment_count": 2,
+      "grounded_packet_count": 2,
+      "qids": [
+        "Q10403939",
+        "Q731938"
+      ],
+      "status_counts": {
+        "grounded": 2
+      }
+    },
+    {
+      "index": 1,
+      "lane_id": "wikidata_nat_wdu_p5991_p14143",
+      "attachment_count": 1,
+      "grounded_packet_count": 1,
+      "qids": [
+        "Q10422059"
+      ],
+      "status_counts": {
+        "grounded": 1
+      }
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_grounding_depth_comparison_single_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_grounding_depth_comparison_single_20260402.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "sl.wikidata_review_packet.grounding_depth_evidence_report.v0_1",
+  "comparison_count": 1,
+  "comparison": [
+    {
+      "index": 0,
+      "lane_id": "wikidata_nat_wdu_p5991_p14143",
+      "attachment_count": 1,
+      "grounded_packet_count": 1,
+      "qids": [
+        "Q10422059"
+      ],
+      "status_counts": {
+        "grounded": 1
+      }
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_grounding_depth_evidence_report_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_grounding_depth_evidence_report_20260402.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "sl.wikidata_review_packet.grounding_depth_evidence_report.v0_1",
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "packet_count": 3,
+  "grounded_packet_count": 3,
+  "packets": [
+    {
+      "packet_id": "review-packet:5bae90b4fcb444f6",
+      "qid": "Q10403939",
+      "revision_url": "https://www.wikidata.org/w/index.php?title=Q10403939&oldid=2474420124",
+      "grounding_status": "grounded",
+      "evidence_count": 1,
+      "missing_fields": [],
+      "notes": [
+        "Original pinned packet, used as baseline reference for qualification."
+      ]
+    },
+    {
+      "packet_id": "review-packet:atrium-ljungberg-20260401",
+      "qid": "Q10422059",
+      "revision_url": "https://www.wikidata.org/wiki/User:Nat_(WDU)/Sandbox/Fossil_fuel_industries/Migrate_from_carbon_footprint_to_GHG_emissions",
+      "grounding_status": "grounded",
+      "evidence_count": 1,
+      "missing_fields": [],
+      "notes": [
+        "Held split row now packetized; evidence snippet highlights policy questions."
+      ]
+    },
+    {
+      "packet_id": "review-packet:c52b8308fdbdd5e3",
+      "qid": "Q731938",
+      "revision_url": "https://www.wikidata.org/wiki/User:Nat_(WDU)/Sandbox/Fossil_fuel_industries/Migrate_from_carbon_footprint_to_GHG_emissions",
+      "grounding_status": "grounded",
+      "evidence_count": 2,
+      "missing_fields": [],
+      "notes": [
+        "Live-tranche sample flagged for non-GHG `P459` evidence."
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_grounding_depth_operator_surface_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_grounding_depth_operator_surface_20260402.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "sl.wikidata_review_packet.grounding_depth_attachment.v0_1",
+  "packet_id": "review-packet:5bae90b4fcb444f6",
+  "qid": "Q10403939",
+  "grounding_status": "grounded",
+  "revision_url": "https://www.wikidata.org/w/index.php?title=Q10403939&oldid=2474420124",
+  "evidence": [
+    {
+      "follow_receipt_url": "https://w.wiki/KR5d",
+      "excerpt": "query_row: https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th",
+      "excerpt_summary": "Follow receipt confirms the exact query that anchored the migration discussion.",
+      "status": "ok"
+    }
+  ],
+  "notes": [
+    "Original pinned packet, used as baseline reference for qualification."
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_grounding_depth_packets_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_grounding_depth_packets_20260402.json
@@ -1,0 +1,51 @@
+{
+  "lane_id": "wikidata_nat_wdu_p5991_p14143",
+  "source_revision_fixture": "wiki_revision_nat_wdu_sandbox_p5991_p14143_20260401.json",
+  "evidence_focus": "hard packets grounding depth",
+  "sample_packets": [
+    {
+      "packet_id": "review-packet:5bae90b4fcb444f6",
+      "qid": "Q10403939",
+      "revision_url": "https://www.wikidata.org/w/index.php?title=Q10403939&oldid=2474420124",
+      "revision_locked_notes": "Original pinned packet, used as baseline reference for qualification.",
+      "revision_evidence": [
+        {
+          "follow_receipt_url": "https://w.wiki/KR5d",
+          "excerpt": "query_row: https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th",
+          "excerpt_summary": "Follow receipt confirms the exact query that anchored the migration discussion."
+        }
+      ]
+    },
+    {
+      "packet_id": "review-packet:atrium-ljungberg-20260401",
+      "qid": "Q10422059",
+      "revision_url": "https://www.wikidata.org/wiki/User:Nat_(WDU)/Sandbox/Fossil_fuel_industries/Migrate_from_carbon_footprint_to_GHG_emissions",
+      "revision_locked_notes": "Held split row now packetized; evidence snippet highlights policy questions.",
+      "revision_evidence": [
+        {
+          "follow_receipt_url": "https://w.wiki/KR5d",
+          "excerpt": "evaluate migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)",
+          "excerpt_summary": "Grounds the qualifier-level expectation for the split axes."
+        }
+      ]
+    },
+    {
+      "packet_id": "review-packet:c52b8308fdbdd5e3",
+      "qid": "Q731938",
+      "revision_url": "https://www.wikidata.org/wiki/User:Nat_(WDU)/Sandbox/Fossil_fuel_industries/Migrate_from_carbon_footprint_to_GHG_emissions",
+      "revision_locked_notes": "Live-tranche sample flagged for non-GHG `P459` evidence.",
+      "revision_evidence": [
+        {
+          "follow_receipt_url": "https://w.wiki/KR5d",
+          "excerpt": "capture all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find",
+          "excerpt_summary": "Highlights the qualifier families used in policy-risk review."
+        },
+        {
+          "follow_receipt_url": "https://w.wiki/KR5d",
+          "excerpt": "is it necesary to add the rank?",
+          "excerpt_summary": "Revision question that appears in follow-receipt uncertainty."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_grounding_depth_review_packets_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_grounding_depth_review_packets_20260402.json
@@ -1,0 +1,10 @@
+[
+  {
+    "packet_id": "review-packet:5bae90b4fcb444f6",
+    "review_entity_qid": "Q10403939"
+  },
+  {
+    "packet_id": "review-packet:c52b8308fdbdd5e3",
+    "review_entity_qid": "Q731938"
+  }
+]

--- a/tests/fixtures/wikidata/wikidata_nat_grounding_depth_scorecard_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_grounding_depth_scorecard_20260402.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "sl.wikidata_review_packet.grounding_depth_scorecard.v0_1",
+  "run_count": 2,
+  "total_grounded_packet_count": 4,
+  "total_attachment_count": 4,
+  "runs": [
+    {
+      "run_id": "baseline",
+      "comparison_count": 2,
+      "grounded_packet_count": 3,
+      "attachment_count": 3,
+      "status_counts": {
+        "grounded": 3
+      }
+    },
+    {
+      "run_id": "single",
+      "comparison_count": 1,
+      "grounded_packet_count": 1,
+      "attachment_count": 1,
+      "status_counts": {
+        "grounded": 1
+      }
+    }
+  ]
+}

--- a/tests/fixtures/wikidata/wikidata_nat_review_packet_Q10416948_sidecar_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_review_packet_Q10416948_sidecar_20260402.json
@@ -151,6 +151,11 @@
         "unit_type": "query_row_surface"
       },
       {
+        "text": "receipt_id=follow:query:1 url=https://w.wiki/KR5d reason=bounded follow of the query link named in the source surface evidence_count=1 unresolved_count=3",
+        "unit_id": "follow_receipt:1",
+        "unit_type": "follow_receipt_surface"
+      },
+      {
         "text": "is it necesary to add the rank?",
         "unit_id": "open_question:1",
         "unit_type": "open_question_surface"
@@ -234,17 +239,109 @@
         "text": "capture references",
         "unit_id": "todo_item:15",
         "unit_type": "todo_surface"
+      },
+      {
+        "unit_id": "anchor:goal",
+        "unit_type": "anchor_surface",
+        "text": "migration_goal: Since the cretion of P14143 I have to migrate most of the P5991 statements with their references and qualifiers to use this new property (This has been discussed in the property proposal and documented in Wikiproject climate change).\n\ntasks\ndone\n\n- is there"
+      },
+      {
+        "unit_id": "anchor:cohort_business_family",
+        "unit_type": "anchor_surface",
+        "text": "cohort_business_family: migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)\n- capt"
+      },
+      {
+        "unit_id": "anchor:qualifier_family",
+        "unit_type": "anchor_surface",
+        "text": "expected_qualifier_family: all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P"
+      },
+      {
+        "unit_id": "anchor:reference_family",
+        "unit_type": "anchor_surface",
+        "text": "expected_reference_family: , empresa de capital abierto, institución financiera)\n- capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we fo"
+      },
+      {
+        "unit_id": "anchor:query_anchor",
+        "unit_type": "anchor_surface",
+        "text": "query_anchor: protocol (otro determination method o no tiene el determination method)\n- evaluate"
+      },
+      {
+        "unit_id": "split_plan:context",
+        "unit_type": "split_context_surface",
+        "text": "split://Q10416948|P5991 status=structurally_decomposable action=review_structured_split review_required=True proposed_bundle_count=2"
+      },
+      {
+        "unit_id": "split_axis:1",
+        "unit_type": "split_axis_surface",
+        "text": "property=P585 source=slot reason=multi_valued_dimension cardinality=2"
+      },
+      {
+        "unit_id": "split_axis:2",
+        "unit_type": "split_axis_surface",
+        "text": "property=__value__ source=slot reason=multi_value_slot cardinality=2"
+      },
+      {
+        "unit_id": "split_candidates:summary",
+        "unit_type": "split_context_surface",
+        "text": "source_candidate_ids=2 sample=Q10416948|P5991|1,Q10416948|P5991|2"
+      },
+      {
+        "unit_id": "missing_evidence:1",
+        "unit_type": "missing_evidence_surface",
+        "text": "anchor_refs_not_promoted_to_grounded_claims"
+      },
+      {
+        "unit_id": "missing_evidence:2",
+        "unit_type": "missing_evidence_surface",
+        "text": "follow_receipts_not_promoted_to_semantic_claims"
+      },
+      {
+        "unit_id": "missing_evidence:3",
+        "unit_type": "missing_evidence_surface",
+        "text": "no_claim_boundary_mapping_for_candidate_units"
+      },
+      {
+        "unit_id": "missing_evidence:4",
+        "unit_type": "missing_evidence_surface",
+        "text": "no_cross_source_alignment_for_candidate_units"
+      },
+      {
+        "unit_id": "missing_evidence:5",
+        "unit_type": "missing_evidence_surface",
+        "text": "no_revision_locked_excerpts_for_candidate_units"
+      },
+      {
+        "unit_id": "missing_evidence:6",
+        "unit_type": "missing_evidence_surface",
+        "text": "open_questions_not_resolved_into_grounded_assertions"
+      },
+      {
+        "unit_id": "missing_evidence:7",
+        "unit_type": "missing_evidence_surface",
+        "text": "query_rows_not_expanded_into_fetched_semantic_units"
+      },
+      {
+        "unit_id": "missing_evidence:8",
+        "unit_type": "missing_evidence_surface",
+        "text": "split_context_not_lifted_into_semantic_decision_graph"
+      },
+      {
+        "unit_id": "missing_evidence:9",
+        "unit_type": "missing_evidence_surface",
+        "text": "todo_items_not_lifted_into_review_decision_graph"
       }
     ],
     "decomposition_state": "surface_only",
     "layer_schema_version": "sl.wikidata_review_packet.semantic_layer.v0_1",
     "missing_evidence": [
+      "anchor_refs_not_promoted_to_grounded_claims",
       "follow_receipts_not_promoted_to_semantic_claims",
       "no_claim_boundary_mapping_for_candidate_units",
       "no_cross_source_alignment_for_candidate_units",
       "no_revision_locked_excerpts_for_candidate_units",
       "open_questions_not_resolved_into_grounded_assertions",
       "query_rows_not_expanded_into_fetched_semantic_units",
+      "split_context_not_lifted_into_semantic_decision_graph",
       "todo_items_not_lifted_into_review_decision_graph"
     ],
     "separate_from_parsed_page": true

--- a/tests/fixtures/wikidata/wikidata_nat_review_packet_Q1785637_sidecar_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_review_packet_Q1785637_sidecar_20260402.json
@@ -1,0 +1,978 @@
+{
+  "follow_receipts": [
+    {
+      "extracted_evidence": [
+        "query_row: https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th"
+      ],
+      "follow_reason": "bounded follow of the query link named in the source surface",
+      "receipt_id": "follow:query:1",
+      "unresolved_uncertainty": [
+        "query output is live search evidence rather than a revision-locked source",
+        "followed link not expanded into a deeper fetch in this packet slice",
+        "query row should be checked against the reviewed split bundle"
+      ],
+      "url": "https://w.wiki/KR5d"
+    }
+  ],
+  "packet_id": "review-packet:f451ac11e012b114",
+  "page_signals": {
+    "cited_links": [
+      "https://w.wiki/KR5d"
+    ],
+    "expected_qualifier_properties": [
+      "P3831",
+      "P459",
+      "P518",
+      "P580",
+      "P582",
+      "P585",
+      "P7452"
+    ],
+    "expected_reference_properties": [
+      "P1065",
+      "P1476",
+      "P2960",
+      "P813",
+      "P854"
+    ],
+    "outbound_links": [],
+    "query_links": [
+      "https://w.wiki/KR5d"
+    ],
+    "unresolved_questions": [
+      "is it necesary to add the rank?",
+      "is there any documentation or protocol on how to make this kind of migrations? Asked Jan and Wikiproject onthology"
+    ]
+  },
+  "parsed_page": {
+    "cohort_task_lines": [
+      "evaluate migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)",
+      "capture all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P518), reason for preferred rank (P7452)",
+      "check if there really are not extra qualifiers within the items that are instances of instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera)",
+      "capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we found only the following reference properties: reference URL (P854), archive URL (P1065), retrieved (P813), title (P1476), archive date (P2960)",
+      "evaluate migration for all other reconciled \"instance of\"",
+      "evaluate migrations of statements cuyo determination method no es GHG protocol (otro determination method o no tiene el determination method)",
+      "evaluate migration for 1395 statements cuyo sujeto no tiene un \"instance of\"",
+      "evaluar migración para 142 declaraciones cuyo sujeto tiene un instance of que no pudo ser reconciliado"
+    ],
+    "headings": [
+      "tasks",
+      "done",
+      "to do",
+      "queries"
+    ],
+    "query_rows": [
+      "https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th"
+    ],
+    "sections": [
+      {
+        "heading": "tasks",
+        "items": []
+      },
+      {
+        "heading": "done",
+        "items": [
+          "is there any documentation or protocol on how to make this kind of migrations? Asked Jan and Wikiproject onthology",
+          "get the units wip query"
+        ]
+      },
+      {
+        "heading": "to do",
+        "items": [
+          "evaluate migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)",
+          "capture all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P518), reason for preferred rank (P7452)",
+          "check if there really are not extra qualifiers within the items that are instances of instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera)",
+          "capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we found only the following reference properties: reference URL (P854), archive URL (P1065), retrieved (P813), title (P1476), archive date (P2960)",
+          "is it necesary to add the rank?",
+          "evaluate migration for all other reconciled \"instance of\"",
+          "look for any unexpected qualifiers",
+          "capture references",
+          "evaluate migrations of statements cuyo determination method no es GHG protocol (otro determination method o no tiene el determination method)",
+          "evaluate migration for 1395 statements cuyo sujeto no tiene un \"instance of\"",
+          "look for any unexpected qualifiers",
+          "capture references",
+          "evaluar migración para 142 declaraciones cuyo sujeto tiene un instance of que no pudo ser reconciliado",
+          "look for any unexpected qualifiers",
+          "capture references"
+        ]
+      },
+      {
+        "heading": "queries",
+        "items": [
+          "https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th"
+        ]
+      }
+    ],
+    "task_buckets": {
+      "done": [
+        "is there any documentation or protocol on how to make this kind of migrations? Asked Jan and Wikiproject onthology",
+        "get the units wip query"
+      ],
+      "todo": [
+        "evaluate migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)",
+        "capture all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P518), reason for preferred rank (P7452)",
+        "check if there really are not extra qualifiers within the items that are instances of instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera)",
+        "capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we found only the following reference properties: reference URL (P854), archive URL (P1065), retrieved (P813), title (P1476), archive date (P2960)",
+        "is it necesary to add the rank?",
+        "evaluate migration for all other reconciled \"instance of\"",
+        "look for any unexpected qualifiers",
+        "capture references",
+        "evaluate migrations of statements cuyo determination method no es GHG protocol (otro determination method o no tiene el determination method)",
+        "evaluate migration for 1395 statements cuyo sujeto no tiene un \"instance of\"",
+        "look for any unexpected qualifiers",
+        "capture references",
+        "evaluar migración para 142 declaraciones cuyo sujeto tiene un instance of que no pudo ser reconciliado",
+        "look for any unexpected qualifiers",
+        "capture references"
+      ]
+    }
+  },
+  "review_entity_qid": "Q1785637",
+  "reviewer_view": {
+    "decision_focus": [
+      "confirm_split_axes",
+      "confirm_target_bundle_count",
+      "spot_check_reference_propagation",
+      "spot_check_qualifier_propagation",
+      "resolve_page_open_questions",
+      "use_todo_bucket_as_review_checklist"
+    ],
+    "recommended_next_step": "review_structured_split",
+    "uncertainty_flags": [
+      "page_open_questions"
+    ]
+  },
+  "schema_version": "sl.wikidata_review_packet.v0_1",
+  "semantic_decomposition": {
+    "candidate_units": [
+      {
+        "text": "https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th",
+        "unit_id": "query_row:1",
+        "unit_type": "query_row_surface"
+      },
+      {
+        "text": "receipt_id=follow:query:1 url=https://w.wiki/KR5d reason=bounded follow of the query link named in the source surface evidence_count=1 unresolved_count=3",
+        "unit_id": "follow_receipt:1",
+        "unit_type": "follow_receipt_surface"
+      },
+      {
+        "text": "is it necesary to add the rank?",
+        "unit_id": "open_question:1",
+        "unit_type": "open_question_surface"
+      },
+      {
+        "text": "is there any documentation or protocol on how to make this kind of migrations? Asked Jan and Wikiproject onthology",
+        "unit_id": "open_question:2",
+        "unit_type": "open_question_surface"
+      },
+      {
+        "text": "evaluate migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)",
+        "unit_id": "todo_item:1",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "capture all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P518), reason for preferred rank (P7452)",
+        "unit_id": "todo_item:2",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "check if there really are not extra qualifiers within the items that are instances of instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera)",
+        "unit_id": "todo_item:3",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we found only the following reference properties: reference URL (P854), archive URL (P1065), retrieved (P813), title (P1476), archive date (P2960)",
+        "unit_id": "todo_item:4",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "is it necesary to add the rank?",
+        "unit_id": "todo_item:5",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "evaluate migration for all other reconciled \"instance of\"",
+        "unit_id": "todo_item:6",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "look for any unexpected qualifiers",
+        "unit_id": "todo_item:7",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "capture references",
+        "unit_id": "todo_item:8",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "evaluate migrations of statements cuyo determination method no es GHG protocol (otro determination method o no tiene el determination method)",
+        "unit_id": "todo_item:9",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "evaluate migration for 1395 statements cuyo sujeto no tiene un \"instance of\"",
+        "unit_id": "todo_item:10",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "look for any unexpected qualifiers",
+        "unit_id": "todo_item:11",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "capture references",
+        "unit_id": "todo_item:12",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "evaluar migración para 142 declaraciones cuyo sujeto tiene un instance of que no pudo ser reconciliado",
+        "unit_id": "todo_item:13",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "look for any unexpected qualifiers",
+        "unit_id": "todo_item:14",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "capture references",
+        "unit_id": "todo_item:15",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "migration_goal: Since the cretion of P14143 I have to migrate most of the P5991 statements with their references and qualifiers to use this new property (This has been discussed in the property proposal and documented in Wikiproject climate change).\n\ntasks\ndone\n\n- is there",
+        "unit_id": "anchor:goal",
+        "unit_type": "anchor_surface"
+      },
+      {
+        "text": "cohort_business_family: migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)\n- capt",
+        "unit_id": "anchor:cohort_business_family",
+        "unit_type": "anchor_surface"
+      },
+      {
+        "text": "expected_qualifier_family: all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P",
+        "unit_id": "anchor:qualifier_family",
+        "unit_type": "anchor_surface"
+      },
+      {
+        "text": "expected_reference_family: , empresa de capital abierto, institución financiera)\n- capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we fo",
+        "unit_id": "anchor:reference_family",
+        "unit_type": "anchor_surface"
+      },
+      {
+        "text": "query_anchor: protocol (otro determination method o no tiene el determination method)\n- evaluate",
+        "unit_id": "anchor:query_anchor",
+        "unit_type": "anchor_surface"
+      },
+      {
+        "text": "split://Q1785637|P5991 status=structurally_decomposable action=review_structured_split review_required=True proposed_bundle_count=42",
+        "unit_id": "split_plan:context",
+        "unit_type": "split_context_surface"
+      },
+      {
+        "text": "property=P3831 source=slot reason=multi_valued_dimension cardinality=4",
+        "unit_id": "split_axis:1",
+        "unit_type": "split_axis_surface"
+      },
+      {
+        "text": "property=P518 source=slot reason=multi_valued_dimension cardinality=8",
+        "unit_id": "split_axis:2",
+        "unit_type": "split_axis_surface"
+      },
+      {
+        "text": "property=P580 source=slot reason=multi_valued_dimension cardinality=4",
+        "unit_id": "split_axis:3",
+        "unit_type": "split_axis_surface"
+      },
+      {
+        "text": "property=P582 source=slot reason=multi_valued_dimension cardinality=4",
+        "unit_id": "split_axis:4",
+        "unit_type": "split_axis_surface"
+      },
+      {
+        "text": "property=__value__ source=slot reason=multi_value_slot cardinality=42",
+        "unit_id": "split_axis:5",
+        "unit_type": "split_axis_surface"
+      },
+      {
+        "text": "source_candidate_ids=42 sample=Q1785637|P5991|1,Q1785637|P5991|2,Q1785637|P5991|3",
+        "unit_id": "split_candidates:summary",
+        "unit_type": "split_context_surface"
+      },
+      {
+        "text": "anchor_refs_not_promoted_to_grounded_claims",
+        "unit_id": "missing_evidence:1",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "follow_receipts_not_promoted_to_semantic_claims",
+        "unit_id": "missing_evidence:2",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "no_claim_boundary_mapping_for_candidate_units",
+        "unit_id": "missing_evidence:3",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "no_cross_source_alignment_for_candidate_units",
+        "unit_id": "missing_evidence:4",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "no_revision_locked_excerpts_for_candidate_units",
+        "unit_id": "missing_evidence:5",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "open_questions_not_resolved_into_grounded_assertions",
+        "unit_id": "missing_evidence:6",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "query_rows_not_expanded_into_fetched_semantic_units",
+        "unit_id": "missing_evidence:7",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "split_context_not_lifted_into_semantic_decision_graph",
+        "unit_id": "missing_evidence:8",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "todo_items_not_lifted_into_review_decision_graph",
+        "unit_id": "missing_evidence:9",
+        "unit_type": "missing_evidence_surface"
+      }
+    ],
+    "claim_boundaries": {
+      "candidate_claim_boundaries": [
+        {
+          "anchor_ref": {
+            "anchor_id": "goal",
+            "end": 257,
+            "label": "migration_goal",
+            "start": 0
+          },
+          "axis_signals": [
+            {
+              "axis_id": "axis:1",
+              "cardinality": 4,
+              "property": "P3831",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:2",
+              "cardinality": 8,
+              "property": "P518",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:3",
+              "cardinality": 4,
+              "property": "P580",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:4",
+              "cardinality": 4,
+              "property": "P582",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:5",
+              "cardinality": 42,
+              "property": "__value__",
+              "reason": "multi_value_slot",
+              "source": "slot"
+            }
+          ],
+          "boundary_id": "boundary:1",
+          "boundary_state": "candidate_only",
+          "candidate_claim_text": "Since the cretion of P14143 I have to migrate most of the P5991 statements with their references and qualifiers to use this new property (This has been discussed in the property proposal and documented in Wikiproject climate change).\n\ntasks\ndone\n\n- is there",
+          "missing_evidence": [
+            "no_clause_level_segmentation",
+            "no_cross_source_alignment",
+            "no_grounded_claim_assertion",
+            "open_questions_unresolved"
+          ],
+          "review_prompt": "Check whether anchor 'migration_goal' expresses one claim boundary per axis: P3831, P518, P580, P582, __value__."
+        },
+        {
+          "anchor_ref": {
+            "anchor_id": "cohort_business_family",
+            "end": 585,
+            "label": "cohort_business_family",
+            "start": 408
+          },
+          "axis_signals": [
+            {
+              "axis_id": "axis:1",
+              "cardinality": 4,
+              "property": "P3831",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:2",
+              "cardinality": 8,
+              "property": "P518",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:3",
+              "cardinality": 4,
+              "property": "P580",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:4",
+              "cardinality": 4,
+              "property": "P582",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:5",
+              "cardinality": 42,
+              "property": "__value__",
+              "reason": "multi_value_slot",
+              "source": "slot"
+            }
+          ],
+          "boundary_id": "boundary:2",
+          "boundary_state": "candidate_only",
+          "candidate_claim_text": "migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)\n- capt",
+          "missing_evidence": [
+            "no_clause_level_segmentation",
+            "no_cross_source_alignment",
+            "no_grounded_claim_assertion",
+            "open_questions_unresolved"
+          ],
+          "review_prompt": "Check whether anchor 'cohort_business_family' expresses one claim boundary per axis: P3831, P518, P580, P582, __value__."
+        },
+        {
+          "anchor_ref": {
+            "anchor_id": "qualifier_family",
+            "end": 847,
+            "label": "expected_qualifier_family",
+            "start": 588
+          },
+          "axis_signals": [
+            {
+              "axis_id": "axis:1",
+              "cardinality": 4,
+              "property": "P3831",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:2",
+              "cardinality": 8,
+              "property": "P518",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:3",
+              "cardinality": 4,
+              "property": "P580",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:4",
+              "cardinality": 4,
+              "property": "P582",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:5",
+              "cardinality": 42,
+              "property": "__value__",
+              "reason": "multi_value_slot",
+              "source": "slot"
+            }
+          ],
+          "boundary_id": "boundary:3",
+          "boundary_state": "candidate_only",
+          "candidate_claim_text": "all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P",
+          "missing_evidence": [
+            "no_clause_level_segmentation",
+            "no_cross_source_alignment",
+            "no_grounded_claim_assertion",
+            "open_questions_unresolved"
+          ],
+          "review_prompt": "Check whether anchor 'expected_qualifier_family' expresses one claim boundary per axis: P3831, P518, P580, P582, __value__."
+        },
+        {
+          "anchor_ref": {
+            "anchor_id": "reference_family",
+            "end": 1289,
+            "label": "expected_reference_family",
+            "start": 1047
+          },
+          "axis_signals": [
+            {
+              "axis_id": "axis:1",
+              "cardinality": 4,
+              "property": "P3831",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:2",
+              "cardinality": 8,
+              "property": "P518",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:3",
+              "cardinality": 4,
+              "property": "P580",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:4",
+              "cardinality": 4,
+              "property": "P582",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:5",
+              "cardinality": 42,
+              "property": "__value__",
+              "reason": "multi_value_slot",
+              "source": "slot"
+            }
+          ],
+          "boundary_id": "boundary:4",
+          "boundary_state": "candidate_only",
+          "candidate_claim_text": ", empresa de capital abierto, institución financiera)\n- capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we fo",
+          "missing_evidence": [
+            "no_clause_level_segmentation",
+            "no_cross_source_alignment",
+            "no_grounded_claim_assertion",
+            "open_questions_unresolved"
+          ],
+          "review_prompt": "Check whether anchor 'expected_reference_family' expresses one claim boundary per axis: P3831, P518, P580, P582, __value__."
+        },
+        {
+          "anchor_ref": {
+            "anchor_id": "query_anchor",
+            "end": 1737,
+            "label": "query_anchor",
+            "start": 1655
+          },
+          "axis_signals": [
+            {
+              "axis_id": "axis:1",
+              "cardinality": 4,
+              "property": "P3831",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:2",
+              "cardinality": 8,
+              "property": "P518",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:3",
+              "cardinality": 4,
+              "property": "P580",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:4",
+              "cardinality": 4,
+              "property": "P582",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:5",
+              "cardinality": 42,
+              "property": "__value__",
+              "reason": "multi_value_slot",
+              "source": "slot"
+            }
+          ],
+          "boundary_id": "boundary:5",
+          "boundary_state": "candidate_only",
+          "candidate_claim_text": "protocol (otro determination method o no tiene el determination method)\n- evaluate",
+          "missing_evidence": [
+            "no_clause_level_segmentation",
+            "no_cross_source_alignment",
+            "no_grounded_claim_assertion",
+            "open_questions_unresolved"
+          ],
+          "review_prompt": "Check whether anchor 'query_anchor' expresses one claim boundary per axis: P3831, P518, P580, P582, __value__."
+        }
+      ],
+      "decomposition_state": "candidate_only",
+      "non_claims": [
+        "not_full_semantic_decomposition",
+        "not_claim_truth_evaluation",
+        "not_execution_ready_migration_logic"
+      ],
+      "schema_version": "sl.wikidata_review_packet.claim_boundaries.v0_1",
+      "summary": {
+        "anchor_count": 5,
+        "axis_count": 5,
+        "candidate_boundary_count": 5,
+        "unresolved_question_count": 2
+      }
+    },
+    "cross_source_alignment": {
+      "agreements": [
+        "Shared entity id Q1785637 appears in 3 source(s)."
+      ],
+      "common_fields": [],
+      "consensus_identity": "Q1785637",
+      "consensus_level": "full_consensus",
+      "disagreements": [
+        "Fields documented on each surface do not overlap, so reviewers should cross-check."
+      ],
+      "packet_id": "review-packet:f451ac11e012b114",
+      "pairwise_signatures": [
+        {
+          "field_overlap": [
+            "https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th"
+          ],
+          "only_in_left": [
+            "source"
+          ],
+          "only_in_right": [],
+          "pair": "wiki_surface vs query_slice",
+          "shared_keys": [
+            "fields",
+            "qid",
+            "summary"
+          ]
+        },
+        {
+          "field_overlap": [],
+          "only_in_left": [
+            "qid",
+            "source"
+          ],
+          "only_in_right": [
+            "primary_qid"
+          ],
+          "pair": "wiki_surface vs split_bundle",
+          "shared_keys": [
+            "fields",
+            "summary"
+          ]
+        },
+        {
+          "field_overlap": [],
+          "only_in_left": [
+            "qid"
+          ],
+          "only_in_right": [
+            "primary_qid"
+          ],
+          "pair": "query_slice vs split_bundle",
+          "shared_keys": [
+            "fields",
+            "summary"
+          ]
+        }
+      ],
+      "profiles": {
+        "query_slice": {
+          "field_signature": [
+            "https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th"
+          ],
+          "identity": "Q1785637",
+          "key_signature": [
+            "fields",
+            "qid",
+            "summary"
+          ],
+          "label": "query_slice",
+          "source_tag": "",
+          "summary": "query rows from parsed page"
+        },
+        "split_bundle": {
+          "field_signature": [
+            "P3831",
+            "P518",
+            "P580",
+            "P582",
+            "__value__"
+          ],
+          "identity": "Q1785637",
+          "key_signature": [
+            "fields",
+            "primary_qid",
+            "summary"
+          ],
+          "label": "split_bundle",
+          "source_tag": "",
+          "summary": "review_structured_split"
+        },
+        "wiki_surface": {
+          "field_signature": [
+            "https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th"
+          ],
+          "identity": "Q1785637",
+          "key_signature": [
+            "fields",
+            "qid",
+            "source",
+            "summary"
+          ],
+          "label": "wiki_surface",
+          "source_tag": "wiki",
+          "summary": "User:Nat (WDU)/Sandbox/Fossil fuel industries/Migrate from carbon footprint to GHG emissions"
+        }
+      },
+      "schema_version": "sl.wikidata_review_packet.cross_source_alignment.v0_1"
+    },
+    "decomposition_state": "surface_only",
+    "follow_depth": {
+      "enriched_count": 1,
+      "no_excerpt_count": 0,
+      "packet_id": "review-packet:f451ac11e012b114",
+      "receipt_count": 1,
+      "receipts": [
+        {
+          "evidence_excerpt": "query_row: https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th",
+          "excerpt_source": "extracted_evidence",
+          "receipt_id": "follow:query:1",
+          "status": "enriched",
+          "unresolved_uncertainty": [
+            "query output is live search evidence rather than a revision-locked source",
+            "followed link not expanded into a deeper fetch in this packet slice",
+            "query row should be checked against the reviewed split bundle"
+          ],
+          "url": "https://w.wiki/KR5d"
+        }
+      ],
+      "schema_version": "sl.wikidata_review_packet.follow_depth.v0_1"
+    },
+    "layer_schema_version": "sl.wikidata_review_packet.semantic_layer.v0_1",
+    "missing_evidence": [
+      "anchor_refs_not_promoted_to_grounded_claims",
+      "follow_receipts_not_promoted_to_semantic_claims",
+      "no_claim_boundary_mapping_for_candidate_units",
+      "no_cross_source_alignment_for_candidate_units",
+      "no_revision_locked_excerpts_for_candidate_units",
+      "open_questions_not_resolved_into_grounded_assertions",
+      "query_rows_not_expanded_into_fetched_semantic_units",
+      "split_context_not_lifted_into_semantic_decision_graph",
+      "todo_items_not_lifted_into_review_decision_graph"
+    ],
+    "reviewer_actions": {
+      "can_execute_edits": false,
+      "decision_focus": [
+        "confirm_split_axes",
+        "confirm_target_bundle_count",
+        "spot_check_reference_propagation",
+        "spot_check_qualifier_propagation",
+        "resolve_page_open_questions",
+        "use_todo_bucket_as_review_checklist"
+      ],
+      "likely_decision": "review_structured_split",
+      "non_claims": [
+        "review aid only",
+        "does not execute edits",
+        "does not resolve uncertainty automatically"
+      ],
+      "packet_id": "review-packet:f451ac11e012b114",
+      "review_entity_qid": "Q1785637",
+      "schema_version": "sl.wikidata_review_packet.reviewer_actions.v0_1",
+      "smallest_next_check": {
+        "check_id": "confirm_first_split_axis",
+        "rationale": "split plan is axis-driven; confirm first axis property=P3831 cardinality=4"
+      },
+      "uncertainty_flags": [
+        "page_open_questions"
+      ],
+      "why_this_row_is_in_review": [
+        "split_status=structurally_decomposable",
+        "split_plan_requires_review",
+        "split_axes_detected=5",
+        "uncertainty=page_open_questions"
+      ]
+    },
+    "separate_from_parsed_page": true,
+    "variant_comparison": {
+      "comparisons": [
+        {
+          "agreements": [
+            "P3831"
+          ],
+          "comparison_action": "review_structured_split",
+          "comparison_id": "split://Q738421|P5991",
+          "disagreements": [
+            "P518",
+            "P580",
+            "P582",
+            "__value__"
+          ],
+          "notes": [],
+          "primary_action": "review_structured_split",
+          "status": "disagreement"
+        }
+      ],
+      "diagnostic_flags": [],
+      "non_authoritative": true,
+      "primary_candidate_id": "split://Q1785637|P5991"
+    }
+  },
+  "source_surface": {
+    "anchor_refs": [
+      {
+        "anchor_id": "goal",
+        "end": 257,
+        "label": "migration_goal",
+        "start": 0,
+        "text_excerpt": "Since the cretion of P14143 I have to migrate most of the P5991 statements with their references and qualifiers to use this new property (This has been discussed in the property proposal and documented in Wikiproject climate change).\n\ntasks\ndone\n\n- is there"
+      },
+      {
+        "anchor_id": "cohort_business_family",
+        "end": 585,
+        "label": "cohort_business_family",
+        "start": 408,
+        "text_excerpt": "migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)\n- capt"
+      },
+      {
+        "anchor_id": "qualifier_family",
+        "end": 847,
+        "label": "expected_qualifier_family",
+        "start": 588,
+        "text_excerpt": "all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P"
+      },
+      {
+        "anchor_id": "reference_family",
+        "end": 1289,
+        "label": "expected_reference_family",
+        "start": 1047,
+        "text_excerpt": ", empresa de capital abierto, institución financiera)\n- capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we fo"
+      },
+      {
+        "anchor_id": "query_anchor",
+        "end": 1737,
+        "label": "query_anchor",
+        "start": 1655,
+        "text_excerpt": "protocol (otro determination method o no tiene el determination method)\n- evaluate"
+      }
+    ],
+    "origin": {
+      "source_type": "wiki",
+      "source_url": "https://www.wikidata.org/wiki/User:Nat_(WDU)/Sandbox/Fossil_fuel_industries/Migrate_from_carbon_footprint_to_GHG_emissions",
+      "title": "User:Nat (WDU)/Sandbox/Fossil fuel industries/Migrate from carbon footprint to GHG emissions"
+    },
+    "revision": {
+      "retrieval_method": "wiki_revision",
+      "revision_id": "provided_snapshot_2026-04-01",
+      "revision_timestamp": "2026-04-01T00:00:00+10:00"
+    },
+    "source_entity_qid": "Q10884",
+    "source_unit_id": "unit:wikidata_user_sandbox:nat_wdu:p5991_p14143:2026-04-01"
+  },
+  "split_review_context": {
+    "merged_split_axes": [
+      {
+        "cardinality": 4,
+        "property": "P3831",
+        "reason": "multi_valued_dimension",
+        "source": "slot"
+      },
+      {
+        "cardinality": 8,
+        "property": "P518",
+        "reason": "multi_valued_dimension",
+        "source": "slot"
+      },
+      {
+        "cardinality": 4,
+        "property": "P580",
+        "reason": "multi_valued_dimension",
+        "source": "slot"
+      },
+      {
+        "cardinality": 4,
+        "property": "P582",
+        "reason": "multi_valued_dimension",
+        "source": "slot"
+      },
+      {
+        "cardinality": 42,
+        "property": "__value__",
+        "reason": "multi_value_slot",
+        "source": "slot"
+      }
+    ],
+    "proposed_bundle_count": 42,
+    "qualifier_propagation": "exact",
+    "reference_propagation": "exact",
+    "review_required": true,
+    "source_candidate_ids": [
+      "Q1785637|P5991|1",
+      "Q1785637|P5991|2",
+      "Q1785637|P5991|3",
+      "Q1785637|P5991|4",
+      "Q1785637|P5991|5",
+      "Q1785637|P5991|6",
+      "Q1785637|P5991|7",
+      "Q1785637|P5991|8",
+      "Q1785637|P5991|9",
+      "Q1785637|P5991|10",
+      "Q1785637|P5991|11",
+      "Q1785637|P5991|12",
+      "Q1785637|P5991|13",
+      "Q1785637|P5991|14",
+      "Q1785637|P5991|15",
+      "Q1785637|P5991|16",
+      "Q1785637|P5991|17",
+      "Q1785637|P5991|18",
+      "Q1785637|P5991|19",
+      "Q1785637|P5991|20",
+      "Q1785637|P5991|21",
+      "Q1785637|P5991|22",
+      "Q1785637|P5991|23",
+      "Q1785637|P5991|24",
+      "Q1785637|P5991|25",
+      "Q1785637|P5991|26",
+      "Q1785637|P5991|27",
+      "Q1785637|P5991|28",
+      "Q1785637|P5991|29",
+      "Q1785637|P5991|30",
+      "Q1785637|P5991|31",
+      "Q1785637|P5991|32",
+      "Q1785637|P5991|33",
+      "Q1785637|P5991|34",
+      "Q1785637|P5991|35",
+      "Q1785637|P5991|36",
+      "Q1785637|P5991|37",
+      "Q1785637|P5991|38",
+      "Q1785637|P5991|39",
+      "Q1785637|P5991|40",
+      "Q1785637|P5991|41",
+      "Q1785637|P5991|42"
+    ],
+    "source_slot_id": "Q1785637|P5991",
+    "split_plan_id": "split://Q1785637|P5991",
+    "status": "structurally_decomposable",
+    "suggested_action": "review_structured_split"
+  }
+}

--- a/tests/fixtures/wikidata/wikidata_nat_review_packet_Q56404383_sidecar_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_review_packet_Q56404383_sidecar_20260402.json
@@ -152,6 +152,11 @@
         "unit_type": "query_row_surface"
       },
       {
+        "text": "receipt_id=follow:query:1 url=https://w.wiki/KR5d reason=bounded follow of the query link named in the source surface evidence_count=1 unresolved_count=3",
+        "unit_id": "follow_receipt:1",
+        "unit_type": "follow_receipt_surface"
+      },
+      {
         "text": "is it necesary to add the rank?",
         "unit_id": "open_question:1",
         "unit_type": "open_question_surface"
@@ -235,17 +240,99 @@
         "text": "capture references",
         "unit_id": "todo_item:15",
         "unit_type": "todo_surface"
+      },
+      {
+        "unit_id": "anchor:goal",
+        "unit_type": "anchor_surface",
+        "text": "migration_goal: Since the cretion of P14143 I have to migrate most of the P5991 statements with their references and qualifiers to use this new property (This has been discussed in the property proposal and documented in Wikiproject climate change).\n\ntasks\ndone\n\n- is there"
+      },
+      {
+        "unit_id": "anchor:cohort_business_family",
+        "unit_type": "anchor_surface",
+        "text": "cohort_business_family: migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)\n- capt"
+      },
+      {
+        "unit_id": "anchor:qualifier_family",
+        "unit_type": "anchor_surface",
+        "text": "expected_qualifier_family: all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P"
+      },
+      {
+        "unit_id": "anchor:reference_family",
+        "unit_type": "anchor_surface",
+        "text": "expected_reference_family: , empresa de capital abierto, institución financiera)\n- capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we fo"
+      },
+      {
+        "unit_id": "anchor:query_anchor",
+        "unit_type": "anchor_surface",
+        "text": "query_anchor: protocol (otro determination method o no tiene el determination method)\n- evaluate"
+      },
+      {
+        "unit_id": "split_plan:context",
+        "unit_type": "split_context_surface",
+        "text": "split://Q56404383|P5991 status=review_only action=review_only review_required=True proposed_bundle_count=1"
+      },
+      {
+        "unit_id": "split_candidates:summary",
+        "unit_type": "split_context_surface",
+        "text": "source_candidate_ids=1 sample=Q56404383|P5991|1"
+      },
+      {
+        "unit_id": "missing_evidence:1",
+        "unit_type": "missing_evidence_surface",
+        "text": "anchor_refs_not_promoted_to_grounded_claims"
+      },
+      {
+        "unit_id": "missing_evidence:2",
+        "unit_type": "missing_evidence_surface",
+        "text": "follow_receipts_not_promoted_to_semantic_claims"
+      },
+      {
+        "unit_id": "missing_evidence:3",
+        "unit_type": "missing_evidence_surface",
+        "text": "no_claim_boundary_mapping_for_candidate_units"
+      },
+      {
+        "unit_id": "missing_evidence:4",
+        "unit_type": "missing_evidence_surface",
+        "text": "no_cross_source_alignment_for_candidate_units"
+      },
+      {
+        "unit_id": "missing_evidence:5",
+        "unit_type": "missing_evidence_surface",
+        "text": "no_revision_locked_excerpts_for_candidate_units"
+      },
+      {
+        "unit_id": "missing_evidence:6",
+        "unit_type": "missing_evidence_surface",
+        "text": "open_questions_not_resolved_into_grounded_assertions"
+      },
+      {
+        "unit_id": "missing_evidence:7",
+        "unit_type": "missing_evidence_surface",
+        "text": "query_rows_not_expanded_into_fetched_semantic_units"
+      },
+      {
+        "unit_id": "missing_evidence:8",
+        "unit_type": "missing_evidence_surface",
+        "text": "split_context_not_lifted_into_semantic_decision_graph"
+      },
+      {
+        "unit_id": "missing_evidence:9",
+        "unit_type": "missing_evidence_surface",
+        "text": "todo_items_not_lifted_into_review_decision_graph"
       }
     ],
     "decomposition_state": "surface_only",
     "layer_schema_version": "sl.wikidata_review_packet.semantic_layer.v0_1",
     "missing_evidence": [
+      "anchor_refs_not_promoted_to_grounded_claims",
       "follow_receipts_not_promoted_to_semantic_claims",
       "no_claim_boundary_mapping_for_candidate_units",
       "no_cross_source_alignment_for_candidate_units",
       "no_revision_locked_excerpts_for_candidate_units",
       "open_questions_not_resolved_into_grounded_assertions",
       "query_rows_not_expanded_into_fetched_semantic_units",
+      "split_context_not_lifted_into_semantic_decision_graph",
       "todo_items_not_lifted_into_review_decision_graph"
     ],
     "separate_from_parsed_page": true

--- a/tests/fixtures/wikidata/wikidata_nat_review_packet_Q738421_sidecar_20260402.json
+++ b/tests/fixtures/wikidata/wikidata_nat_review_packet_Q738421_sidecar_20260402.json
@@ -1,0 +1,977 @@
+{
+  "follow_receipts": [
+    {
+      "extracted_evidence": [
+        "query_row: https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th"
+      ],
+      "follow_reason": "bounded follow of the query link named in the source surface",
+      "receipt_id": "follow:query:1",
+      "unresolved_uncertainty": [
+        "query output is live search evidence rather than a revision-locked source",
+        "followed link not expanded into a deeper fetch in this packet slice",
+        "query row should be checked against the reviewed split bundle"
+      ],
+      "url": "https://w.wiki/KR5d"
+    }
+  ],
+  "packet_id": "review-packet:041f7506c2efdeca",
+  "page_signals": {
+    "cited_links": [
+      "https://w.wiki/KR5d"
+    ],
+    "expected_qualifier_properties": [
+      "P3831",
+      "P459",
+      "P518",
+      "P580",
+      "P582",
+      "P585",
+      "P7452"
+    ],
+    "expected_reference_properties": [
+      "P1065",
+      "P1476",
+      "P2960",
+      "P813",
+      "P854"
+    ],
+    "outbound_links": [],
+    "query_links": [
+      "https://w.wiki/KR5d"
+    ],
+    "unresolved_questions": [
+      "is it necesary to add the rank?",
+      "is there any documentation or protocol on how to make this kind of migrations? Asked Jan and Wikiproject onthology"
+    ]
+  },
+  "parsed_page": {
+    "cohort_task_lines": [
+      "evaluate migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)",
+      "capture all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P518), reason for preferred rank (P7452)",
+      "check if there really are not extra qualifiers within the items that are instances of instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera)",
+      "capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we found only the following reference properties: reference URL (P854), archive URL (P1065), retrieved (P813), title (P1476), archive date (P2960)",
+      "evaluate migration for all other reconciled \"instance of\"",
+      "evaluate migrations of statements cuyo determination method no es GHG protocol (otro determination method o no tiene el determination method)",
+      "evaluate migration for 1395 statements cuyo sujeto no tiene un \"instance of\"",
+      "evaluar migración para 142 declaraciones cuyo sujeto tiene un instance of que no pudo ser reconciliado"
+    ],
+    "headings": [
+      "tasks",
+      "done",
+      "to do",
+      "queries"
+    ],
+    "query_rows": [
+      "https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th"
+    ],
+    "sections": [
+      {
+        "heading": "tasks",
+        "items": []
+      },
+      {
+        "heading": "done",
+        "items": [
+          "is there any documentation or protocol on how to make this kind of migrations? Asked Jan and Wikiproject onthology",
+          "get the units wip query"
+        ]
+      },
+      {
+        "heading": "to do",
+        "items": [
+          "evaluate migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)",
+          "capture all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P518), reason for preferred rank (P7452)",
+          "check if there really are not extra qualifiers within the items that are instances of instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera)",
+          "capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we found only the following reference properties: reference URL (P854), archive URL (P1065), retrieved (P813), title (P1476), archive date (P2960)",
+          "is it necesary to add the rank?",
+          "evaluate migration for all other reconciled \"instance of\"",
+          "look for any unexpected qualifiers",
+          "capture references",
+          "evaluate migrations of statements cuyo determination method no es GHG protocol (otro determination method o no tiene el determination method)",
+          "evaluate migration for 1395 statements cuyo sujeto no tiene un \"instance of\"",
+          "look for any unexpected qualifiers",
+          "capture references",
+          "evaluar migración para 142 declaraciones cuyo sujeto tiene un instance of que no pudo ser reconciliado",
+          "look for any unexpected qualifiers",
+          "capture references"
+        ]
+      },
+      {
+        "heading": "queries",
+        "items": [
+          "https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th"
+        ]
+      }
+    ],
+    "task_buckets": {
+      "done": [
+        "is there any documentation or protocol on how to make this kind of migrations? Asked Jan and Wikiproject onthology",
+        "get the units wip query"
+      ],
+      "todo": [
+        "evaluate migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)",
+        "capture all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P518), reason for preferred rank (P7452)",
+        "check if there really are not extra qualifiers within the items that are instances of instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera)",
+        "capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we found only the following reference properties: reference URL (P854), archive URL (P1065), retrieved (P813), title (P1476), archive date (P2960)",
+        "is it necesary to add the rank?",
+        "evaluate migration for all other reconciled \"instance of\"",
+        "look for any unexpected qualifiers",
+        "capture references",
+        "evaluate migrations of statements cuyo determination method no es GHG protocol (otro determination method o no tiene el determination method)",
+        "evaluate migration for 1395 statements cuyo sujeto no tiene un \"instance of\"",
+        "look for any unexpected qualifiers",
+        "capture references",
+        "evaluar migración para 142 declaraciones cuyo sujeto tiene un instance of que no pudo ser reconciliado",
+        "look for any unexpected qualifiers",
+        "capture references"
+      ]
+    }
+  },
+  "review_entity_qid": "Q738421",
+  "reviewer_view": {
+    "decision_focus": [
+      "confirm_split_axes",
+      "confirm_target_bundle_count",
+      "spot_check_reference_propagation",
+      "spot_check_qualifier_propagation",
+      "resolve_page_open_questions",
+      "use_todo_bucket_as_review_checklist"
+    ],
+    "recommended_next_step": "review_structured_split",
+    "uncertainty_flags": [
+      "page_open_questions"
+    ]
+  },
+  "schema_version": "sl.wikidata_review_packet.v0_1",
+  "semantic_decomposition": {
+    "candidate_units": [
+      {
+        "text": "https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th",
+        "unit_id": "query_row:1",
+        "unit_type": "query_row_surface"
+      },
+      {
+        "text": "receipt_id=follow:query:1 url=https://w.wiki/KR5d reason=bounded follow of the query link named in the source surface evidence_count=1 unresolved_count=3",
+        "unit_id": "follow_receipt:1",
+        "unit_type": "follow_receipt_surface"
+      },
+      {
+        "text": "is it necesary to add the rank?",
+        "unit_id": "open_question:1",
+        "unit_type": "open_question_surface"
+      },
+      {
+        "text": "is there any documentation or protocol on how to make this kind of migrations? Asked Jan and Wikiproject onthology",
+        "unit_id": "open_question:2",
+        "unit_type": "open_question_surface"
+      },
+      {
+        "text": "evaluate migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)",
+        "unit_id": "todo_item:1",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "capture all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P518), reason for preferred rank (P7452)",
+        "unit_id": "todo_item:2",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "check if there really are not extra qualifiers within the items that are instances of instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera)",
+        "unit_id": "todo_item:3",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we found only the following reference properties: reference URL (P854), archive URL (P1065), retrieved (P813), title (P1476), archive date (P2960)",
+        "unit_id": "todo_item:4",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "is it necesary to add the rank?",
+        "unit_id": "todo_item:5",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "evaluate migration for all other reconciled \"instance of\"",
+        "unit_id": "todo_item:6",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "look for any unexpected qualifiers",
+        "unit_id": "todo_item:7",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "capture references",
+        "unit_id": "todo_item:8",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "evaluate migrations of statements cuyo determination method no es GHG protocol (otro determination method o no tiene el determination method)",
+        "unit_id": "todo_item:9",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "evaluate migration for 1395 statements cuyo sujeto no tiene un \"instance of\"",
+        "unit_id": "todo_item:10",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "look for any unexpected qualifiers",
+        "unit_id": "todo_item:11",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "capture references",
+        "unit_id": "todo_item:12",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "evaluar migración para 142 declaraciones cuyo sujeto tiene un instance of que no pudo ser reconciliado",
+        "unit_id": "todo_item:13",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "look for any unexpected qualifiers",
+        "unit_id": "todo_item:14",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "capture references",
+        "unit_id": "todo_item:15",
+        "unit_type": "todo_surface"
+      },
+      {
+        "text": "migration_goal: Since the cretion of P14143 I have to migrate most of the P5991 statements with their references and qualifiers to use this new property (This has been discussed in the property proposal and documented in Wikiproject climate change).\n\ntasks\ndone\n\n- is there",
+        "unit_id": "anchor:goal",
+        "unit_type": "anchor_surface"
+      },
+      {
+        "text": "cohort_business_family: migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)\n- capt",
+        "unit_id": "anchor:cohort_business_family",
+        "unit_type": "anchor_surface"
+      },
+      {
+        "text": "expected_qualifier_family: all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P",
+        "unit_id": "anchor:qualifier_family",
+        "unit_type": "anchor_surface"
+      },
+      {
+        "text": "expected_reference_family: , empresa de capital abierto, institución financiera)\n- capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we fo",
+        "unit_id": "anchor:reference_family",
+        "unit_type": "anchor_surface"
+      },
+      {
+        "text": "query_anchor: protocol (otro determination method o no tiene el determination method)\n- evaluate",
+        "unit_id": "anchor:query_anchor",
+        "unit_type": "anchor_surface"
+      },
+      {
+        "text": "split://Q738421|P5991 status=structurally_decomposable action=review_structured_split review_required=True proposed_bundle_count=41",
+        "unit_id": "split_plan:context",
+        "unit_type": "split_context_surface"
+      },
+      {
+        "text": "property=P3831 source=slot reason=multi_valued_dimension cardinality=4",
+        "unit_id": "split_axis:1",
+        "unit_type": "split_axis_surface"
+      },
+      {
+        "text": "property=P518 source=slot reason=multi_valued_dimension cardinality=9",
+        "unit_id": "split_axis:2",
+        "unit_type": "split_axis_surface"
+      },
+      {
+        "text": "property=P580 source=slot reason=multi_valued_dimension cardinality=7",
+        "unit_id": "split_axis:3",
+        "unit_type": "split_axis_surface"
+      },
+      {
+        "text": "property=P582 source=slot reason=multi_valued_dimension cardinality=7",
+        "unit_id": "split_axis:4",
+        "unit_type": "split_axis_surface"
+      },
+      {
+        "text": "property=__value__ source=slot reason=multi_value_slot cardinality=41",
+        "unit_id": "split_axis:5",
+        "unit_type": "split_axis_surface"
+      },
+      {
+        "text": "source_candidate_ids=41 sample=Q738421|P5991|1,Q738421|P5991|2,Q738421|P5991|3",
+        "unit_id": "split_candidates:summary",
+        "unit_type": "split_context_surface"
+      },
+      {
+        "text": "anchor_refs_not_promoted_to_grounded_claims",
+        "unit_id": "missing_evidence:1",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "follow_receipts_not_promoted_to_semantic_claims",
+        "unit_id": "missing_evidence:2",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "no_claim_boundary_mapping_for_candidate_units",
+        "unit_id": "missing_evidence:3",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "no_cross_source_alignment_for_candidate_units",
+        "unit_id": "missing_evidence:4",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "no_revision_locked_excerpts_for_candidate_units",
+        "unit_id": "missing_evidence:5",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "open_questions_not_resolved_into_grounded_assertions",
+        "unit_id": "missing_evidence:6",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "query_rows_not_expanded_into_fetched_semantic_units",
+        "unit_id": "missing_evidence:7",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "split_context_not_lifted_into_semantic_decision_graph",
+        "unit_id": "missing_evidence:8",
+        "unit_type": "missing_evidence_surface"
+      },
+      {
+        "text": "todo_items_not_lifted_into_review_decision_graph",
+        "unit_id": "missing_evidence:9",
+        "unit_type": "missing_evidence_surface"
+      }
+    ],
+    "claim_boundaries": {
+      "candidate_claim_boundaries": [
+        {
+          "anchor_ref": {
+            "anchor_id": "goal",
+            "end": 257,
+            "label": "migration_goal",
+            "start": 0
+          },
+          "axis_signals": [
+            {
+              "axis_id": "axis:1",
+              "cardinality": 4,
+              "property": "P3831",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:2",
+              "cardinality": 9,
+              "property": "P518",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:3",
+              "cardinality": 7,
+              "property": "P580",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:4",
+              "cardinality": 7,
+              "property": "P582",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:5",
+              "cardinality": 41,
+              "property": "__value__",
+              "reason": "multi_value_slot",
+              "source": "slot"
+            }
+          ],
+          "boundary_id": "boundary:1",
+          "boundary_state": "candidate_only",
+          "candidate_claim_text": "Since the cretion of P14143 I have to migrate most of the P5991 statements with their references and qualifiers to use this new property (This has been discussed in the property proposal and documented in Wikiproject climate change).\n\ntasks\ndone\n\n- is there",
+          "missing_evidence": [
+            "no_clause_level_segmentation",
+            "no_cross_source_alignment",
+            "no_grounded_claim_assertion",
+            "open_questions_unresolved"
+          ],
+          "review_prompt": "Check whether anchor 'migration_goal' expresses one claim boundary per axis: P3831, P518, P580, P582, __value__."
+        },
+        {
+          "anchor_ref": {
+            "anchor_id": "cohort_business_family",
+            "end": 585,
+            "label": "cohort_business_family",
+            "start": 408
+          },
+          "axis_signals": [
+            {
+              "axis_id": "axis:1",
+              "cardinality": 4,
+              "property": "P3831",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:2",
+              "cardinality": 9,
+              "property": "P518",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:3",
+              "cardinality": 7,
+              "property": "P580",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:4",
+              "cardinality": 7,
+              "property": "P582",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:5",
+              "cardinality": 41,
+              "property": "__value__",
+              "reason": "multi_value_slot",
+              "source": "slot"
+            }
+          ],
+          "boundary_id": "boundary:2",
+          "boundary_state": "candidate_only",
+          "candidate_claim_text": "migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)\n- capt",
+          "missing_evidence": [
+            "no_clause_level_segmentation",
+            "no_cross_source_alignment",
+            "no_grounded_claim_assertion",
+            "open_questions_unresolved"
+          ],
+          "review_prompt": "Check whether anchor 'cohort_business_family' expresses one claim boundary per axis: P3831, P518, P580, P582, __value__."
+        },
+        {
+          "anchor_ref": {
+            "anchor_id": "qualifier_family",
+            "end": 847,
+            "label": "expected_qualifier_family",
+            "start": 588
+          },
+          "axis_signals": [
+            {
+              "axis_id": "axis:1",
+              "cardinality": 4,
+              "property": "P3831",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:2",
+              "cardinality": 9,
+              "property": "P518",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:3",
+              "cardinality": 7,
+              "property": "P580",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:4",
+              "cardinality": 7,
+              "property": "P582",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:5",
+              "cardinality": 41,
+              "property": "__value__",
+              "reason": "multi_value_slot",
+              "source": "slot"
+            }
+          ],
+          "boundary_id": "boundary:3",
+          "boundary_state": "candidate_only",
+          "candidate_claim_text": "all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P",
+          "missing_evidence": [
+            "no_clause_level_segmentation",
+            "no_cross_source_alignment",
+            "no_grounded_claim_assertion",
+            "open_questions_unresolved"
+          ],
+          "review_prompt": "Check whether anchor 'expected_qualifier_family' expresses one claim boundary per axis: P3831, P518, P580, P582, __value__."
+        },
+        {
+          "anchor_ref": {
+            "anchor_id": "reference_family",
+            "end": 1289,
+            "label": "expected_reference_family",
+            "start": 1047
+          },
+          "axis_signals": [
+            {
+              "axis_id": "axis:1",
+              "cardinality": 4,
+              "property": "P3831",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:2",
+              "cardinality": 9,
+              "property": "P518",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:3",
+              "cardinality": 7,
+              "property": "P580",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:4",
+              "cardinality": 7,
+              "property": "P582",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:5",
+              "cardinality": 41,
+              "property": "__value__",
+              "reason": "multi_value_slot",
+              "source": "slot"
+            }
+          ],
+          "boundary_id": "boundary:4",
+          "boundary_state": "candidate_only",
+          "candidate_claim_text": ", empresa de capital abierto, institución financiera)\n- capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we fo",
+          "missing_evidence": [
+            "no_clause_level_segmentation",
+            "no_cross_source_alignment",
+            "no_grounded_claim_assertion",
+            "open_questions_unresolved"
+          ],
+          "review_prompt": "Check whether anchor 'expected_reference_family' expresses one claim boundary per axis: P3831, P518, P580, P582, __value__."
+        },
+        {
+          "anchor_ref": {
+            "anchor_id": "query_anchor",
+            "end": 1737,
+            "label": "query_anchor",
+            "start": 1655
+          },
+          "axis_signals": [
+            {
+              "axis_id": "axis:1",
+              "cardinality": 4,
+              "property": "P3831",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:2",
+              "cardinality": 9,
+              "property": "P518",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:3",
+              "cardinality": 7,
+              "property": "P580",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:4",
+              "cardinality": 7,
+              "property": "P582",
+              "reason": "multi_valued_dimension",
+              "source": "slot"
+            },
+            {
+              "axis_id": "axis:5",
+              "cardinality": 41,
+              "property": "__value__",
+              "reason": "multi_value_slot",
+              "source": "slot"
+            }
+          ],
+          "boundary_id": "boundary:5",
+          "boundary_state": "candidate_only",
+          "candidate_claim_text": "protocol (otro determination method o no tiene el determination method)\n- evaluate",
+          "missing_evidence": [
+            "no_clause_level_segmentation",
+            "no_cross_source_alignment",
+            "no_grounded_claim_assertion",
+            "open_questions_unresolved"
+          ],
+          "review_prompt": "Check whether anchor 'query_anchor' expresses one claim boundary per axis: P3831, P518, P580, P582, __value__."
+        }
+      ],
+      "decomposition_state": "candidate_only",
+      "non_claims": [
+        "not_full_semantic_decomposition",
+        "not_claim_truth_evaluation",
+        "not_execution_ready_migration_logic"
+      ],
+      "schema_version": "sl.wikidata_review_packet.claim_boundaries.v0_1",
+      "summary": {
+        "anchor_count": 5,
+        "axis_count": 5,
+        "candidate_boundary_count": 5,
+        "unresolved_question_count": 2
+      }
+    },
+    "cross_source_alignment": {
+      "agreements": [
+        "Shared entity id Q738421 appears in 3 source(s)."
+      ],
+      "common_fields": [],
+      "consensus_identity": "Q738421",
+      "consensus_level": "full_consensus",
+      "disagreements": [
+        "Fields documented on each surface do not overlap, so reviewers should cross-check."
+      ],
+      "packet_id": "review-packet:041f7506c2efdeca",
+      "pairwise_signatures": [
+        {
+          "field_overlap": [
+            "https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th"
+          ],
+          "only_in_left": [
+            "source"
+          ],
+          "only_in_right": [],
+          "pair": "wiki_surface vs query_slice",
+          "shared_keys": [
+            "fields",
+            "qid",
+            "summary"
+          ]
+        },
+        {
+          "field_overlap": [],
+          "only_in_left": [
+            "qid",
+            "source"
+          ],
+          "only_in_right": [
+            "primary_qid"
+          ],
+          "pair": "wiki_surface vs split_bundle",
+          "shared_keys": [
+            "fields",
+            "summary"
+          ]
+        },
+        {
+          "field_overlap": [],
+          "only_in_left": [
+            "qid"
+          ],
+          "only_in_right": [
+            "primary_qid"
+          ],
+          "pair": "query_slice vs split_bundle",
+          "shared_keys": [
+            "fields",
+            "summary"
+          ]
+        }
+      ],
+      "profiles": {
+        "query_slice": {
+          "field_signature": [
+            "https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th"
+          ],
+          "identity": "Q738421",
+          "key_signature": [
+            "fields",
+            "qid",
+            "summary"
+          ],
+          "label": "query_slice",
+          "source_tag": "",
+          "summary": "query rows from parsed page"
+        },
+        "split_bundle": {
+          "field_signature": [
+            "P3831",
+            "P518",
+            "P580",
+            "P582",
+            "__value__"
+          ],
+          "identity": "Q738421",
+          "key_signature": [
+            "fields",
+            "primary_qid",
+            "summary"
+          ],
+          "label": "split_bundle",
+          "source_tag": "",
+          "summary": "review_structured_split"
+        },
+        "wiki_surface": {
+          "field_signature": [
+            "https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th"
+          ],
+          "identity": "Q738421",
+          "key_signature": [
+            "fields",
+            "qid",
+            "source",
+            "summary"
+          ],
+          "label": "wiki_surface",
+          "source_tag": "wiki",
+          "summary": "User:Nat (WDU)/Sandbox/Fossil fuel industries/Migrate from carbon footprint to GHG emissions"
+        }
+      },
+      "schema_version": "sl.wikidata_review_packet.cross_source_alignment.v0_1"
+    },
+    "decomposition_state": "surface_only",
+    "follow_depth": {
+      "enriched_count": 1,
+      "no_excerpt_count": 0,
+      "packet_id": "review-packet:041f7506c2efdeca",
+      "receipt_count": 1,
+      "receipts": [
+        {
+          "evidence_excerpt": "query_row: https://w.wiki/KR5d all carbon footprint statements. 57835 results on march 27th",
+          "excerpt_source": "extracted_evidence",
+          "receipt_id": "follow:query:1",
+          "status": "enriched",
+          "unresolved_uncertainty": [
+            "query output is live search evidence rather than a revision-locked source",
+            "followed link not expanded into a deeper fetch in this packet slice",
+            "query row should be checked against the reviewed split bundle"
+          ],
+          "url": "https://w.wiki/KR5d"
+        }
+      ],
+      "schema_version": "sl.wikidata_review_packet.follow_depth.v0_1"
+    },
+    "layer_schema_version": "sl.wikidata_review_packet.semantic_layer.v0_1",
+    "missing_evidence": [
+      "anchor_refs_not_promoted_to_grounded_claims",
+      "follow_receipts_not_promoted_to_semantic_claims",
+      "no_claim_boundary_mapping_for_candidate_units",
+      "no_cross_source_alignment_for_candidate_units",
+      "no_revision_locked_excerpts_for_candidate_units",
+      "open_questions_not_resolved_into_grounded_assertions",
+      "query_rows_not_expanded_into_fetched_semantic_units",
+      "split_context_not_lifted_into_semantic_decision_graph",
+      "todo_items_not_lifted_into_review_decision_graph"
+    ],
+    "reviewer_actions": {
+      "can_execute_edits": false,
+      "decision_focus": [
+        "confirm_split_axes",
+        "confirm_target_bundle_count",
+        "spot_check_reference_propagation",
+        "spot_check_qualifier_propagation",
+        "resolve_page_open_questions",
+        "use_todo_bucket_as_review_checklist"
+      ],
+      "likely_decision": "review_structured_split",
+      "non_claims": [
+        "review aid only",
+        "does not execute edits",
+        "does not resolve uncertainty automatically"
+      ],
+      "packet_id": "review-packet:041f7506c2efdeca",
+      "review_entity_qid": "Q738421",
+      "schema_version": "sl.wikidata_review_packet.reviewer_actions.v0_1",
+      "smallest_next_check": {
+        "check_id": "confirm_first_split_axis",
+        "rationale": "split plan is axis-driven; confirm first axis property=P3831 cardinality=4"
+      },
+      "uncertainty_flags": [
+        "page_open_questions"
+      ],
+      "why_this_row_is_in_review": [
+        "split_status=structurally_decomposable",
+        "split_plan_requires_review",
+        "split_axes_detected=5",
+        "uncertainty=page_open_questions"
+      ]
+    },
+    "separate_from_parsed_page": true,
+    "variant_comparison": {
+      "comparisons": [
+        {
+          "agreements": [
+            "P3831"
+          ],
+          "comparison_action": "review_structured_split",
+          "comparison_id": "split://Q1785637|P5991",
+          "disagreements": [
+            "P518",
+            "P580",
+            "P582",
+            "__value__"
+          ],
+          "notes": [],
+          "primary_action": "review_structured_split",
+          "status": "disagreement"
+        }
+      ],
+      "diagnostic_flags": [],
+      "non_authoritative": true,
+      "primary_candidate_id": "split://Q738421|P5991"
+    }
+  },
+  "source_surface": {
+    "anchor_refs": [
+      {
+        "anchor_id": "goal",
+        "end": 257,
+        "label": "migration_goal",
+        "start": 0,
+        "text_excerpt": "Since the cretion of P14143 I have to migrate most of the P5991 statements with their references and qualifiers to use this new property (This has been discussed in the property proposal and documented in Wikiproject climate change).\n\ntasks\ndone\n\n- is there"
+      },
+      {
+        "anchor_id": "cohort_business_family",
+        "end": 585,
+        "label": "cohort_business_family",
+        "start": 408,
+        "text_excerpt": "migration for 22514 statements on items that are instances of business (Q4830453), 7138 instances of enterprise (Q6881511) and 7913 instances of public company (Q891723)\n- capt"
+      },
+      {
+        "anchor_id": "qualifier_family",
+        "end": 847,
+        "label": "expected_qualifier_family",
+        "start": 588,
+        "text_excerpt": "all \"extra\" qualifiers wip: for these 3 \"instance of\" we are capturing all the qualifiers we can find: determination method or standard (P459), object of statement has role (P3831), point in time (P585), start time (P580), end time (P582), applies to part (P"
+      },
+      {
+        "anchor_id": "reference_family",
+        "end": 1289,
+        "label": "expected_reference_family",
+        "start": 1047,
+        "text_excerpt": ", empresa de capital abierto, institución financiera)\n- capture the references. the first set (things that are instance of empresa, negocio, banco, biopharmaceutical company, compañía, empresa de capital abierto, institución financiera) we fo"
+      },
+      {
+        "anchor_id": "query_anchor",
+        "end": 1737,
+        "label": "query_anchor",
+        "start": 1655,
+        "text_excerpt": "protocol (otro determination method o no tiene el determination method)\n- evaluate"
+      }
+    ],
+    "origin": {
+      "source_type": "wiki",
+      "source_url": "https://www.wikidata.org/wiki/User:Nat_(WDU)/Sandbox/Fossil_fuel_industries/Migrate_from_carbon_footprint_to_GHG_emissions",
+      "title": "User:Nat (WDU)/Sandbox/Fossil fuel industries/Migrate from carbon footprint to GHG emissions"
+    },
+    "revision": {
+      "retrieval_method": "wiki_revision",
+      "revision_id": "provided_snapshot_2026-04-01",
+      "revision_timestamp": "2026-04-01T00:00:00+10:00"
+    },
+    "source_entity_qid": "Q10884",
+    "source_unit_id": "unit:wikidata_user_sandbox:nat_wdu:p5991_p14143:2026-04-01"
+  },
+  "split_review_context": {
+    "merged_split_axes": [
+      {
+        "cardinality": 4,
+        "property": "P3831",
+        "reason": "multi_valued_dimension",
+        "source": "slot"
+      },
+      {
+        "cardinality": 9,
+        "property": "P518",
+        "reason": "multi_valued_dimension",
+        "source": "slot"
+      },
+      {
+        "cardinality": 7,
+        "property": "P580",
+        "reason": "multi_valued_dimension",
+        "source": "slot"
+      },
+      {
+        "cardinality": 7,
+        "property": "P582",
+        "reason": "multi_valued_dimension",
+        "source": "slot"
+      },
+      {
+        "cardinality": 41,
+        "property": "__value__",
+        "reason": "multi_value_slot",
+        "source": "slot"
+      }
+    ],
+    "proposed_bundle_count": 41,
+    "qualifier_propagation": "exact",
+    "reference_propagation": "exact",
+    "review_required": true,
+    "source_candidate_ids": [
+      "Q738421|P5991|1",
+      "Q738421|P5991|2",
+      "Q738421|P5991|3",
+      "Q738421|P5991|4",
+      "Q738421|P5991|5",
+      "Q738421|P5991|6",
+      "Q738421|P5991|7",
+      "Q738421|P5991|8",
+      "Q738421|P5991|9",
+      "Q738421|P5991|10",
+      "Q738421|P5991|11",
+      "Q738421|P5991|12",
+      "Q738421|P5991|13",
+      "Q738421|P5991|14",
+      "Q738421|P5991|15",
+      "Q738421|P5991|16",
+      "Q738421|P5991|17",
+      "Q738421|P5991|18",
+      "Q738421|P5991|19",
+      "Q738421|P5991|20",
+      "Q738421|P5991|21",
+      "Q738421|P5991|22",
+      "Q738421|P5991|23",
+      "Q738421|P5991|24",
+      "Q738421|P5991|25",
+      "Q738421|P5991|26",
+      "Q738421|P5991|27",
+      "Q738421|P5991|28",
+      "Q738421|P5991|29",
+      "Q738421|P5991|30",
+      "Q738421|P5991|31",
+      "Q738421|P5991|32",
+      "Q738421|P5991|33",
+      "Q738421|P5991|34",
+      "Q738421|P5991|35",
+      "Q738421|P5991|36",
+      "Q738421|P5991|37",
+      "Q738421|P5991|38",
+      "Q738421|P5991|39",
+      "Q738421|P5991|40",
+      "Q738421|P5991|41"
+    ],
+    "source_slot_id": "Q738421|P5991",
+    "split_plan_id": "split://Q738421|P5991",
+    "status": "structurally_decomposable",
+    "suggested_action": "review_structured_split"
+  }
+}

--- a/tests/fixtures/wikidata/wikidata_nat_review_packet_attachment_coverage_20260401.json
+++ b/tests/fixtures/wikidata/wikidata_nat_review_packet_attachment_coverage_20260401.json
@@ -4,7 +4,7 @@
   "lane_id": "wikidata_nat_p5991_p14143",
   "source_revision_fixture": "wiki_revision_nat_wdu_sandbox_p5991_p14143_20260401.json",
   "held_split_rows_total": 53,
-  "packetized_split_rows": 13,
+  "packetized_split_rows": 15,
   "packetized_split_row_ids": [
     "Q10403939|P5991",
     "Q10422059|P5991",
@@ -18,7 +18,9 @@
     "Q47508289|P5991",
     "Q731938|P5991",
     "Q10416948|P5991",
-    "Q56404383|P5991"
+    "Q56404383|P5991",
+    "Q1785637|P5991",
+    "Q738421|P5991"
   ],
   "coverage_state": "partial_packetized",
   "packet_slots": [
@@ -2600,13 +2602,27 @@
       "split_plan_id": "split://Q56404383|P5991",
       "packet_ref": "SensibLaw/tests/fixtures/wikidata/wikidata_nat_review_packet_Q56404383_sidecar_20260402.json",
       "packet_status": "attached_review_surface_with_sidecar"
+    },
+    {
+      "packet_id": "review-packet:f451ac11e012b114",
+      "review_entity_qid": "Q1785637",
+      "split_plan_id": "split://Q1785637|P5991",
+      "packet_ref": "SensibLaw/tests/fixtures/wikidata/wikidata_nat_review_packet_Q1785637_sidecar_20260402.json",
+      "packet_status": "attached_review_surface"
+    },
+    {
+      "packet_id": "review-packet:041f7506c2efdeca",
+      "review_entity_qid": "Q738421",
+      "split_plan_id": "split://Q738421|P5991",
+      "packet_ref": "SensibLaw/tests/fixtures/wikidata/wikidata_nat_review_packet_Q738421_sidecar_20260402.json",
+      "packet_status": "attached_review_surface"
     }
   ],
   "ready_for_reviewers": [
     "Pinned review packet for Q10403939",
     "Second packetized held row for Q10422059",
     "Live-tranche packets now include AstraZeneca (Q731938) plus eight other wider-online rows",
-    "Coverage index showing 13 / 53 packetized rows"
+    "Coverage index showing 15 / 53 packetized rows"
   ],
   "still_missing": [
     "packet attachment across the remaining held split rows",
@@ -2616,6 +2632,6 @@
   "notes": [
     "This index widens Nat packet coverage without changing shared trackers.",
     "It is a review aid, not an execution authority.",
-    "The expanded packet surface now spans the original two held rows plus nine wider-online reviewed rows from the live tranche, including AstraZeneca (Q731938)."
+    "The expanded packet surface now spans the original two held rows plus eleven wider-online reviewed rows from the live tranche, including AstraZeneca (Q731938), Apoteket (Q1785637), and Assa Abloy (Q738421)."
   ]
 }

--- a/tests/test_wikidata_cli.py
+++ b/tests/test_wikidata_cli.py
@@ -668,3 +668,369 @@ def test_wikidata_cohort_c_operator_packet_cli_wraps_scan_payload(tmp_path, caps
     assert stdout["candidate_count"] == 3
     assert payload["decision"] == "review"
     assert payload["triage_prompts"][0].startswith("Review the candidate P459 status split")
+
+
+def test_wikidata_cohort_d_operator_review_cli_materializes_queue_surface(tmp_path, capsys) -> None:
+    root = Path(__file__).resolve().parent
+    in_path = (
+        root
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_d_type_probing_surface_20260402.json"
+    )
+    out_path = tmp_path / "cohort_d_operator_review_surface.json"
+
+    cli_main.main(
+        [
+            "wikidata",
+            "cohort-d-operator-review",
+            "--input",
+            str(in_path),
+            "--output",
+            str(out_path),
+        ]
+    )
+
+    stdout = json.loads(capsys.readouterr().out)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert stdout["output"] == str(out_path)
+    assert stdout["readiness"] == "review_queue_ready"
+    assert stdout["queue_size"] == 2
+    assert stdout["unresolved_packet_ref_count"] == 0
+    assert payload["readiness"] == "review_queue_ready"
+    assert payload["queue_size"] == 2
+    assert payload["governance"]["automation_allowed"] is False
+    assert payload["governance"]["can_execute_edits"] is False
+    assert all(row["execution_allowed"] is False for row in payload["operator_queue"])
+
+
+def test_wikidata_cohort_d_operator_report_cli_materializes_report_surface(tmp_path, capsys) -> None:
+    root = Path(__file__).resolve().parent
+    in_path = (
+        root
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_d_operator_review_surface_20260402.json"
+    )
+    out_path = tmp_path / "cohort_d_operator_report.json"
+
+    cli_main.main(
+        [
+            "wikidata",
+            "cohort-d-operator-report",
+            "--input",
+            str(in_path),
+            "--output",
+            str(out_path),
+        ]
+    )
+
+    stdout = json.loads(capsys.readouterr().out)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert stdout["output"] == str(out_path)
+    assert stdout["readiness"] == "review_queue_ready"
+    assert stdout["decision"] == "review"
+    assert stdout["promotion_allowed"] is False
+    assert stdout["queue_size"] == 2
+    assert payload["decision"] == "review"
+    assert payload["promotion_allowed"] is False
+    assert payload["summary"]["queue_size"] == 2
+    assert payload["governance"]["automation_allowed"] is False
+    assert payload["governance"]["can_execute_edits"] is False
+
+
+def test_wikidata_cohort_d_operator_report_batch_cli_materializes_batch_report(tmp_path, capsys) -> None:
+    root = Path(__file__).resolve().parent
+    in_path = (
+        root
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_d_operator_report_batch_input_20260402.json"
+    )
+    out_path = tmp_path / "cohort_d_operator_report_batch.json"
+
+    cli_main.main(
+        [
+            "wikidata",
+            "cohort-d-operator-report-batch",
+            "--input",
+            str(in_path),
+            "--output",
+            str(out_path),
+        ]
+    )
+
+    stdout = json.loads(capsys.readouterr().out)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert stdout["output"] == str(out_path)
+    assert stdout["batch_id"] == "cohort_d_operator_batch_20260402"
+    assert stdout["decision"] == "review"
+    assert stdout["promotion_allowed"] is False
+    assert stdout["case_count"] == 2
+    assert stdout["all_cases_ready"] is False
+    assert payload["summary"]["case_count"] == 2
+    assert payload["summary"]["total_unresolved_packet_ref_count"] == 1
+
+
+def test_wikidata_cohort_d_review_control_index_cli_materializes_control_index(tmp_path, capsys) -> None:
+    root = Path(__file__).resolve().parent
+    in_path = (
+        root
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_d_review_control_index_input_20260402.json"
+    )
+    out_path = tmp_path / "cohort_d_review_control_index.json"
+
+    cli_main.main(
+        [
+            "wikidata",
+            "cohort-d-review-control-index",
+            "--input",
+            str(in_path),
+            "--output",
+            str(out_path),
+        ]
+    )
+
+    stdout = json.loads(capsys.readouterr().out)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert stdout["output"] == str(out_path)
+    assert stdout["index_id"] == "cohort_d_review_control_index_20260402"
+    assert stdout["decision"] == "review"
+    assert stdout["promotion_allowed"] is False
+    assert stdout["batch_count"] == 2
+    assert stdout["all_batches_ready"] is False
+    assert payload["summary"]["batch_count"] == 2
+    assert payload["summary"]["all_batches_ready"] is False
+    assert "batch_not_all_cases_ready" in payload["blocked_signals"]
+
+
+def test_wikidata_automation_graduation_eval_cli_approves_gate_a(tmp_path, capsys) -> None:
+    root = Path(__file__).resolve().parent
+    criteria_path = (
+        root / "fixtures" / "wikidata" / "wikidata_nat_automation_graduation_criteria_20260402.json"
+    )
+    proposal_path = (
+        root
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_automation_promotion_proposal_gate_a_promote_20260402.json"
+    )
+    out_path = tmp_path / "automation_graduation_report_gate_a.json"
+
+    cli_main.main(
+        [
+            "wikidata",
+            "automation-graduation-eval",
+            "--criteria",
+            str(criteria_path),
+            "--proposal",
+            str(proposal_path),
+            "--output",
+            str(out_path),
+        ]
+    )
+
+    stdout = json.loads(capsys.readouterr().out)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert stdout["output"] == str(out_path)
+    assert stdout["status"] == "approved"
+    assert stdout["decision"] == "promote"
+    assert stdout["promotion_allowed"] is True
+    assert payload["status"] == "approved"
+    assert payload["failed_checks"] == []
+
+
+def test_wikidata_automation_graduation_eval_cli_holds_gate_b_with_blocker(tmp_path, capsys) -> None:
+    root = Path(__file__).resolve().parent
+    criteria_path = (
+        root / "fixtures" / "wikidata" / "wikidata_nat_automation_graduation_criteria_20260402.json"
+    )
+    proposal_path = (
+        root
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_automation_promotion_proposal_gate_b_hold_20260402.json"
+    )
+    out_path = tmp_path / "automation_graduation_report_gate_b.json"
+
+    cli_main.main(
+        [
+            "wikidata",
+            "automation-graduation-eval",
+            "--criteria",
+            str(criteria_path),
+            "--proposal",
+            str(proposal_path),
+            "--output",
+            str(out_path),
+        ]
+    )
+
+    stdout = json.loads(capsys.readouterr().out)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert stdout["output"] == str(out_path)
+    assert stdout["status"] == "rejected"
+    assert stdout["decision"] == "hold"
+    assert stdout["promotion_allowed"] is False
+    assert payload["status"] == "rejected"
+    assert "blocked_signal_triggered" in payload["failed_checks"]
+
+
+def test_wikidata_automation_graduation_eval_batch_cli_writes_index_report(tmp_path, capsys) -> None:
+    root = Path(__file__).resolve().parent
+    criteria_path = (
+        root / "fixtures" / "wikidata" / "wikidata_nat_automation_graduation_criteria_20260402.json"
+    )
+    proposal_batch_path = (
+        root
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_automation_promotion_proposal_batch_20260402.json"
+    )
+    out_path = tmp_path / "automation_graduation_batch_report.json"
+
+    cli_main.main(
+        [
+            "wikidata",
+            "automation-graduation-eval-batch",
+            "--criteria",
+            str(criteria_path),
+            "--proposal-batch",
+            str(proposal_batch_path),
+            "--output",
+            str(out_path),
+        ]
+    )
+
+    stdout = json.loads(capsys.readouterr().out)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert stdout["output"] == str(out_path)
+    assert stdout["batch_id"] == "nat-grad-batch-v1"
+    assert stdout["proposal_count"] == 2
+    assert stdout["summary"]["approved_count"] == 1
+    assert stdout["summary"]["rejected_count"] == 1
+    assert stdout["summary"]["fail_closed_count"] == 1
+    assert payload["proposal_count"] == 2
+    assert payload["summary"]["approved_count"] == 1
+    assert payload["summary"]["rejected_count"] == 1
+
+
+def test_wikidata_automation_graduation_evidence_report_cli_writes_readiness_surface(tmp_path, capsys) -> None:
+    root = Path(__file__).resolve().parent
+    criteria_path = (
+        root / "fixtures" / "wikidata" / "wikidata_nat_automation_graduation_criteria_20260402.json"
+    )
+    proposal_batches_path = (
+        root
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_automation_promotion_proposal_batches_20260402.json"
+    )
+    out_path = tmp_path / "automation_graduation_evidence_report.json"
+
+    cli_main.main(
+        [
+            "wikidata",
+            "automation-graduation-evidence-report",
+            "--criteria",
+            str(criteria_path),
+            "--proposal-batches",
+            str(proposal_batches_path),
+            "--output",
+            str(out_path),
+        ]
+    )
+
+    stdout = json.loads(capsys.readouterr().out)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert stdout["output"] == str(out_path)
+    assert stdout["evidence_batch_id"] == "nat-grad-evidence-v1"
+    assert stdout["status"] == "not_ready"
+    assert stdout["decision"] == "hold"
+    assert stdout["promotion_ready"] is False
+    assert stdout["summary"]["rejected_count"] == 2
+    assert payload["status"] == "not_ready"
+    assert "rejected_proposals_present" in payload["readiness_failed_reasons"]
+    assert "fail_closed_proposals_present" in payload["readiness_failed_reasons"]
+
+
+def test_wikidata_automation_graduation_governance_index_cli_writes_snapshot_summary(tmp_path, capsys) -> None:
+    root = Path(__file__).resolve().parent
+    criteria_path = (
+        root / "fixtures" / "wikidata" / "wikidata_nat_automation_graduation_criteria_20260402.json"
+    )
+    evidence_snapshots_path = (
+        root
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_automation_evidence_snapshots_20260402.json"
+    )
+    out_path = tmp_path / "automation_graduation_governance_index.json"
+
+    cli_main.main(
+        [
+            "wikidata",
+            "automation-graduation-governance-index",
+            "--criteria",
+            str(criteria_path),
+            "--evidence-snapshots",
+            str(evidence_snapshots_path),
+            "--output",
+            str(out_path),
+        ]
+    )
+
+    stdout = json.loads(capsys.readouterr().out)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert stdout["output"] == str(out_path)
+    assert stdout["governance_batch_id"] == "nat-grad-governance-v1"
+    assert stdout["status"] == "not_ready"
+    assert stdout["decision"] == "hold"
+    assert stdout["promotion_ready"] is False
+    assert stdout["summary"]["ready_count"] == 0
+    assert stdout["summary"]["not_ready_count"] == 2
+    assert payload["status"] == "not_ready"
+    assert "not_ready_snapshots_present" in payload["readiness_failed_reasons"]
+
+
+def test_wikidata_automation_graduation_governance_summary_cli_writes_repeated_index_summary(
+    tmp_path, capsys
+) -> None:
+    root = Path(__file__).resolve().parent
+    criteria_path = (
+        root / "fixtures" / "wikidata" / "wikidata_nat_automation_graduation_criteria_20260402.json"
+    )
+    governance_snapshots_path = (
+        root
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_automation_governance_snapshots_20260402.json"
+    )
+    out_path = tmp_path / "automation_graduation_governance_summary.json"
+
+    cli_main.main(
+        [
+            "wikidata",
+            "automation-graduation-governance-summary",
+            "--criteria",
+            str(criteria_path),
+            "--governance-snapshots",
+            str(governance_snapshots_path),
+            "--output",
+            str(out_path),
+        ]
+    )
+
+    stdout = json.loads(capsys.readouterr().out)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert stdout["output"] == str(out_path)
+    assert stdout["governance_summary_id"] == "nat-grad-governance-summary-v1"
+    assert stdout["status"] == "not_ready"
+    assert stdout["decision"] == "hold"
+    assert stdout["promotion_ready"] is False
+    assert stdout["summary"]["ready_count"] == 0
+    assert stdout["summary"]["not_ready_count"] == 2
+    assert payload["status"] == "not_ready"
+    assert "not_ready_governance_indexes_present" in payload["readiness_failed_reasons"]

--- a/tests/test_wikidata_cli.py
+++ b/tests/test_wikidata_cli.py
@@ -643,3 +643,28 @@ def test_wikidata_build_split_plan_cli_writes_json(tmp_path, capsys) -> None:
     assert stdout["plan_count"] == 1
     assert stdout["counts_by_status"] == {"structurally_decomposable": 1}
     assert payload["plans"][0]["status"] == "structurally_decomposable"
+
+
+def test_wikidata_cohort_c_operator_packet_cli_wraps_scan_payload(tmp_path, capsys) -> None:
+    root = Path(__file__).resolve().parent
+    in_path = root / "fixtures" / "wikidata" / "wikidata_nat_cohort_c_population_scan_20260402.json"
+    out_path = tmp_path / "cohort_c_operator_packet.json"
+
+    cli_main.main(
+        [
+            "wikidata",
+            "cohort-c-operator-packet",
+            "--input",
+            str(in_path),
+            "--output",
+            str(out_path),
+        ]
+    )
+
+    stdout = json.loads(capsys.readouterr().out)
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert stdout["output"] == str(out_path)
+    assert stdout["decision"] == "review"
+    assert stdout["candidate_count"] == 3
+    assert payload["decision"] == "review"
+    assert payload["triage_prompts"][0].startswith("Review the candidate P459 status split")

--- a/tests/test_wikidata_cohort_c_live_preview_extension.py
+++ b/tests/test_wikidata_cohort_c_live_preview_extension.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_cohort_c_live_preview_extension_fixture_shape() -> None:
+    fixture_path = Path(__file__).resolve().parent / "fixtures" / "wikidata" / "wikidata_nat_cohort_c_live_preview_extension_20260402.json"
+    candidates = json.loads(fixture_path.read_text(encoding="utf-8"))
+    assert isinstance(candidates, list)
+    required_keys = {
+        "qid",
+        "label",
+        "p459_status",
+        "preview_hold_reason",
+        "hold_gate",
+        "notes",
+    }
+    for candidate in candidates:
+        assert required_keys.issubset(candidate.keys())
+        assert candidate["hold_gate"] == "review_first_population_scan"
+        assert candidate["p459_status"] in {"missing", "non-ghg-protocol"}
+        assert candidate["preview_hold_reason"]

--- a/tests/test_wikidata_cohort_c_operator_digest.py
+++ b/tests/test_wikidata_cohort_c_operator_digest.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.ontology import wikidata_cohort_c_operator_digest as digest
+
+
+def _load_packets() -> list[dict[str, object]]:
+    base = Path(__file__).resolve().parent / "fixtures" / "wikidata"
+    paths = [
+        base / "wikidata_nat_cohort_c_operator_evidence_packet_20260404.json",
+        base / "wikidata_nat_cohort_c_ptolemy_evidence_sample_20260405.json",
+    ]
+    return [json.loads(path.read_text(encoding="utf-8")) for path in paths]
+
+
+def test_operator_digest_aggregates_reference_qualifier_counts() -> None:
+    packets = _load_packets()
+    report = digest.build_nat_cohort_c_operator_digest(packets)
+    assert report["candidate_count"] == sum(
+        len(packet["evidence_rows"]) for packet in packets
+    )
+    assert "hold_reason_summary" in report
+    assert report["reference_summary"]
+    assert len(report["packet_ids"]) == 2

--- a/tests/test_wikidata_cohort_c_operator_evidence_packet.py
+++ b/tests/test_wikidata_cohort_c_operator_evidence_packet.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.ontology import wikidata_cohort_c_operator_evidence as evidence
+
+
+def _load_fixture() -> dict[str, object]:
+    fixture_path = Path(__file__).resolve().parent / "fixtures" / "wikidata" / "wikidata_nat_cohort_c_operator_packet_extension_20260403.json"
+    candidates = json.loads(fixture_path.read_text(encoding="utf-8"))
+    return {
+        "lane_id": "wikidata_nat_wdu_p5991_p14143",
+        "cohort_id": "non_ghg_protocol_or_missing_p459",
+        "scan_status": "live_population_scan_preview",
+        "sample_candidates": candidates,
+        "summary": {"p459_status_counts": {"missing": 2, "non-ghg-protocol": 1}},
+    }
+
+
+def test_operator_evidence_packet_from_preview_fixture() -> None:
+    payload = _load_fixture()
+    packet = evidence.build_nat_cohort_c_operator_evidence_packet(payload)
+    rows = packet["evidence_rows"]
+    assert packet["summary"]["candidate_count"] == len(rows)
+    assert all(row["promotion_guard"] == "hold" for row in rows)
+    qids = [row["qid"] for row in rows]
+    assert qids == sorted(qids)
+    assert len({row["evidence_id"] for row in rows}) == len(rows)
+    first_row = rows[0]
+    assert first_row["hold_gate"] == "review_first_population_scan"
+    assert first_row["qualifier_hint"]
+    assert "operator_hold_reason" in first_row

--- a/tests/test_wikidata_cohort_c_operator_index.py
+++ b/tests/test_wikidata_cohort_c_operator_index.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.ontology import wikidata_cohort_c_operator_index as operator_index
+
+
+def _load_evidence_packet() -> dict[str, object]:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_c_ptolemy_evidence_sample_20260405.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_operator_index_summary_lists_reference_qualifiers_and_hold_reasons() -> None:
+    packet = _load_evidence_packet()
+    index = operator_index.build_nat_cohort_c_operator_index(packet)
+    assert index["total_candidates"] == len(packet["evidence_rows"])
+    assert "reference_summary" in index
+    for ref, qualifiers in index["reference_summary"].items():
+        assert qualifiers
+    assert index["hold_reason_summary"]

--- a/tests/test_wikidata_cohort_c_operator_packet_extension.py
+++ b/tests/test_wikidata_cohort_c_operator_packet_extension.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_operator_packet_extension_fixture_valid() -> None:
+    fixture_path = Path(__file__).resolve().parent / "fixtures" / "wikidata" / "wikidata_nat_cohort_c_operator_packet_extension_20260403.json"
+    candidates = json.loads(fixture_path.read_text(encoding="utf-8"))
+    assert isinstance(candidates, list)
+    for candidate in candidates:
+        assert candidate["hold_gate"] == "review_first_population_scan"
+        assert candidate["p459_status"] in {"missing", "non-ghg-protocol"}
+        assert candidate["operator_hold_reason"]
+        assert candidate["preview_hold_reason"]
+        assert candidate["qualifier_hint"]

--- a/tests/test_wikidata_cohort_c_operator_report.py
+++ b/tests/test_wikidata_cohort_c_operator_report.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.ontology import wikidata_cohort_c_operator_report as report
+
+
+def _load_packet_fixture() -> dict[str, object]:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_c_operator_packet_extension_20260403.json"
+    )
+    sample_candidates = json.loads(fixture_path.read_text(encoding="utf-8"))
+    packet = {
+        "schema_version": "sl.wikidata_nat.cohort_c.operator_evidence.v0_1",
+        "packet_id": "operator-evidence:test",
+        "lane_id": "wikidata_nat_wdu_p5991_p14143",
+        "cohort_id": "non_ghg_protocol_or_missing_p459",
+        "scan_status": "live_population_scan_preview",
+        "evidence_rows": sample_candidates,
+    }
+    return packet
+
+
+def test_operator_report_summarizes_hold_reasons_and_refs() -> None:
+    packet = _load_packet_fixture()
+    summary = report.build_nat_cohort_c_operator_report(packet)
+    assert summary["candidate_count"] == len(packet["evidence_rows"])
+    assert "Operator hold reason" not in summary  # ensure we only return counts/anchors
+    assert summary["hold_reason_summary"]
+    assert summary["reference_anchors"]

--- a/tests/test_wikidata_cohort_c_operator_report_batch.py
+++ b/tests/test_wikidata_cohort_c_operator_report_batch.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.ontology import wikidata_cohort_c_operator_report_batch as report_batch
+
+
+def _load_packet_fixture() -> dict[str, object]:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_c_operator_evidence_packet_20260404.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_batch_report_combines_hold_reasons() -> None:
+    packet = _load_packet_fixture()
+    batch = report_batch.build_nat_cohort_c_operator_report_batch([packet, packet])
+    assert batch["batch_candidate_count"] == 2 * len(packet["evidence_rows"])
+    assert batch["hold_reason_summary"]
+    assert "P854 https://www.wikidata.org/wiki/Q1000001" in batch["reference_anchors"]

--- a/tests/test_wikidata_cohort_c_ptolemy_report.py
+++ b/tests/test_wikidata_cohort_c_ptolemy_report.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.ontology import wikidata_cohort_c_operator_report_batch as report_batch
+
+
+def _load_ptolemy_fixture() -> dict[str, object]:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_c_ptolemy_evidence_sample_20260405.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_ptolemy_batch_report_includes_multiple_packets() -> None:
+    packet = _load_ptolemy_fixture()
+    other_packet = _load_ptolemy_fixture()
+    batch = report_batch.build_nat_cohort_c_operator_report_batch([packet, other_packet])
+    assert batch["batch_candidate_count"] == 6
+    assert len(batch["packet_ids"]) == 2
+    assert "P854 https://www.wikidata.org/wiki/Q4000001" in batch["reference_anchors"]
+    assert batch["hold_reason_summary"]

--- a/tests/test_wikidata_cohort_e_diagnostics.py
+++ b/tests/test_wikidata_cohort_e_diagnostics.py
@@ -1,0 +1,223 @@
+import json
+import sys
+from pathlib import Path
+
+from cli import cohort_e_diagnostics
+from src.ontology.wikidata_cohort_e_diagnostics import (
+    build_cohort_e_diagnostic_report,
+)
+from src.ontology.wikidata_cohort_e_summary_index import build_summary_index
+
+
+def _load_sample_axis_fixture() -> dict[str, object]:
+    path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_e_split_axis_sample_20260403.json"
+    )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_build_cohort_e_diagnostic_report_holds_on_mismatch() -> None:
+    fixture = _load_sample_axis_fixture()
+    sample = fixture["samples"]
+    report = build_cohort_e_diagnostic_report(
+        primary_candidate=sample[0],
+        reference_candidates=[sample[1]],
+        max_comparisons=1,
+    )
+
+    assert report["lane_id"] == "wikidata_nat_cohort_e_unreconciled_instanceof"
+    assert report["hold_reason"] == "unreconciled instance of"
+    assert report["comparisons"][0]["status"] == "disagreement"
+    assert "__value__" in report["comparisons"][0]["disagreements"]
+    assert report["non_authoritative"] is True
+
+
+def test_diagnostic_fixture_matches_helper() -> None:
+    fixture = _load_sample_axis_fixture()
+    sample = fixture["samples"]
+    computed = build_cohort_e_diagnostic_report(
+        primary_candidate=sample[0],
+        reference_candidates=[sample[1]],
+        max_comparisons=1,
+    )
+    fixture_report = _load_diagnostic_report_fixture()
+
+    assert computed == fixture_report
+
+
+def _load_diagnostic_report_fixture() -> dict[str, object]:
+    path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_e_diagnostic_report_20260403.json"
+    )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_batch_sample_fixture() -> dict[str, object]:
+    path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_e_split_axis_batch_sample_20260403.json"
+    )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_batch_report_fixture() -> list[dict[str, object]]:
+    path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_e_diagnostic_batch_report_20260403.json"
+    )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_batch_summary_fixture() -> dict[str, object]:
+    path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_e_diagnostic_summary_20260403.json"
+    )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_cli_regenerates_diagnostic_report(tmp_path, monkeypatch) -> None:
+    samples_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_e_split_axis_sample_20260403.json"
+    )
+    output_path = tmp_path / "generated_report.json"
+    summary_path = tmp_path / "generated_summary.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cohort-e-diagnostics",
+            "--samples",
+            str(samples_path),
+            "--output",
+            str(output_path),
+            "--summary-output",
+            str(summary_path),
+        ],
+    )
+    cohort_e_diagnostics.main()
+    assert output_path.exists()
+    generated = json.loads(output_path.read_text(encoding="utf-8"))
+    fixture = _load_diagnostic_report_fixture()
+    assert generated == fixture
+
+
+def test_cli_batch_outputs_repeat(tmp_path, monkeypatch) -> None:
+    samples_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_e_split_axis_batch_sample_20260403.json"
+    )
+    output_path = tmp_path / "batch_report.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cohort-e-diagnostics",
+            "--batch",
+            "--samples",
+            str(samples_path),
+            "--output",
+            str(output_path),
+            "--summary-output",
+            str(tmp_path / "batch_summary_repeat.json"),
+        ],
+    )
+    cohort_e_diagnostics.main()
+    assert output_path.exists()
+    generated = json.loads(output_path.read_text(encoding="utf-8"))
+    fixture = _load_batch_report_fixture()
+    assert generated == fixture
+
+
+def test_cli_batch_outputs_summary(tmp_path, monkeypatch) -> None:
+    samples_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_e_split_axis_batch_sample_20260403.json"
+    )
+    output_path = tmp_path / "batch_report.json"
+    summary_path = tmp_path / "batch_summary.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cohort-e-diagnostics",
+            "--batch",
+            "--samples",
+            str(samples_path),
+            "--output",
+            str(output_path),
+            "--summary-output",
+            str(summary_path),
+        ],
+    )
+    cohort_e_diagnostics.main()
+    assert summary_path.exists()
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert summary == _load_batch_summary_fixture()
+    index = build_summary_index([summary, summary])
+    expected_index = _load_summary_index_fixture()
+    assert index == expected_index
+
+
+def test_cli_index_output(tmp_path, monkeypatch) -> None:
+    summary_fixture = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_e_diagnostic_summary_20260403.json"
+    )
+    output_path = tmp_path / "batch_report.json"
+    summary_path = tmp_path / "batch_summary.json"
+    index_path = tmp_path / "summary_index.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "cohort-e-diagnostics",
+            "--batch",
+            "--samples",
+            str(summary_fixture),
+            "--output",
+            str(output_path),
+            "--summary-output",
+            str(summary_path),
+            "--summaries",
+            str(summary_fixture),
+            str(summary_fixture),
+            "--index-output",
+            str(index_path),
+        ],
+    )
+    cohort_e_diagnostics.main()
+    assert index_path.exists()
+    generated_index = json.loads(index_path.read_text(encoding="utf-8"))
+    fixture = _load_summary_index_fixture()
+    assert generated_index == fixture
+
+def _load_summary_index_fixture() -> dict[str, object]:
+    path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_e_summary_index_20260403.json"
+    )
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/tests/test_wikidata_nat_automation_graduation.py
+++ b/tests/test_wikidata_nat_automation_graduation.py
@@ -1,0 +1,587 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.ontology.wikidata_nat_automation_graduation import (
+    AUTOMATION_GRADUATION_EVIDENCE_REPORT_SCHEMA_VERSION,
+    AUTOMATION_GRADUATION_GOVERNANCE_INDEX_SCHEMA_VERSION,
+    AUTOMATION_GRADUATION_GOVERNANCE_SUMMARY_SCHEMA_VERSION,
+    AUTOMATION_GRADUATION_BATCH_REPORT_SCHEMA_VERSION,
+    AUTOMATION_GRADUATION_REPORT_SCHEMA_VERSION,
+    AUTOMATION_GRADUATION_EVAL_SCHEMA_VERSION,
+    build_nat_automation_graduation_batch_report,
+    build_nat_automation_graduation_evidence_report,
+    build_nat_automation_graduation_governance_index,
+    build_nat_automation_graduation_governance_summary,
+    build_nat_automation_graduation_report,
+    evaluate_nat_automation_promotion,
+)
+
+
+def _load_graduation_fixture() -> dict:
+    return json.loads(
+        (
+            Path(__file__).resolve().parent
+            / "fixtures"
+            / "wikidata"
+            / "wikidata_nat_automation_graduation_criteria_20260402.json"
+        ).read_text(encoding="utf-8")
+    )
+
+
+def test_evaluator_approves_gate_a_when_all_requirements_are_met() -> None:
+    criteria = _load_graduation_fixture()
+    proposal = {
+        "gate_id": "A",
+        "from_level": 0,
+        "to_level": 1,
+        "gate_families_passed": criteria["gate_families_required"],
+        "evidence_signals": [
+            "reviewer_packets_for_representative_split_shapes",
+            "bounded_follow_depth_present_and_fail_closed",
+            "split_plan_verification_on_representative_reviewed_plans",
+            "uncertainty_flags_preserved",
+        ],
+        "risk_signals": [],
+        "metrics": {metric: {"observed": 1} for metric in criteria["metrics_required"]},
+        "recommendation": "promote",
+    }
+
+    result = evaluate_nat_automation_promotion(criteria, proposal)
+
+    assert result["schema_version"] == AUTOMATION_GRADUATION_EVAL_SCHEMA_VERSION
+    assert result["status"] == "approved"
+    assert result["decision"] == "promote"
+    assert result["promotion_allowed"] is True
+    assert result["failed_checks"] == []
+
+
+def test_evaluator_rejects_when_blocked_signal_is_triggered() -> None:
+    criteria = _load_graduation_fixture()
+    proposal = {
+        "gate_id": "B",
+        "from_level": 1,
+        "to_level": 2,
+        "gate_families_passed": criteria["gate_families_required"],
+        "evidence_signals": [
+            "repeated_family_scoped_direct_safe_behavior",
+            "stable_after_state_verification_across_repeated_tranches",
+            "false_positive_rate_within_family_budget",
+            "hold_and_abstain_paths_effective",
+        ],
+        "risk_signals": ["repeated_tranches_revert_to_split_required_majority"],
+        "metrics": {metric: {"observed": 1} for metric in criteria["metrics_required"]},
+        "recommendation": "promote",
+    }
+
+    result = evaluate_nat_automation_promotion(criteria, proposal)
+
+    assert result["status"] == "rejected"
+    assert result["decision"] == "hold"
+    assert result["promotion_allowed"] is False
+    assert "blocked_signal_triggered" in result["failed_checks"]
+    assert result["triggered_blockers"] == ["repeated_tranches_revert_to_split_required_majority"]
+
+
+def test_evaluator_fail_closed_on_missing_evidence_families_and_metrics() -> None:
+    criteria = _load_graduation_fixture()
+    proposal = {
+        "gate_id": "C",
+        "from_level": 2,
+        "to_level": 3,
+        "gate_families_passed": [
+            "evidence_grounding",
+            "verification_quality",
+        ],
+        "evidence_signals": [
+            "automation_success_across_multiple_structural_families",
+        ],
+        "risk_signals": [],
+        "metrics": {},
+        "recommendation": "promote",
+    }
+
+    result = evaluate_nat_automation_promotion(criteria, proposal)
+
+    assert result["status"] == "rejected"
+    assert result["decision"] == "hold"
+    assert result["promotion_allowed"] is False
+    assert "missing_required_gate_families" in result["failed_checks"]
+    assert "missing_must_show_evidence" in result["failed_checks"]
+    assert "missing_required_metrics" in result["failed_checks"]
+
+
+def test_evaluator_rejects_unknown_gate_fail_closed() -> None:
+    criteria = _load_graduation_fixture()
+    proposal = {
+        "gate_id": "Z",
+        "from_level": 0,
+        "to_level": 1,
+        "gate_families_passed": criteria["gate_families_required"],
+        "evidence_signals": [],
+        "risk_signals": [],
+        "metrics": {},
+        "recommendation": "promote",
+    }
+
+    result = evaluate_nat_automation_promotion(criteria, proposal)
+
+    assert result["status"] == "rejected"
+    assert result["decision"] == "hold"
+    assert result["promotion_allowed"] is False
+    assert result["failed_checks"] == ["gate_not_found"]
+
+
+def test_report_surface_wraps_evaluation_deterministically() -> None:
+    criteria = _load_graduation_fixture()
+    proposal = {
+        "proposal_id": "proposal-123",
+        "gate_id": "A",
+        "from_level": 0,
+        "to_level": 1,
+        "gate_families_passed": criteria["gate_families_required"],
+        "evidence_signals": [
+            "reviewer_packets_for_representative_split_shapes",
+            "bounded_follow_depth_present_and_fail_closed",
+            "split_plan_verification_on_representative_reviewed_plans",
+            "uncertainty_flags_preserved",
+        ],
+        "risk_signals": [],
+        "metrics": {metric: {"observed": 1} for metric in criteria["metrics_required"]},
+        "recommendation": "promote",
+    }
+
+    report = build_nat_automation_graduation_report(criteria, proposal)
+
+    assert report["schema_version"] == AUTOMATION_GRADUATION_REPORT_SCHEMA_VERSION
+    assert report["proposal_id"] == "proposal-123"
+    assert report["gate_id"] == "A"
+    assert report["status"] == "approved"
+    assert report["decision"] == "promote"
+    assert report["promotion_allowed"] is True
+    assert report["failed_checks"] == []
+
+
+def test_batch_report_surface_aggregates_mixed_outcomes_fail_closed() -> None:
+    criteria = _load_graduation_fixture()
+    proposal_batch = {
+        "batch_id": "batch-1",
+        "proposals": [
+            {
+                "proposal_id": "p-approve",
+                "gate_id": "A",
+                "from_level": 0,
+                "to_level": 1,
+                "gate_families_passed": criteria["gate_families_required"],
+                "evidence_signals": [
+                    "reviewer_packets_for_representative_split_shapes",
+                    "bounded_follow_depth_present_and_fail_closed",
+                    "split_plan_verification_on_representative_reviewed_plans",
+                    "uncertainty_flags_preserved",
+                ],
+                "risk_signals": [],
+                "metrics": {metric: {"observed": 1} for metric in criteria["metrics_required"]},
+                "recommendation": "promote",
+            },
+            {
+                "proposal_id": "p-reject",
+                "gate_id": "B",
+                "from_level": 1,
+                "to_level": 2,
+                "gate_families_passed": criteria["gate_families_required"],
+                "evidence_signals": [
+                    "repeated_family_scoped_direct_safe_behavior",
+                    "stable_after_state_verification_across_repeated_tranches",
+                    "false_positive_rate_within_family_budget",
+                    "hold_and_abstain_paths_effective",
+                ],
+                "risk_signals": ["repeated_tranches_revert_to_split_required_majority"],
+                "metrics": {metric: {"observed": 1} for metric in criteria["metrics_required"]},
+                "recommendation": "promote",
+            },
+        ],
+    }
+
+    report = build_nat_automation_graduation_batch_report(criteria, proposal_batch)
+
+    assert report["schema_version"] == AUTOMATION_GRADUATION_BATCH_REPORT_SCHEMA_VERSION
+    assert report["batch_id"] == "batch-1"
+    assert report["proposal_count"] == 2
+    assert report["summary"]["approved_count"] == 1
+    assert report["summary"]["rejected_count"] == 1
+    assert report["summary"]["fail_closed_count"] == 1
+
+
+def test_evidence_report_surface_holds_when_repeated_runs_include_fail_closed_rows() -> None:
+    criteria = _load_graduation_fixture()
+    repeated_batches = {
+        "evidence_batch_id": "evidence-1",
+        "runs": [
+            {
+                "run_id": "run-1",
+                "batch_id": "batch-1",
+                "proposals": [
+                    {
+                        "proposal_id": "p-1",
+                        "gate_id": "A",
+                        "from_level": 0,
+                        "to_level": 1,
+                        "gate_families_passed": criteria["gate_families_required"],
+                        "evidence_signals": [
+                            "reviewer_packets_for_representative_split_shapes",
+                            "bounded_follow_depth_present_and_fail_closed",
+                            "split_plan_verification_on_representative_reviewed_plans",
+                            "uncertainty_flags_preserved",
+                        ],
+                        "risk_signals": [],
+                        "metrics": {metric: {"observed": 1} for metric in criteria["metrics_required"]},
+                        "recommendation": "promote",
+                    },
+                    {
+                        "proposal_id": "p-2",
+                        "gate_id": "B",
+                        "from_level": 1,
+                        "to_level": 2,
+                        "gate_families_passed": criteria["gate_families_required"],
+                        "evidence_signals": [
+                            "repeated_family_scoped_direct_safe_behavior",
+                            "stable_after_state_verification_across_repeated_tranches",
+                            "false_positive_rate_within_family_budget",
+                            "hold_and_abstain_paths_effective",
+                        ],
+                        "risk_signals": ["repeated_tranches_revert_to_split_required_majority"],
+                        "metrics": {metric: {"observed": 1} for metric in criteria["metrics_required"]},
+                        "recommendation": "promote",
+                    },
+                ],
+            },
+            {
+                "run_id": "run-2",
+                "batch_id": "batch-2",
+                "proposals": [
+                    {
+                        "proposal_id": "p-3",
+                        "gate_id": "A",
+                        "from_level": 0,
+                        "to_level": 1,
+                        "gate_families_passed": criteria["gate_families_required"],
+                        "evidence_signals": [
+                            "reviewer_packets_for_representative_split_shapes",
+                            "bounded_follow_depth_present_and_fail_closed",
+                            "split_plan_verification_on_representative_reviewed_plans",
+                            "uncertainty_flags_preserved",
+                        ],
+                        "risk_signals": [],
+                        "metrics": {metric: {"observed": 1} for metric in criteria["metrics_required"]},
+                        "recommendation": "promote",
+                    },
+                    {
+                        "proposal_id": "p-4",
+                        "gate_id": "B",
+                        "from_level": 1,
+                        "to_level": 2,
+                        "gate_families_passed": criteria["gate_families_required"],
+                        "evidence_signals": [
+                            "repeated_family_scoped_direct_safe_behavior",
+                            "stable_after_state_verification_across_repeated_tranches",
+                            "false_positive_rate_within_family_budget",
+                            "hold_and_abstain_paths_effective",
+                        ],
+                        "risk_signals": ["repeated_tranches_revert_to_split_required_majority"],
+                        "metrics": {metric: {"observed": 1} for metric in criteria["metrics_required"]},
+                        "recommendation": "promote",
+                    },
+                ],
+            },
+        ],
+    }
+
+    report = build_nat_automation_graduation_evidence_report(criteria, repeated_batches, min_runs=2)
+
+    assert report["schema_version"] == AUTOMATION_GRADUATION_EVIDENCE_REPORT_SCHEMA_VERSION
+    assert report["status"] == "not_ready"
+    assert report["decision"] == "hold"
+    assert report["promotion_ready"] is False
+    assert "rejected_proposals_present" in report["readiness_failed_reasons"]
+    assert "fail_closed_proposals_present" in report["readiness_failed_reasons"]
+    assert "mixed_gate_scope" in report["readiness_failed_reasons"]
+
+
+def test_evidence_report_surface_promotes_when_repeated_runs_are_clean_and_consistent() -> None:
+    criteria = _load_graduation_fixture()
+    repeated_batches = {
+        "evidence_batch_id": "evidence-2",
+        "runs": [
+            {
+                "run_id": "run-1",
+                "batch_id": "batch-1",
+                "proposals": [
+                    {
+                        "proposal_id": "p-1",
+                        "gate_id": "A",
+                        "from_level": 0,
+                        "to_level": 1,
+                        "gate_families_passed": criteria["gate_families_required"],
+                        "evidence_signals": [
+                            "reviewer_packets_for_representative_split_shapes",
+                            "bounded_follow_depth_present_and_fail_closed",
+                            "split_plan_verification_on_representative_reviewed_plans",
+                            "uncertainty_flags_preserved",
+                        ],
+                        "risk_signals": [],
+                        "metrics": {metric: {"observed": 1} for metric in criteria["metrics_required"]},
+                        "recommendation": "promote",
+                    }
+                ],
+            },
+            {
+                "run_id": "run-2",
+                "batch_id": "batch-2",
+                "proposals": [
+                    {
+                        "proposal_id": "p-2",
+                        "gate_id": "A",
+                        "from_level": 0,
+                        "to_level": 1,
+                        "gate_families_passed": criteria["gate_families_required"],
+                        "evidence_signals": [
+                            "reviewer_packets_for_representative_split_shapes",
+                            "bounded_follow_depth_present_and_fail_closed",
+                            "split_plan_verification_on_representative_reviewed_plans",
+                            "uncertainty_flags_preserved",
+                        ],
+                        "risk_signals": [],
+                        "metrics": {metric: {"observed": 1} for metric in criteria["metrics_required"]},
+                        "recommendation": "promote",
+                    }
+                ],
+            },
+        ],
+    }
+
+    report = build_nat_automation_graduation_evidence_report(criteria, repeated_batches, min_runs=2)
+
+    assert report["schema_version"] == AUTOMATION_GRADUATION_EVIDENCE_REPORT_SCHEMA_VERSION
+    assert report["status"] == "ready"
+    assert report["decision"] == "promote"
+    assert report["promotion_ready"] is True
+    assert report["readiness_failed_reasons"] == []
+    assert report["readiness_scope"]["gate_consistent"] is True
+    assert report["readiness_scope"]["gate_id"] == "A"
+
+
+def test_governance_index_holds_when_any_snapshot_not_ready() -> None:
+    criteria = _load_graduation_fixture()
+    snapshots = {
+        "governance_batch_id": "gov-1",
+        "snapshots": [
+            {
+                "snapshot_id": "s1",
+                "evidence_report": {
+                    "schema_version": AUTOMATION_GRADUATION_EVIDENCE_REPORT_SCHEMA_VERSION,
+                    "status": "ready",
+                    "decision": "promote",
+                    "promotion_ready": True,
+                    "readiness_failed_reasons": [],
+                    "readiness_scope": {"gate_id": "A", "run_count": 2},
+                    "summary": {
+                        "approved_count": 2,
+                        "held_count": 0,
+                        "rejected_count": 0,
+                        "fail_closed_count": 0,
+                    },
+                },
+            },
+            {
+                "snapshot_id": "s2",
+                "evidence_report": {
+                    "schema_version": AUTOMATION_GRADUATION_EVIDENCE_REPORT_SCHEMA_VERSION,
+                    "status": "not_ready",
+                    "decision": "hold",
+                    "promotion_ready": False,
+                    "readiness_failed_reasons": ["rejected_proposals_present"],
+                    "readiness_scope": {"gate_id": "A", "run_count": 2},
+                    "summary": {
+                        "approved_count": 1,
+                        "held_count": 0,
+                        "rejected_count": 1,
+                        "fail_closed_count": 1,
+                    },
+                },
+            },
+        ],
+    }
+
+    report = build_nat_automation_graduation_governance_index(criteria, snapshots, min_snapshots=2)
+
+    assert report["schema_version"] == AUTOMATION_GRADUATION_GOVERNANCE_INDEX_SCHEMA_VERSION
+    assert report["status"] == "not_ready"
+    assert report["decision"] == "hold"
+    assert report["promotion_ready"] is False
+    assert "not_ready_snapshots_present" in report["readiness_failed_reasons"]
+    assert "rejected_proposals_present" in report["readiness_failed_reasons"]
+    assert "fail_closed_proposals_present" in report["readiness_failed_reasons"]
+
+
+def test_governance_index_promotes_when_all_snapshots_ready_and_consistent() -> None:
+    criteria = _load_graduation_fixture()
+    snapshots = {
+        "governance_batch_id": "gov-2",
+        "snapshots": [
+            {
+                "snapshot_id": "s1",
+                "evidence_report": {
+                    "schema_version": AUTOMATION_GRADUATION_EVIDENCE_REPORT_SCHEMA_VERSION,
+                    "status": "ready",
+                    "decision": "promote",
+                    "promotion_ready": True,
+                    "readiness_failed_reasons": [],
+                    "readiness_scope": {"gate_id": "A", "run_count": 2},
+                    "summary": {
+                        "approved_count": 2,
+                        "held_count": 0,
+                        "rejected_count": 0,
+                        "fail_closed_count": 0,
+                    },
+                },
+            },
+            {
+                "snapshot_id": "s2",
+                "evidence_report": {
+                    "schema_version": AUTOMATION_GRADUATION_EVIDENCE_REPORT_SCHEMA_VERSION,
+                    "status": "ready",
+                    "decision": "promote",
+                    "promotion_ready": True,
+                    "readiness_failed_reasons": [],
+                    "readiness_scope": {"gate_id": "A", "run_count": 2},
+                    "summary": {
+                        "approved_count": 1,
+                        "held_count": 0,
+                        "rejected_count": 0,
+                        "fail_closed_count": 0,
+                    },
+                },
+            },
+        ],
+    }
+
+    report = build_nat_automation_graduation_governance_index(criteria, snapshots, min_snapshots=2)
+
+    assert report["schema_version"] == AUTOMATION_GRADUATION_GOVERNANCE_INDEX_SCHEMA_VERSION
+    assert report["status"] == "ready"
+    assert report["decision"] == "promote"
+    assert report["promotion_ready"] is True
+    assert report["readiness_failed_reasons"] == []
+    assert report["scope"]["gate_scope_consistent"] is True
+    assert report["scope"]["gate_id"] == "A"
+
+
+def test_governance_summary_holds_when_any_governance_index_not_ready() -> None:
+    criteria = _load_graduation_fixture()
+    governance_snapshots = {
+        "governance_summary_id": "gov-summary-1",
+        "snapshots": [
+            {
+                "snapshot_id": "g1",
+                "governance_index": {
+                    "schema_version": AUTOMATION_GRADUATION_GOVERNANCE_INDEX_SCHEMA_VERSION,
+                    "status": "ready",
+                    "decision": "promote",
+                    "promotion_ready": True,
+                    "scope": {"gate_id": "A", "snapshot_count": 2},
+                    "summary": {
+                        "ready_count": 2,
+                        "not_ready_count": 0,
+                        "rejected_count": 0,
+                        "fail_closed_count": 0,
+                    },
+                },
+            },
+            {
+                "snapshot_id": "g2",
+                "governance_index": {
+                    "schema_version": AUTOMATION_GRADUATION_GOVERNANCE_INDEX_SCHEMA_VERSION,
+                    "status": "not_ready",
+                    "decision": "hold",
+                    "promotion_ready": False,
+                    "scope": {"gate_id": "A", "snapshot_count": 2},
+                    "summary": {
+                        "ready_count": 1,
+                        "not_ready_count": 1,
+                        "rejected_count": 1,
+                        "fail_closed_count": 1,
+                    },
+                },
+            },
+        ],
+    }
+
+    report = build_nat_automation_graduation_governance_summary(
+        criteria,
+        governance_snapshots,
+        min_indexes=2,
+    )
+
+    assert report["schema_version"] == AUTOMATION_GRADUATION_GOVERNANCE_SUMMARY_SCHEMA_VERSION
+    assert report["status"] == "not_ready"
+    assert report["decision"] == "hold"
+    assert report["promotion_ready"] is False
+    assert "not_ready_governance_indexes_present" in report["readiness_failed_reasons"]
+    assert "rejected_proposals_present" in report["readiness_failed_reasons"]
+    assert "fail_closed_proposals_present" in report["readiness_failed_reasons"]
+
+
+def test_governance_summary_promotes_when_governance_indexes_are_ready_and_consistent() -> None:
+    criteria = _load_graduation_fixture()
+    governance_snapshots = {
+        "governance_summary_id": "gov-summary-2",
+        "snapshots": [
+            {
+                "snapshot_id": "g1",
+                "governance_index": {
+                    "schema_version": AUTOMATION_GRADUATION_GOVERNANCE_INDEX_SCHEMA_VERSION,
+                    "status": "ready",
+                    "decision": "promote",
+                    "promotion_ready": True,
+                    "scope": {"gate_id": "A", "snapshot_count": 2},
+                    "summary": {
+                        "ready_count": 2,
+                        "not_ready_count": 0,
+                        "rejected_count": 0,
+                        "fail_closed_count": 0,
+                    },
+                },
+            },
+            {
+                "snapshot_id": "g2",
+                "governance_index": {
+                    "schema_version": AUTOMATION_GRADUATION_GOVERNANCE_INDEX_SCHEMA_VERSION,
+                    "status": "ready",
+                    "decision": "promote",
+                    "promotion_ready": True,
+                    "scope": {"gate_id": "A", "snapshot_count": 2},
+                    "summary": {
+                        "ready_count": 2,
+                        "not_ready_count": 0,
+                        "rejected_count": 0,
+                        "fail_closed_count": 0,
+                    },
+                },
+            },
+        ],
+    }
+
+    report = build_nat_automation_graduation_governance_summary(
+        criteria,
+        governance_snapshots,
+        min_indexes=2,
+    )
+
+    assert report["schema_version"] == AUTOMATION_GRADUATION_GOVERNANCE_SUMMARY_SCHEMA_VERSION
+    assert report["status"] == "ready"
+    assert report["decision"] == "promote"
+    assert report["promotion_ready"] is True
+    assert report["readiness_failed_reasons"] == []
+    assert report["scope"]["gate_scope_consistent"] is True
+    assert report["scope"]["gate_id"] == "A"

--- a/tests/test_wikidata_nat_cohort_b_operator_batch_report.py
+++ b/tests/test_wikidata_nat_cohort_b_operator_batch_report.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+
+from src.ontology.wikidata_nat_cohort_b_operator_batch_report import (
+    WIKIDATA_NAT_COHORT_B_OPERATOR_BATCH_REPORT_SCHEMA_VERSION,
+    build_nat_cohort_b_operator_batch_report,
+)
+
+
+def _load_fixture(name: str) -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / name
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_build_nat_cohort_b_operator_batch_report_matches_pinned_fixture() -> None:
+    case1 = _load_fixture("wikidata_nat_cohort_b_operator_packet_20260402.json")
+    case2 = _load_fixture("wikidata_nat_cohort_b_operator_packet_case2_20260402.json")
+    expected = _load_fixture("wikidata_nat_cohort_b_operator_batch_report_20260402.json")
+
+    payload = build_nat_cohort_b_operator_batch_report(
+        [case1, case2],
+        max_queue_items=10,
+        max_examples=5,
+    )
+    assert payload["schema_version"] == WIKIDATA_NAT_COHORT_B_OPERATOR_BATCH_REPORT_SCHEMA_VERSION
+    assert payload == expected
+
+
+def test_build_nat_cohort_b_operator_batch_report_holds_with_single_case() -> None:
+    case1 = _load_fixture("wikidata_nat_cohort_b_operator_packet_20260402.json")
+    payload = build_nat_cohort_b_operator_batch_report([case1])
+
+    assert payload["batch_status"] == "hold"
+    assert payload["decision_reasons"] == ["requires_at_least_two_operator_cases"]
+
+
+def test_build_nat_cohort_b_operator_batch_report_holds_when_queue_not_ready() -> None:
+    hold_case = {
+        "packet_id": "operator-packet:hold",
+        "lane_id": "wikidata_nat_wdu_p5991_p14143",
+        "cohort_id": "cohort_b_reconciled_non_business",
+        "decision": "hold",
+        "selected_rows": [],
+        "summary": {"selected_row_count": 0, "variance_flag_counts": {}},
+    }
+    review_case = _load_fixture("wikidata_nat_cohort_b_operator_packet_case2_20260402.json")
+    payload = build_nat_cohort_b_operator_batch_report([review_case, hold_case])
+
+    assert payload["batch_status"] == "hold"
+    assert payload["decision_reasons"] == ["queue_not_ready"]
+    assert payload["queue"]["queue_status"] == "hold"

--- a/tests/test_wikidata_nat_cohort_b_operator_control_summary.py
+++ b/tests/test_wikidata_nat_cohort_b_operator_control_summary.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+from src.ontology.wikidata_nat_cohort_b_operator_control_summary import (
+    WIKIDATA_NAT_COHORT_B_OPERATOR_CONTROL_SUMMARY_SCHEMA_VERSION,
+    build_nat_cohort_b_operator_control_summary,
+)
+
+
+def _load_fixture(name: str) -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / name
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_build_nat_cohort_b_operator_control_summary_matches_pinned_fixture() -> None:
+    index1 = _load_fixture("wikidata_nat_cohort_b_operator_evidence_index_20260402.json")
+    index2 = _load_fixture("wikidata_nat_cohort_b_operator_evidence_index_case2_20260402.json")
+    expected = _load_fixture("wikidata_nat_cohort_b_operator_control_summary_20260402.json")
+
+    payload = build_nat_cohort_b_operator_control_summary(
+        [index1, index2],
+        min_ready_indexes=2,
+    )
+    assert payload["schema_version"] == WIKIDATA_NAT_COHORT_B_OPERATOR_CONTROL_SUMMARY_SCHEMA_VERSION
+    assert payload == expected
+
+
+def test_build_nat_cohort_b_operator_control_summary_holds_on_insufficient_ready_indexes() -> None:
+    index2 = _load_fixture("wikidata_nat_cohort_b_operator_evidence_index_case2_20260402.json")
+    payload = build_nat_cohort_b_operator_control_summary([index2], min_ready_indexes=2)
+
+    assert payload["control_status"] == "hold"
+    assert payload["decision_reasons"] == ["insufficient_ready_indexes"]
+    assert payload["ready_index_ids"] == []
+
+
+def test_build_nat_cohort_b_operator_control_summary_holds_on_validation_error() -> None:
+    invalid = {"cohort_id": "cohort_x", "index_status": "review_index_ready"}
+    payload = build_nat_cohort_b_operator_control_summary([invalid], min_ready_indexes=1)
+
+    assert payload["control_status"] == "hold"
+    assert payload["decision_reasons"] == ["validation_errors_present"]
+    assert payload["summary"]["validation_error_count"] == 1

--- a/tests/test_wikidata_nat_cohort_b_operator_control_summary_cli.py
+++ b/tests/test_wikidata_nat_cohort_b_operator_control_summary_cli.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+from cli.cohort_b_operator_control_summary import main
+
+
+def test_cohort_b_operator_control_summary_cli_materializes_pinned_fixture(tmp_path) -> None:
+    root = Path(__file__).resolve().parent
+    fixture_dir = root / "fixtures" / "wikidata"
+    index1 = fixture_dir / "wikidata_nat_cohort_b_operator_evidence_index_20260402.json"
+    index2 = fixture_dir / "wikidata_nat_cohort_b_operator_evidence_index_case2_20260402.json"
+    expected = json.loads(
+        (fixture_dir / "wikidata_nat_cohort_b_operator_control_summary_20260402.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    out_path = tmp_path / "cohort_b_operator_control_summary.json"
+
+    exit_code = main(
+        [
+            "--inputs",
+            str(index1),
+            str(index2),
+            "--min-ready-indexes",
+            "2",
+            "--output",
+            str(out_path),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload == expected

--- a/tests/test_wikidata_nat_cohort_b_operator_evidence_index.py
+++ b/tests/test_wikidata_nat_cohort_b_operator_evidence_index.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+from src.ontology.wikidata_nat_cohort_b_operator_evidence_index import (
+    WIKIDATA_NAT_COHORT_B_OPERATOR_EVIDENCE_INDEX_SCHEMA_VERSION,
+    build_nat_cohort_b_operator_evidence_index,
+)
+
+
+def _load_fixture(name: str) -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / name
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_build_nat_cohort_b_operator_evidence_index_matches_pinned_fixture() -> None:
+    batch1 = _load_fixture("wikidata_nat_cohort_b_operator_batch_report_20260402.json")
+    batch2 = _load_fixture("wikidata_nat_cohort_b_operator_batch_report_case2_20260402.json")
+    expected = _load_fixture("wikidata_nat_cohort_b_operator_evidence_index_20260402.json")
+
+    payload = build_nat_cohort_b_operator_evidence_index(
+        [batch1, batch2],
+        min_ready_batches=2,
+    )
+    assert payload["schema_version"] == WIKIDATA_NAT_COHORT_B_OPERATOR_EVIDENCE_INDEX_SCHEMA_VERSION
+    assert payload == expected
+
+
+def test_build_nat_cohort_b_operator_evidence_index_holds_on_insufficient_ready_batches() -> None:
+    batch1 = _load_fixture("wikidata_nat_cohort_b_operator_batch_report_20260402.json")
+    payload = build_nat_cohort_b_operator_evidence_index([batch1], min_ready_batches=2)
+
+    assert payload["index_status"] == "hold"
+    assert payload["decision_reasons"] == ["insufficient_ready_batches"]
+    assert payload["ready_batch_ids"] == []
+
+
+def test_build_nat_cohort_b_operator_evidence_index_holds_on_validation_error() -> None:
+    invalid = {"cohort_id": "cohort_x", "batch_status": "batch_review_ready"}
+    payload = build_nat_cohort_b_operator_evidence_index([invalid], min_ready_batches=1)
+
+    assert payload["index_status"] == "hold"
+    assert payload["decision_reasons"] == ["validation_errors_present"]
+    assert payload["summary"]["validation_error_count"] == 1

--- a/tests/test_wikidata_nat_cohort_b_operator_index_cli.py
+++ b/tests/test_wikidata_nat_cohort_b_operator_index_cli.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+from cli.cohort_b_operator_index import main
+
+
+def test_cohort_b_operator_index_cli_materializes_pinned_index(tmp_path) -> None:
+    root = Path(__file__).resolve().parent
+    fixture_dir = root / "fixtures" / "wikidata"
+    batch1 = fixture_dir / "wikidata_nat_cohort_b_operator_batch_report_20260402.json"
+    batch2 = fixture_dir / "wikidata_nat_cohort_b_operator_batch_report_case2_20260402.json"
+    expected = json.loads(
+        (fixture_dir / "wikidata_nat_cohort_b_operator_evidence_index_20260402.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    out_path = tmp_path / "cohort_b_operator_evidence_index.json"
+
+    exit_code = main(
+        [
+            "--inputs",
+            str(batch1),
+            str(batch2),
+            "--min-ready-batches",
+            "2",
+            "--output",
+            str(out_path),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload == expected

--- a/tests/test_wikidata_nat_cohort_b_operator_packet.py
+++ b/tests/test_wikidata_nat_cohort_b_operator_packet.py
@@ -1,0 +1,88 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.ontology.wikidata_nat_cohort_b_operator_packet import (
+    WIKIDATA_NAT_COHORT_B_OPERATOR_PACKET_SCHEMA_VERSION,
+    build_nat_cohort_b_operator_packet,
+)
+from src.ontology.wikidata_nat_cohort_b_review_bucket import (
+    WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION,
+    build_nat_cohort_b_review_bucket,
+)
+
+
+def _load_fixture(name: str) -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / name
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_build_nat_cohort_b_operator_packet_from_review_bucket_fixture() -> None:
+    payload = _load_fixture("wikidata_nat_cohort_b_operator_packet_input_20260402.json")
+    packet = build_nat_cohort_b_operator_packet(payload, max_rows=2)
+
+    assert packet["schema_version"] == WIKIDATA_NAT_COHORT_B_OPERATOR_PACKET_SCHEMA_VERSION
+    assert packet["cohort_id"] == "cohort_b_reconciled_non_business"
+    assert packet["decision"] == "review"
+    assert packet["source_bucket_decision"] == "review_only"
+    assert packet["summary"]["selected_row_count"] == 2
+    assert packet["summary"]["source_review_row_count"] == 2
+    assert packet["summary"]["contract_violation_count"] == 0
+    assert "unexpected_qualifier_properties" in packet["summary"]["variance_flag_counts"]
+    assert packet["governance"]["fail_closed"] is True
+    assert packet["governance"]["automation_allowed"] is False
+    assert packet["selected_rows"][0]["row_id"] == "Q8646|P5991|4"
+
+
+def test_build_nat_cohort_b_operator_packet_matches_pinned_fixture() -> None:
+    review_bucket = _load_fixture("wikidata_nat_cohort_b_operator_packet_input_20260402.json")
+    expected = _load_fixture("wikidata_nat_cohort_b_operator_packet_20260402.json")
+
+    packet = build_nat_cohort_b_operator_packet(review_bucket, max_rows=2)
+    assert packet == expected
+
+
+def test_build_nat_cohort_b_operator_packet_holds_when_bucket_is_hold() -> None:
+    bucket_payload = {
+        "schema_version": WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION,
+        "lane_id": "wikidata_nat_wdu_p5991_p14143",
+        "candidates": [
+            {
+                "row_id": "Q1|P5991|1",
+                "entity_qid": "Q1",
+                "instance_of_qid": "Q4830453",
+                "reconciled_instance_of": True,
+                "qualifier_properties": ["P459"],
+                "reference_properties": ["P854"],
+            }
+        ],
+    }
+    review_bucket = build_nat_cohort_b_review_bucket(bucket_payload)
+    packet = build_nat_cohort_b_operator_packet(review_bucket)
+
+    assert review_bucket["decision"] == "hold"
+    assert packet["decision"] == "hold"
+    assert packet["selected_rows"] == []
+    assert packet["summary"]["contract_violation_count"] == 1
+    assert packet["contract_violations"][0]["violation"] == "business_family_instance_of_in_cohort_b_payload"
+    assert packet["triage_prompts"][0].startswith("Payload violated the Cohort B contract")
+
+
+def test_build_nat_cohort_b_operator_packet_requires_valid_cohort_shape() -> None:
+    with pytest.raises(ValueError, match="requires cohort_b_reconciled_non_business payload"):
+        build_nat_cohort_b_operator_packet({"cohort_id": "wrong"})
+
+    with pytest.raises(ValueError, match="decision must be review_only or hold"):
+        build_nat_cohort_b_operator_packet(
+            {
+                "cohort_id": "cohort_b_reconciled_non_business",
+                "decision": "review",
+                "review_bucket_rows": [],
+            }
+        )

--- a/tests/test_wikidata_nat_cohort_b_operator_queue.py
+++ b/tests/test_wikidata_nat_cohort_b_operator_queue.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+
+from src.ontology.wikidata_nat_cohort_b_operator_packet import (
+    WIKIDATA_NAT_COHORT_B_OPERATOR_PACKET_SCHEMA_VERSION,
+    build_nat_cohort_b_operator_packet,
+)
+from src.ontology.wikidata_nat_cohort_b_operator_queue import (
+    WIKIDATA_NAT_COHORT_B_OPERATOR_QUEUE_SCHEMA_VERSION,
+    build_nat_cohort_b_operator_queue,
+)
+from src.ontology.wikidata_nat_cohort_b_review_bucket import (
+    WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION,
+    build_nat_cohort_b_review_bucket,
+)
+
+
+def _load_fixture(name: str) -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / name
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_build_nat_cohort_b_operator_queue_matches_pinned_fixture() -> None:
+    operator_packet = _load_fixture("wikidata_nat_cohort_b_operator_packet_20260402.json")
+    expected = _load_fixture("wikidata_nat_cohort_b_operator_queue_20260402.json")
+
+    queue = build_nat_cohort_b_operator_queue([operator_packet], max_queue_items=10)
+    assert queue["schema_version"] == WIKIDATA_NAT_COHORT_B_OPERATOR_QUEUE_SCHEMA_VERSION
+    assert queue == expected
+
+
+def test_build_nat_cohort_b_operator_queue_holds_when_any_input_packet_is_hold() -> None:
+    review_bucket = build_nat_cohort_b_review_bucket(
+        {
+            "schema_version": WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION,
+            "lane_id": "wikidata_nat_wdu_p5991_p14143",
+            "candidates": [
+                {
+                    "row_id": "Q1|P5991|1",
+                    "entity_qid": "Q1",
+                    "instance_of_qid": "Q4830453",
+                    "reconciled_instance_of": True,
+                    "qualifier_properties": ["P459"],
+                    "reference_properties": ["P854"],
+                }
+            ],
+        }
+    )
+    hold_packet = build_nat_cohort_b_operator_packet(review_bucket)
+    review_packet = _load_fixture("wikidata_nat_cohort_b_operator_packet_20260402.json")
+
+    queue = build_nat_cohort_b_operator_queue([review_packet, hold_packet])
+    assert queue["queue_status"] == "hold"
+    assert queue["queue_items"] == []
+    assert queue["summary"]["hold_packet_count"] == 1
+    assert queue["blocked_packets"][0]["packet_id"] == hold_packet["packet_id"]
+
+
+def test_build_nat_cohort_b_operator_queue_holds_on_validation_errors() -> None:
+    invalid_packet = {
+        "schema_version": WIKIDATA_NAT_COHORT_B_OPERATOR_PACKET_SCHEMA_VERSION,
+        "packet_id": "operator-packet:invalid",
+        "lane_id": "wikidata_nat_wdu_p5991_p14143",
+        "cohort_id": "cohort_c_wrong",
+        "decision": "review",
+        "selected_rows": [{"row_id": "r1"}],
+    }
+
+    queue = build_nat_cohort_b_operator_queue([invalid_packet])
+    assert queue["queue_status"] == "hold"
+    assert queue["queue_items"] == []
+    assert queue["summary"]["validation_error_count"] == 1
+    assert queue["validation_errors"][0]["error"] == "packet_not_cohort_b"

--- a/tests/test_wikidata_nat_cohort_b_operator_report.py
+++ b/tests/test_wikidata_nat_cohort_b_operator_report.py
@@ -1,0 +1,73 @@
+import json
+from pathlib import Path
+
+from src.ontology.wikidata_nat_cohort_b_operator_packet import (
+    build_nat_cohort_b_operator_packet,
+)
+from src.ontology.wikidata_nat_cohort_b_operator_queue import (
+    build_nat_cohort_b_operator_queue,
+)
+from src.ontology.wikidata_nat_cohort_b_operator_report import (
+    WIKIDATA_NAT_COHORT_B_OPERATOR_REPORT_SCHEMA_VERSION,
+    build_nat_cohort_b_operator_report,
+)
+from src.ontology.wikidata_nat_cohort_b_review_bucket import (
+    WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION,
+    build_nat_cohort_b_review_bucket,
+)
+
+
+def _load_fixture(name: str) -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / name
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_build_nat_cohort_b_operator_report_matches_pinned_fixture() -> None:
+    queue_payload = _load_fixture("wikidata_nat_cohort_b_operator_queue_20260402.json")
+    expected = _load_fixture("wikidata_nat_cohort_b_operator_report_20260402.json")
+
+    report = build_nat_cohort_b_operator_report(queue_payload, max_examples=3)
+    assert report["schema_version"] == WIKIDATA_NAT_COHORT_B_OPERATOR_REPORT_SCHEMA_VERSION
+    assert report == expected
+
+
+def test_build_nat_cohort_b_operator_report_holds_when_queue_holds() -> None:
+    review_bucket = build_nat_cohort_b_review_bucket(
+        {
+            "schema_version": WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION,
+            "lane_id": "wikidata_nat_wdu_p5991_p14143",
+            "candidates": [
+                {
+                    "row_id": "Q1|P5991|1",
+                    "entity_qid": "Q1",
+                    "instance_of_qid": "Q4830453",
+                    "reconciled_instance_of": True,
+                    "qualifier_properties": ["P459"],
+                    "reference_properties": ["P854"],
+                }
+            ],
+        }
+    )
+    hold_packet = build_nat_cohort_b_operator_packet(review_bucket)
+    queue_payload = build_nat_cohort_b_operator_queue([hold_packet])
+    report = build_nat_cohort_b_operator_report(queue_payload)
+
+    assert queue_payload["queue_status"] == "hold"
+    assert report["report_status"] == "hold"
+    assert report["examples"] == []
+    assert report["summary"]["blocked_packet_count"] == 1
+    assert report["recommendations"][0].startswith("Queue is not ready")
+
+
+def test_build_nat_cohort_b_operator_report_requires_cohort_b_queue_shape() -> None:
+    try:
+        build_nat_cohort_b_operator_report({"cohort_id": "wrong"})
+    except ValueError as exc:
+        assert "cohort_b_reconciled_non_business" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for non-Cohort-B queue payload")

--- a/tests/test_wikidata_nat_cohort_b_review_bucket.py
+++ b/tests/test_wikidata_nat_cohort_b_review_bucket.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.ontology.wikidata_nat_cohort_b_review_bucket import (
+    WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION,
+    build_nat_cohort_b_review_bucket,
+)
+
+
+def _load_fixture(name: str) -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / name
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_build_nat_cohort_b_review_bucket_emits_review_rows_and_variance_flags() -> None:
+    payload = _load_fixture("wikidata_nat_cohort_b_review_bucket_20260402.json")
+    result = build_nat_cohort_b_review_bucket(payload)
+
+    assert result["schema_version"] == WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION
+    assert result["cohort_id"] == "cohort_b_reconciled_non_business"
+    assert result["decision"] == "review_only"
+    assert result["summary"]["input_candidate_count"] == 2
+    assert result["summary"]["valid_review_row_count"] == 2
+    assert result["summary"]["contract_violation_count"] == 0
+    assert len(result["review_bucket_rows"]) == 2
+    assert result["review_bucket_rows"][0]["instance_of_qid"] == "Q13442814"
+    assert "missing_expected_reference_properties" in result["review_bucket_rows"][0]["variance_flags"]
+    assert "unexpected_qualifier_properties" in result["review_bucket_rows"][1]["variance_flags"]
+    assert "unexpected_reference_properties" in result["review_bucket_rows"][1]["variance_flags"]
+    assert result["contract_violations"] == []
+
+
+def test_build_nat_cohort_b_review_bucket_holds_when_payload_contains_out_of_lane_rows() -> None:
+    payload = {
+        "schema_version": WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION,
+        "lane_id": "wikidata_nat_wdu_p5991_p14143",
+        "candidates": [
+            {
+                "row_id": "Q1|P5991|1",
+                "entity_qid": "Q1",
+                "instance_of_qid": "Q4830453",
+                "reconciled_instance_of": True,
+                "qualifier_properties": ["P459"],
+                "reference_properties": ["P854"],
+            },
+            {
+                "row_id": "Q2|P5991|1",
+                "entity_qid": "Q2",
+                "instance_of_qid": "Q13442814",
+                "reconciled_instance_of": False,
+                "qualifier_properties": ["P459"],
+                "reference_properties": ["P854"],
+            },
+        ],
+    }
+
+    result = build_nat_cohort_b_review_bucket(payload)
+    assert result["decision"] == "hold"
+    assert result["review_bucket_rows"] == []
+    assert result["summary"]["contract_violation_count"] == 2
+    assert {item["violation"] for item in result["contract_violations"]} == {
+        "business_family_instance_of_in_cohort_b_payload",
+        "unreconciled_instance_of_in_cohort_b_payload",
+    }
+
+
+def test_build_nat_cohort_b_review_bucket_requires_schema_and_candidate_shape() -> None:
+    with pytest.raises(ValueError, match="must use"):
+        build_nat_cohort_b_review_bucket({"schema_version": "wrong", "candidates": []})
+    with pytest.raises(ValueError, match="requires candidates list"):
+        build_nat_cohort_b_review_bucket(
+            {"schema_version": WIKIDATA_NAT_COHORT_B_REVIEW_BUCKET_SCHEMA_VERSION}
+        )

--- a/tests/test_wikidata_nat_cohort_d_operator_report.py
+++ b/tests/test_wikidata_nat_cohort_d_operator_report.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+from src.ontology.wikidata_nat_cohort_d_review import (
+    WIKIDATA_NAT_COHORT_D_OPERATOR_REPORT_SCHEMA_VERSION,
+    build_wikidata_nat_cohort_d_operator_report,
+)
+
+
+def _load_fixture(name: str) -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / name
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_cohort_d_operator_report_fixture_is_fail_closed_and_review_only() -> None:
+    payload = _load_fixture("wikidata_nat_cohort_d_operator_report_20260402.json")
+
+    assert payload["schema_version"] == WIKIDATA_NAT_COHORT_D_OPERATOR_REPORT_SCHEMA_VERSION
+    assert payload["readiness"] == "review_queue_ready"
+    assert payload["decision"] == "review"
+    assert payload["promotion_allowed"] is False
+    assert payload["summary"]["queue_size"] == 2
+    assert payload["summary"]["high_priority_count"] == 2
+    assert payload["summary"]["unresolved_packet_ref_count"] == 0
+    assert payload["governance"]["automation_allowed"] is False
+    assert payload["governance"]["can_execute_edits"] is False
+    assert payload["blocked_signals"] == []
+    assert payload["queue_preview"][0]["review_entity_qid"] == "Q1785637"
+
+
+def test_cohort_d_operator_report_adds_blocked_signal_when_queue_not_ready() -> None:
+    operator_review_surface = _load_fixture("wikidata_nat_cohort_d_operator_review_surface_20260402.json")
+    operator_review_surface["readiness"] = "review_queue_incomplete"
+    operator_review_surface["unresolved_packet_ref_count"] = 1
+
+    payload = build_wikidata_nat_cohort_d_operator_report(operator_review_surface)
+
+    assert payload["summary"]["unresolved_packet_ref_count"] == 1
+    assert "unresolved_packet_refs_present" in payload["blocked_signals"]
+    assert "operator_review_surface_not_ready" in payload["blocked_signals"]

--- a/tests/test_wikidata_nat_cohort_d_operator_report_batch.py
+++ b/tests/test_wikidata_nat_cohort_d_operator_report_batch.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+from src.ontology.wikidata_nat_cohort_d_review import (
+    WIKIDATA_NAT_COHORT_D_OPERATOR_REPORT_BATCH_SCHEMA_VERSION,
+    build_wikidata_nat_cohort_d_operator_report_batch,
+)
+
+
+def _load_fixture(name: str) -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / name
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_cohort_d_operator_report_batch_fixture_aggregates_readiness_and_blockers() -> None:
+    payload = _load_fixture("wikidata_nat_cohort_d_operator_report_batch_20260402.json")
+
+    assert payload["schema_version"] == WIKIDATA_NAT_COHORT_D_OPERATOR_REPORT_BATCH_SCHEMA_VERSION
+    assert payload["batch_id"] == "cohort_d_operator_batch_20260402"
+    assert payload["decision"] == "review"
+    assert payload["promotion_allowed"] is False
+    assert payload["summary"]["case_count"] == 2
+    assert payload["summary"]["readiness_counts"] == {
+        "review_queue_ready": 1,
+        "review_queue_incomplete": 1,
+    }
+    assert payload["summary"]["all_cases_ready"] is False
+    assert payload["summary"]["total_unresolved_packet_ref_count"] == 1
+    assert "operator_review_surface_not_ready" in payload["blocked_signals"]
+    assert "unresolved_packet_refs_present" in payload["blocked_signals"]
+
+
+def test_cohort_d_operator_report_batch_builder_accepts_operator_review_surfaces() -> None:
+    batch_input = _load_fixture("wikidata_nat_cohort_d_operator_report_batch_input_20260402.json")
+    payload = build_wikidata_nat_cohort_d_operator_report_batch(
+        operator_review_surfaces=batch_input["operator_review_surfaces"],
+        batch_id=batch_input["batch_id"],
+    )
+
+    assert payload["batch_id"] == "cohort_d_operator_batch_20260402"
+    assert payload["summary"]["case_count"] == 2
+    assert len(payload["case_reports"]) == 2

--- a/tests/test_wikidata_nat_cohort_d_operator_review_surface.py
+++ b/tests/test_wikidata_nat_cohort_d_operator_review_surface.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+from src.ontology.wikidata_nat_cohort_d_review import (
+    WIKIDATA_NAT_COHORT_D_OPERATOR_REVIEW_SURFACE_SCHEMA_VERSION,
+    build_wikidata_nat_cohort_d_operator_review_surface,
+)
+
+
+def _load_fixture(name: str) -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / name
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_cohort_d_operator_review_surface_fixture_is_non_executing_queue() -> None:
+    payload = _load_fixture("wikidata_nat_cohort_d_operator_review_surface_20260402.json")
+
+    assert payload["schema_version"] == WIKIDATA_NAT_COHORT_D_OPERATOR_REVIEW_SURFACE_SCHEMA_VERSION
+    assert payload["readiness"] == "review_queue_ready"
+    assert payload["queue_size"] == 2
+    assert payload["unresolved_packet_ref_count"] == 0
+    assert payload["required_checklist"] == [
+        "confirm_absence_of_instance_of",
+        "collect_typing_candidates",
+        "record_reconcile_or_hold_decision",
+    ]
+    assert payload["governance"]["automation_allowed"] is False
+    assert payload["governance"]["can_execute_edits"] is False
+    assert payload["governance"]["promotion_guard"] == "hold"
+    assert all(row["execution_allowed"] is False for row in payload["operator_queue"])
+
+
+def test_cohort_d_operator_review_surface_becomes_incomplete_when_probe_surface_has_unresolved_refs() -> None:
+    probe = _load_fixture("wikidata_nat_cohort_d_type_probing_surface_20260402.json")
+    probe["unresolved_packet_refs"] = [{"review_entity_qid": "Q1785637", "reason": "missing_packet_payload"}]
+
+    payload = build_wikidata_nat_cohort_d_operator_review_surface(type_probing_surface=probe)
+
+    assert payload["readiness"] == "review_queue_incomplete"
+    assert payload["unresolved_packet_ref_count"] == 1

--- a/tests/test_wikidata_nat_cohort_d_review_control_index.py
+++ b/tests/test_wikidata_nat_cohort_d_review_control_index.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+from src.ontology.wikidata_nat_cohort_d_review import (
+    WIKIDATA_NAT_COHORT_D_REVIEW_CONTROL_INDEX_SCHEMA_VERSION,
+    build_wikidata_nat_cohort_d_review_control_index,
+)
+
+
+def _load_fixture(name: str) -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / name
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_cohort_d_review_control_index_fixture_preserves_blockers_and_hold_signals() -> None:
+    payload = _load_fixture("wikidata_nat_cohort_d_review_control_index_20260402.json")
+
+    assert payload["schema_version"] == WIKIDATA_NAT_COHORT_D_REVIEW_CONTROL_INDEX_SCHEMA_VERSION
+    assert payload["index_id"] == "cohort_d_review_control_index_20260402"
+    assert payload["decision"] == "review"
+    assert payload["promotion_allowed"] is False
+    assert payload["summary"]["batch_count"] == 2
+    assert payload["summary"]["readiness_counts"] == {
+        "review_queue_ready": 1,
+        "review_queue_incomplete": 1,
+    }
+    assert payload["summary"]["all_batches_ready"] is False
+    assert "batch_not_all_cases_ready" in payload["blocked_signals"]
+    assert payload["hold_signals"] == [
+        "promotion_guard_hold_enforced",
+        "incomplete_batch_present",
+        "unresolved_packet_refs_present",
+    ]
+
+
+def test_cohort_d_review_control_index_builder_accepts_batch_reports() -> None:
+    payload = _load_fixture("wikidata_nat_cohort_d_review_control_index_input_20260402.json")
+    report = build_wikidata_nat_cohort_d_review_control_index(
+        batch_reports=payload["batch_reports"],
+        index_id=payload["index_id"],
+    )
+
+    assert report["index_id"] == "cohort_d_review_control_index_20260402"
+    assert report["summary"]["batch_count"] == 2
+    assert len(report["batch_entries"]) == 2

--- a/tests/test_wikidata_nat_cohort_d_review_lane.py
+++ b/tests/test_wikidata_nat_cohort_d_review_lane.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+
+def _load_cohort_d_review_surface_fixture() -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_d_review_surface_20260402.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_cohort_d_review_surface_is_fail_closed_and_review_first() -> None:
+    payload = _load_cohort_d_review_surface_fixture()
+
+    assert payload["schema_version"] == "sl.wikidata_nat_cohort_d_review_surface.v0_1"
+    assert payload["lane_id"] == "wikidata_nat_cohort_d_no_instance_of"
+    assert payload["cohort_id"] == "cohort_d_no_instance_of"
+    assert payload["cohort_bucket_summary"]["sandbox_claimed_statement_count"] == 1395
+
+    governance = payload["governance"]
+    assert governance["bucket_type"] == "typing_deficit_review_only"
+    assert governance["automation_allowed"] is False
+    assert governance["can_execute_edits"] is False
+    assert governance["promotion_guard"] == "hold"
+    assert governance["fail_closed"] is True
+
+    review_surface = payload["review_surface"]
+    assert review_surface["current_gate_id"] == "review_first_typing_resolution_scan"
+    assert review_surface["current_gate_status"] == "open_review"
+    assert review_surface["next_gate_id"] == "type_probing_scan_review_only"
+    assert review_surface["progress_claim"] == "reviewable_surface_only"
+
+
+def test_cohort_d_review_surface_references_disjoint_probe_packets() -> None:
+    payload = _load_cohort_d_review_surface_fixture()
+    packet_refs = payload["candidate_packet_refs"]
+
+    assert len(packet_refs) == 2
+    assert packet_refs[0]["review_entity_qid"] == "Q738421"
+    assert packet_refs[1]["review_entity_qid"] == "Q1785637"
+    assert all(ref["packet_role"] == "cohort_d_typing_deficit_probe" for ref in packet_refs)
+    assert "no_direct_migration_execution" in payload["non_claims"]

--- a/tests/test_wikidata_nat_cohort_d_type_probing_surface.py
+++ b/tests/test_wikidata_nat_cohort_d_type_probing_surface.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+
+from src.ontology.wikidata_nat_cohort_d_review import (
+    WIKIDATA_NAT_COHORT_D_TYPE_PROBING_SURFACE_SCHEMA_VERSION,
+    build_wikidata_nat_cohort_d_type_probing_surface,
+)
+
+
+def _load_fixture(name: str) -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / name
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_cohort_d_type_probing_surface_fixture_is_fail_closed_and_non_executing() -> None:
+    payload = _load_fixture("wikidata_nat_cohort_d_type_probing_surface_20260402.json")
+
+    assert payload["schema_version"] == WIKIDATA_NAT_COHORT_D_TYPE_PROBING_SURFACE_SCHEMA_VERSION
+    assert payload["artifact_status"] == "review_only_ready"
+    assert payload["lane_id"] == "wikidata_nat_cohort_d_no_instance_of"
+    assert payload["current_gate_id"] == "review_first_typing_resolution_scan"
+    assert payload["next_gate_id"] == "type_probing_scan_review_only"
+    assert payload["governance"]["automation_allowed"] is False
+    assert payload["governance"]["can_execute_edits"] is False
+    assert payload["governance"]["fail_closed"] is True
+    assert payload["governance"]["promotion_guard"] == "hold"
+    assert payload["unresolved_packet_refs"] == []
+
+    qids = [row["review_entity_qid"] for row in payload["probe_rows"]]
+    assert qids == ["Q738421", "Q1785637"]
+    assert all(row["execution_allowed"] is False for row in payload["probe_rows"])
+
+
+def test_cohort_d_type_probing_surface_marks_missing_packet_refs_incomplete() -> None:
+    review_surface = _load_fixture("wikidata_nat_cohort_d_review_surface_20260402.json")
+    one_packet = _load_fixture("wikidata_nat_review_packet_Q738421_sidecar_20260402.json")
+
+    payload = build_wikidata_nat_cohort_d_type_probing_surface(
+        cohort_d_review_surface=review_surface,
+        packet_payloads=[one_packet],
+    )
+
+    assert payload["artifact_status"] == "review_only_incomplete"
+    assert payload["unresolved_packet_refs"] == [
+        {"review_entity_qid": "Q1785637", "reason": "missing_packet_payload"}
+    ]

--- a/tests/test_wikidata_nat_grounding_depth.py
+++ b/tests/test_wikidata_nat_grounding_depth.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+from pathlib import Path
+import copy
+import json
+
+from src.ontology.wikidata_grounding_depth import (
+    GROUNDING_ATTACHMENT_SCHEMA_VERSION,
+    GROUNDING_BATCH_SCHEMA_VERSION,
+    GROUNDING_DEPTH_SCHEMA_VERSION,
+    GROUNDING_EVIDENCE_REPORT_SCHEMA_VERSION,
+    GROUNDING_SCORECARD_SCHEMA_VERSION,
+    build_grounding_depth_attachment,
+    build_grounding_depth_batch,
+    build_grounding_depth_comparison,
+    build_grounding_depth_evidence_report,
+    build_grounding_depth_scorecard,
+    build_grounding_depth_summary,
+)
+
+
+def _load_fixture() -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_grounding_depth_packets_20260402.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_grounding_depth_fixture_contains_packets() -> None:
+    payload = _load_fixture()
+    assert payload["lane_id"] == "wikidata_nat_wdu_p5991_p14143"
+    assert payload["evidence_focus"] == "hard packets grounding depth"
+    assert len(payload["sample_packets"]) == 3
+
+
+def test_each_packet_has_revision_evidence() -> None:
+    payload = _load_fixture()
+    for packet in payload["sample_packets"]:
+        assert packet["qid"].startswith("Q")
+        assert packet["revision_url"].startswith("https://")
+        assert isinstance(packet["revision_locked_notes"], str)
+        assert packet["revision_evidence"], "packet should include evidence excerpts"
+        excerpt_texts = [e["excerpt"] for e in packet["revision_evidence"]]
+    assert all(excerpt_texts), "excerpt cannot be empty"
+
+
+def _load_attachment_fixture() -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_grounding_depth_operator_surface_20260402.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_build_grounding_attachment_matches_fixture() -> None:
+    payload = _load_fixture()
+    summary = build_grounding_depth_summary(fixture=payload)
+    review_packet = {"packet_id": "review-packet:5bae90b4fcb444f6", "review_entity_qid": "Q10403939"}
+    attachment = build_grounding_depth_attachment(
+        review_packet=review_packet,
+        grounding_summary=summary,
+    )
+    expected = _load_attachment_fixture()
+    assert attachment["schema_version"] == GROUNDING_ATTACHMENT_SCHEMA_VERSION
+    assert attachment == expected
+
+
+def test_build_grounding_attachment_fail_closed() -> None:
+    payload = _load_fixture()
+    summary = build_grounding_depth_summary(fixture=payload)
+    review_packet = {"packet_id": "unknown", "review_entity_qid": "Q000000"}
+    attachment = build_grounding_depth_attachment(
+        review_packet=review_packet,
+        grounding_summary=summary,
+    )
+    assert attachment["grounding_status"] == "no_grounding_data"
+    assert attachment["notes"] == ["no grounding data matched the provided packet"]
+
+
+def test_build_grounding_summary_uses_fixture() -> None:
+    payload = _load_fixture()
+    summary = build_grounding_depth_summary(fixture=payload)
+    assert summary["schema_version"] == GROUNDING_DEPTH_SCHEMA_VERSION
+    assert summary["lane_id"] == payload["lane_id"]
+    assert summary["packet_count"] == 3
+    assert summary["grounded_packet_count"] == 3
+    assert all(pkt["grounding_status"] == "grounded" for pkt in summary["packets"])
+
+
+def test_missing_evidence_marks_packet_incomplete() -> None:
+    payload = _load_fixture()
+    altered = copy.deepcopy(payload)
+    altered["sample_packets"][0]["revision_evidence"][0]["excerpt"] = ""
+    summary = build_grounding_depth_summary(fixture=altered)
+    assert summary["grounded_packet_count"] == 2
+    assert summary["packets"][0]["grounding_status"] == "missing_evidence"
+    evidence_entry = summary["packets"][0]["revision_evidence"][0]
+    assert evidence_entry["status"] == "incomplete"
+    assert "excerpt" in evidence_entry["missing_fields"]
+
+
+def _load_batch_fixture() -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_grounding_depth_batch_20260402.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_build_grounding_batch_matches_fixture() -> None:
+    payload = _load_fixture()
+    summary = build_grounding_depth_summary(fixture=payload)
+    review_packets = [
+        {"packet_id": "review-packet:5bae90b4fcb444f6", "review_entity_qid": "Q10403939"},
+        {"packet_id": "review-packet:c52b8308fdbdd5e3", "review_entity_qid": "Q731938"},
+    ]
+    batch = build_grounding_depth_batch(
+        review_packets=review_packets,
+        grounding_summary=summary,
+    )
+    expected = _load_batch_fixture()
+    assert batch["schema_version"] == GROUNDING_BATCH_SCHEMA_VERSION
+    assert batch == expected
+
+
+def test_build_grounding_batch_handles_empty_review_packets() -> None:
+    payload = _load_fixture()
+    summary = build_grounding_depth_summary(fixture=payload)
+    batch = build_grounding_depth_batch(
+        review_packets=[],
+        grounding_summary=summary,
+    )
+    assert batch["attachment_count"] == 0
+    assert batch["attachments"] == []
+
+
+def test_cli_generates_expected_batch(tmp_path: Path) -> None:
+    from cli import grounding_depth
+
+    summary_fixture = _load_fixture()
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(json.dumps(summary_fixture, indent=2), encoding="utf-8")
+    packets_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_grounding_depth_review_packets_20260402.json"
+    )
+    output_path = tmp_path / "batch.json"
+    grounding_depth.main(
+        [
+            "--summary",
+            str(summary_path),
+            "--packets",
+            str(packets_path),
+            "--outfile",
+            str(output_path),
+        ]
+    )
+    produced = json.loads(output_path.read_text(encoding="utf-8"))
+    expected = _load_batch_fixture()
+    assert produced == expected
+
+
+def _load_report_fixture() -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_grounding_depth_evidence_report_20260402.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def _load_scorecard_fixture() -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_grounding_depth_scorecard_20260402.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_build_evidence_report_matches_fixture() -> None:
+    payload = _load_fixture()
+    summary = build_grounding_depth_summary(fixture=payload)
+    report = build_grounding_depth_evidence_report(grounding_summary=summary)
+    expected = _load_report_fixture()
+    assert report["schema_version"] == GROUNDING_EVIDENCE_REPORT_SCHEMA_VERSION
+    assert report == expected
+
+
+def test_cli_writes_report(tmp_path: Path) -> None:
+    from SensibLaw.cli import grounding_depth
+
+    summary_fixture = _load_fixture()
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(json.dumps(summary_fixture, indent=2), encoding="utf-8")
+    packets_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_grounding_depth_review_packets_20260402.json"
+    )
+    batch_path = tmp_path / "batch.json"
+    report_path = tmp_path / "report.json"
+    grounding_depth.main(
+        [
+            "--summary",
+            str(summary_path),
+            "--packets",
+            str(packets_path),
+            "--outfile",
+            str(batch_path),
+            "--report-out",
+            str(report_path),
+        ]
+    )
+    produced_report = json.loads(report_path.read_text(encoding="utf-8"))
+    expected_report = _load_report_fixture()
+    assert produced_report == expected_report
+
+
+def _load_single_batch_fixture() -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_grounding_depth_batch_single_20260402.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def _load_comparison_fixture() -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_grounding_depth_comparison_20260402.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_build_comparison_matches_fixture() -> None:
+    base_batch = _load_batch_fixture()
+    single_batch = _load_single_batch_fixture()
+    comparison = build_grounding_depth_comparison(batches=[base_batch, single_batch])
+    expected = _load_comparison_fixture()
+    assert comparison["schema_version"] == GROUNDING_EVIDENCE_REPORT_SCHEMA_VERSION
+    assert comparison == expected
+
+
+def test_cli_writes_comparison(tmp_path: Path) -> None:
+    from SensibLaw.cli import grounding_depth
+
+    summary_fixture = _load_fixture()
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text(json.dumps(summary_fixture, indent=2), encoding="utf-8")
+    packets_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_grounding_depth_review_packets_20260402.json"
+    )
+    batch_path = tmp_path / "batch.json"
+    comparison_path = tmp_path / "comparison.json"
+    scorecard_path = tmp_path / "scorecard.json"
+    grounding_depth.main(
+        [
+            "--summary",
+            str(summary_path),
+            "--packets",
+            str(packets_path),
+            "--outfile",
+            str(batch_path),
+            "--compare",
+            str(
+                Path(__file__).resolve().parent
+                / "fixtures"
+                / "wikidata"
+                / "wikidata_nat_grounding_depth_batch_20260402.json"
+            ),
+            "--compare",
+            str(
+                Path(__file__).resolve().parent
+                / "fixtures"
+                / "wikidata"
+                / "wikidata_nat_grounding_depth_batch_single_20260402.json"
+            ),
+            "--comparison-out",
+            str(comparison_path),
+            "--scorecard-run",
+            "baseline="
+            + str(
+                Path(__file__).resolve().parent
+                / "fixtures"
+                / "wikidata"
+                / "wikidata_nat_grounding_depth_comparison_20260402.json"
+            ),
+            "--scorecard-run",
+            "single="
+            + str(
+                Path(__file__).resolve().parent
+                / "fixtures"
+                / "wikidata"
+                / "wikidata_nat_grounding_depth_comparison_single_20260402.json"
+            ),
+            "--scorecard-out",
+            str(scorecard_path),
+        ]
+    )
+    produced_comparison = json.loads(comparison_path.read_text(encoding="utf-8"))
+    expected_comparison = _load_comparison_fixture()
+    assert produced_comparison == expected_comparison
+    produced_scorecard = json.loads(scorecard_path.read_text(encoding="utf-8"))
+    expected_scorecard = _load_scorecard_fixture()
+    assert produced_scorecard == expected_scorecard

--- a/tests/test_wikidata_projection.py
+++ b/tests/test_wikidata_projection.py
@@ -22,6 +22,7 @@ from src.ontology.wikidata import (
     build_nat_cohort_c_population_scan,
     build_nat_cohort_c_population_scan_from_sparql_results,
     build_nat_cohort_c_population_scan_live,
+    build_nat_cohort_c_operator_packet,
     build_observation_claim_payload_from_source_units,
     build_observation_claim_payload_from_revision_locked_climate_text_sources,
     build_wikidata_split_plan,
@@ -1474,6 +1475,31 @@ def test_nat_cohort_c_live_population_scan_returns_fail_closed_when_query_fails(
         "policy_risk": "high",
     }
     assert payload["failures"][0]["stage"] == "live_query"
+
+
+def test_nat_cohort_c_operator_packet_wraps_scan_payload_with_hold_or_review_decision() -> None:
+    review_scan = _load_nat_cohort_c_population_scan_fixture()
+    review_packet = build_nat_cohort_c_operator_packet(review_scan)
+    assert review_packet["decision"] == "review"
+    assert review_packet["governance"] == {
+        "automation_allowed": False,
+        "fail_closed": True,
+        "live_query_unavailable": False,
+    }
+    assert review_packet["triage_prompts"][0].startswith("Review the candidate P459 status split")
+
+    unavailable_scan = {
+        "lane_id": "wikidata_nat_wdu_p5991_p14143",
+        "cohort_id": "non_ghg_protocol_or_missing_p459",
+        "scan_status": "live_population_scan_unavailable",
+        "summary": {"p459_status_counts": {}, "review_first": True, "policy_risk": "high"},
+        "sample_candidates": [],
+        "notes": ["The live preview helper is fail-closed when the Wikidata query endpoint is unavailable."],
+    }
+    unavailable_packet = build_nat_cohort_c_operator_packet(unavailable_scan)
+    assert unavailable_packet["decision"] == "hold"
+    assert unavailable_packet["governance"]["live_query_unavailable"] is True
+    assert unavailable_packet["triage_prompts"][0].startswith("Live query was unavailable")
 
 
 def test_nat_cohort_a_seed_slice_fixture_pins_business_family_subset_materialization() -> None:

--- a/tests/test_wikidata_projection.py
+++ b/tests/test_wikidata_projection.py
@@ -19,6 +19,7 @@ from src.ontology.wikidata import (
     attach_wikidata_phi_text_bridge_from_source_units,
     attach_wikidata_phi_text_bridge_from_revision_locked_climate_text,
     build_wikidata_review_packet,
+    build_nat_cohort_c_population_scan,
     build_observation_claim_payload_from_source_units,
     build_observation_claim_payload_from_revision_locked_climate_text_sources,
     build_wikidata_split_plan,
@@ -92,6 +93,16 @@ def _load_nat_cohort_c_branch_fixture() -> dict:
         / "fixtures"
         / "wikidata"
         / "wikidata_nat_cohort_c_branch_20260401.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def _load_nat_cohort_c_population_scan_fixture() -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / "wikidata_nat_cohort_c_population_scan_20260402.json"
     )
     return json.loads(fixture_path.read_text(encoding="utf-8"))
 
@@ -1377,6 +1388,27 @@ def test_nat_cohort_c_branch_fixture_pins_non_ghg_or_missing_p459_branch_state()
         "P813",
         "P1476",
         "P2960",
+    ]
+
+
+def test_nat_cohort_c_population_scan_helper_normalizes_review_first_candidates() -> None:
+    payload = _load_nat_cohort_c_population_scan_fixture()
+
+    scan = build_nat_cohort_c_population_scan(payload)
+
+    assert scan["cohort_id"] == "non_ghg_protocol_or_missing_p459"
+    assert scan["scan_status"] == "review_first_population_scan_ready"
+    assert scan["next_gate"] == "review_first_population_scan"
+    assert scan["summary"] == {
+        "candidate_count": 3,
+        "p459_status_counts": {"missing": 2, "non_GHG_protocol": 1},
+        "review_first": True,
+        "policy_risk": "high",
+    }
+    assert [candidate["qid"] for candidate in scan["sample_candidates"]] == [
+        "Q30938280",
+        "Q731938",
+        "Q1785637",
     ]
 
 

--- a/tests/test_wikidata_projection.py
+++ b/tests/test_wikidata_projection.py
@@ -20,6 +20,8 @@ from src.ontology.wikidata import (
     attach_wikidata_phi_text_bridge_from_revision_locked_climate_text,
     build_wikidata_review_packet,
     build_nat_cohort_c_population_scan,
+    build_nat_cohort_c_population_scan_from_sparql_results,
+    build_nat_cohort_c_population_scan_live,
     build_observation_claim_payload_from_source_units,
     build_observation_claim_payload_from_revision_locked_climate_text_sources,
     build_wikidata_split_plan,
@@ -1410,6 +1412,68 @@ def test_nat_cohort_c_population_scan_helper_normalizes_review_first_candidates(
         "Q731938",
         "Q1785637",
     ]
+
+
+def test_nat_cohort_c_live_population_scan_result_normalizer_groups_statement_rows() -> None:
+    sparql_payload = {
+        "results": {
+            "bindings": [
+                {
+                    "item": {"value": "https://www.wikidata.org/entity/Q1"},
+                    "itemLabel": {"value": "Example One"},
+                    "statement": {"value": "https://www.wikidata.org/entity/statement/Q1-abc"},
+                    "qualifier_pid": {"value": "P580"},
+                },
+                {
+                    "item": {"value": "https://www.wikidata.org/entity/Q1"},
+                    "itemLabel": {"value": "Example One"},
+                    "statement": {"value": "https://www.wikidata.org/entity/statement/Q1-abc"},
+                    "qualifier_pid": {"value": "P582"},
+                },
+                {
+                    "item": {"value": "https://www.wikidata.org/entity/Q2"},
+                    "itemLabel": {"value": "Example Two"},
+                    "statement": {"value": "https://www.wikidata.org/entity/statement/Q2-def"},
+                    "p459": {"value": "https://www.wikidata.org/entity/Q999"},
+                    "p459Label": {"value": "Alt standard"},
+                    "qualifier_pid": {"value": "P518"},
+                },
+            ]
+        }
+    }
+
+    scan = build_nat_cohort_c_population_scan_from_sparql_results(sparql_payload)
+
+    assert scan["scan_status"] == "live_population_scan_preview"
+    assert scan["summary"] == {
+        "candidate_count": 2,
+        "p459_status_counts": {"missing": 1, "non_GHG_protocol": 1},
+        "review_first": True,
+        "policy_risk": "high",
+    }
+    assert scan["sample_candidates"][0]["qid"] == "Q1"
+    assert scan["sample_candidates"][0]["p459_status"] == "missing"
+    assert scan["sample_candidates"][0]["qualifier_properties"] == ["P580", "P582"]
+    assert scan["sample_candidates"][1]["qid"] == "Q2"
+    assert scan["sample_candidates"][1]["p459_status"] == "non_GHG_protocol"
+
+
+def test_nat_cohort_c_live_population_scan_returns_fail_closed_when_query_fails(monkeypatch) -> None:
+    def _raise(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("src.ontology.wikidata._http_get_json", _raise)
+
+    payload = build_nat_cohort_c_population_scan_live(row_limit=3, timeout_seconds=1)
+
+    assert payload["scan_status"] == "live_population_scan_unavailable"
+    assert payload["summary"] == {
+        "candidate_count": 0,
+        "p459_status_counts": {},
+        "review_first": True,
+        "policy_risk": "high",
+    }
+    assert payload["failures"][0]["stage"] == "live_query"
 
 
 def test_nat_cohort_a_seed_slice_fixture_pins_business_family_subset_materialization() -> None:

--- a/tests/test_wikidata_projection.py
+++ b/tests/test_wikidata_projection.py
@@ -1551,10 +1551,10 @@ def test_build_wikidata_review_packet_semantic_sidecar_includes_anchor_and_split
     assert "split_context_not_lifted_into_semantic_decision_graph" in semantic["missing_evidence"]
 
 
-def test_nat_review_packet_attachment_coverage_fixture_expands_to_thirteen_rows() -> None:
+def test_nat_review_packet_attachment_coverage_fixture_expands_to_fifteen_rows() -> None:
     payload = _load_nat_review_packet_attachment_coverage_fixture()
 
-    assert payload["packetized_split_rows"] == 13
+    assert payload["packetized_split_rows"] == 15
     assert payload["packetized_split_row_ids"] == [
         "Q10403939|P5991",
         "Q10422059|P5991",
@@ -1569,9 +1569,11 @@ def test_nat_review_packet_attachment_coverage_fixture_expands_to_thirteen_rows(
         "Q731938|P5991",
         "Q10416948|P5991",
         "Q56404383|P5991",
+        "Q1785637|P5991",
+        "Q738421|P5991",
     ]
-    assert len(payload["packet_slots"]) == 13
-    assert payload["ready_for_reviewers"][-1] == "Coverage index showing 13 / 53 packetized rows"
+    assert len(payload["packet_slots"]) == 15
+    assert payload["ready_for_reviewers"][-1] == "Coverage index showing 15 / 53 packetized rows"
 
 
 def test_nat_review_packet_sidecar_fixtures_include_follow_receipts_and_semantic_layers() -> None:

--- a/tests/test_wikidata_projection.py
+++ b/tests/test_wikidata_projection.py
@@ -1532,6 +1532,25 @@ def test_build_wikidata_review_packet_honors_explicit_empty_follow_receipts() ->
     assert "no_follow_receipts" in payload["reviewer_view"]["uncertainty_flags"]
 
 
+def test_build_wikidata_review_packet_semantic_sidecar_includes_anchor_and_split_context_units() -> None:
+    payload = build_wikidata_review_packet(
+        source_unit_payload=_load_nat_wdu_sandbox_source_unit_fixture(),
+        split_plan_payload=_load_nat_cohort_a_split_plan_fixture(),
+        split_plan_id="split://Q10403939|P5991",
+        include_semantic_decomposition=True,
+    )
+
+    semantic = payload["semantic_decomposition"]
+    unit_types = {unit["unit_type"] for unit in semantic["candidate_units"]}
+    assert "follow_receipt_surface" in unit_types
+    assert "anchor_surface" in unit_types
+    assert "split_context_surface" in unit_types
+    assert "missing_evidence_surface" in unit_types
+    assert "split_axis_surface" in unit_types
+    assert "anchor_refs_not_promoted_to_grounded_claims" in semantic["missing_evidence"]
+    assert "split_context_not_lifted_into_semantic_decision_graph" in semantic["missing_evidence"]
+
+
 def test_nat_review_packet_attachment_coverage_fixture_expands_to_thirteen_rows() -> None:
     payload = _load_nat_review_packet_attachment_coverage_fixture()
 
@@ -1564,6 +1583,16 @@ def test_nat_review_packet_sidecar_fixtures_include_follow_receipts_and_semantic
         assert payload["follow_receipts"]
         assert payload["semantic_decomposition"]["separate_from_parsed_page"] is True
         assert payload["semantic_decomposition"]["candidate_units"]
+        unit_types = {
+            unit["unit_type"] for unit in payload["semantic_decomposition"]["candidate_units"]
+        }
+        assert "follow_receipt_surface" in unit_types
+        assert "anchor_surface" in unit_types
+        assert "split_context_surface" in unit_types
+        assert "missing_evidence_surface" in unit_types
+        merged_split_axes = payload["split_review_context"]["merged_split_axes"]
+        if merged_split_axes:
+            assert "split_axis_surface" in unit_types
         assert payload["reviewer_view"]["recommended_next_step"] == expected_step
 
 

--- a/tests/test_wikidata_review_packet_claim_boundaries.py
+++ b/tests/test_wikidata_review_packet_claim_boundaries.py
@@ -1,0 +1,91 @@
+import pytest
+
+from src.ontology.wikidata_review_packet_claim_boundaries import (
+    WIKIDATA_REVIEW_PACKET_CLAIM_BOUNDARY_SCHEMA_VERSION,
+    build_review_packet_claim_boundaries,
+)
+
+
+def _sample_source_surface() -> dict:
+    return {
+        "source_unit_id": "source:1",
+        "source_entity_qid": "Q10403939",
+        "anchor_refs": [
+            {
+                "anchor_id": "a2",
+                "start": 40,
+                "end": 75,
+                "label": "expected_qualifier_family",
+                "text_excerpt": "qualifiers include scope, method, and time dimensions",
+            },
+            {
+                "anchor_id": "a1",
+                "start": 10,
+                "end": 30,
+                "label": "query_surface",
+                "text_excerpt": "all carbon footprint statements",
+            },
+        ],
+    }
+
+
+def _sample_split_review_context() -> dict:
+    return {
+        "split_plan_id": "split://Q10403939|P5991",
+        "merged_split_axes": [
+            {"property": "P518", "source": "slot", "reason": "multi_valued_dimension", "cardinality": 3},
+            {"property": "P580", "source": "slot", "reason": "multi_valued_dimension", "cardinality": 2},
+        ],
+    }
+
+
+def test_build_review_packet_claim_boundaries_maps_anchors_and_axes() -> None:
+    payload = build_review_packet_claim_boundaries(
+        source_surface=_sample_source_surface(),
+        split_review_context=_sample_split_review_context(),
+        page_signals={"unresolved_questions": ["Is scope 3 merged with scope 2?"]},
+    )
+
+    assert payload["schema_version"] == WIKIDATA_REVIEW_PACKET_CLAIM_BOUNDARY_SCHEMA_VERSION
+    assert payload["decomposition_state"] == "candidate_only"
+    assert "not_full_semantic_decomposition" in payload["non_claims"]
+    assert payload["summary"] == {
+        "anchor_count": 2,
+        "axis_count": 2,
+        "candidate_boundary_count": 2,
+        "unresolved_question_count": 1,
+    }
+    first = payload["candidate_claim_boundaries"][0]
+    assert first["anchor_ref"]["anchor_id"] == "a1"
+    assert first["axis_signals"][0]["property"] == "P518"
+    assert "no_clause_level_segmentation" in first["missing_evidence"]
+    assert "open_questions_unresolved" in first["missing_evidence"]
+
+
+def test_build_review_packet_claim_boundaries_produces_axis_only_candidate_without_anchors() -> None:
+    payload = build_review_packet_claim_boundaries(
+        source_surface={"anchor_refs": []},
+        split_review_context=_sample_split_review_context(),
+    )
+
+    assert payload["summary"]["anchor_count"] == 0
+    assert payload["summary"]["axis_count"] == 2
+    assert payload["summary"]["candidate_boundary_count"] == 1
+    only = payload["candidate_claim_boundaries"][0]
+    assert only["anchor_ref"] is None
+    assert only["axis_signals"][1]["property"] == "P580"
+    assert "no_anchor_refs_for_axis_mapping" in only["missing_evidence"]
+
+
+def test_build_review_packet_claim_boundaries_fails_closed_on_invalid_shape() -> None:
+    with pytest.raises(ValueError, match="source_surface\\.anchor_refs must be a list"):
+        build_review_packet_claim_boundaries(
+            source_surface={"anchor_refs": "bad"},
+            split_review_context=_sample_split_review_context(),
+        )
+
+    with pytest.raises(ValueError, match="split_review_context\\.merged_split_axes must be a list"):
+        build_review_packet_claim_boundaries(
+            source_surface=_sample_source_surface(),
+            split_review_context={"merged_split_axes": "bad"},
+        )

--- a/tests/test_wikidata_review_packet_cross_source_alignment.py
+++ b/tests/test_wikidata_review_packet_cross_source_alignment.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from src.ontology import wikidata_review_packet_cross_source_alignment as alignment
+
+
+def _build_surface(
+    *,
+    label: str,
+    identity: str | None = None,
+    fields: list[str] | None = None,
+    source: str | None = None,
+    summary: str | None = None,
+) -> dict[str, object]:
+    data: dict[str, object] = {"source": source or f"surface-{label}"}
+    if identity:
+        data["qid"] = identity
+    if fields:
+        data["fields"] = fields
+    if summary:
+        data["summary"] = summary
+    return data
+
+
+def test_summary_reports_full_alignment_agreement() -> None:
+    result = alignment.summarize_cross_source_alignment(
+        packet_id="packet-1",
+        wiki_surface=_build_surface(
+            label="wiki",
+            identity="Q123",
+            fields=["P2738", "P31"],
+            summary="Disjointness case from the wiki surface.",
+        ),
+        query_slice=_build_surface(
+            label="query",
+            identity="Q123",
+            fields=["P2738", "P11260"],
+            summary="Query slice that mirrors the same entity.",
+        ),
+        split_bundle=_build_surface(
+            label="split",
+            identity="Q123",
+            fields=["P2738"],
+            summary="Held split bundle for the disjoint set.",
+        ),
+    )
+
+    assert result["schema_version"] == alignment.CROSS_SOURCE_ALIGNMENT_SCHEMA_VERSION
+    assert result["packet_id"] == "packet-1"
+    assert result["consensus_level"] == "full_consensus"
+    assert result["consensus_identity"] == "Q123"
+    assert result["common_fields"] == ["P2738"]
+    assert any("Shared entity id" in note for note in result["agreements"])
+    assert "fields documented" not in " ".join(result["disagreements"])
+    for signature in result["pairwise_signatures"]:
+        assert signature["field_overlap"]
+
+
+def test_summary_notes_identity_disagreement() -> None:
+    result = alignment.summarize_cross_source_alignment(
+        packet_id="packet-2",
+        wiki_surface=_build_surface(label="wiki", identity="Q123", fields=["P31"]),
+        query_slice=_build_surface(label="query", identity="Q456", fields=["P31"]),
+        split_bundle=_build_surface(label="split", fields=["P31"]),
+    )
+
+    assert result["consensus_level"] == "no_consensus"
+    assert result["consensus_identity"] == ""
+    assert any("No consistent entity identifier" in note for note in result["disagreements"])

--- a/tests/test_wikidata_review_packet_follow_depth.py
+++ b/tests/test_wikidata_review_packet_follow_depth.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import pytest
+
+from src.ontology import wikidata_review_packet_follow_depth as follow_depth
+
+
+def _build_receipt(
+    *,
+    url: str,
+    extracted_evidence: Sequence[str] | None = None,
+    unresolved_uncertainty: Sequence[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "receipt_id": "receipt-for-" + url,
+        "url": url,
+        "extracted_evidence": extracted_evidence,
+        "unresolved_uncertainty": unresolved_uncertainty,
+    }
+
+
+def test_enrich_follow_receipt_from_extracted_evidence() -> None:
+    raw = _build_receipt(
+        url="https://example.org/follow/1",
+        extracted_evidence=[
+            "The extracted detail describes the migration step.",
+            "Second snippet elaborates on qualifier propagation.",
+        ],
+    )
+    enriched = follow_depth.enrich_follow_receipt_with_depth(
+        raw,
+        max_excerpt_chars=200,
+    )
+    assert enriched["status"] == "enriched"
+    assert enriched["excerpt_source"] == "extracted_evidence"
+    assert enriched["evidence_excerpt"] == "The extracted detail describes the migration step."
+    assert enriched["evidence_summary"] == (
+        "The extracted detail describes the migration step.; Second snippet elaborates on qualifier propagation."
+    )
+    assert "failure_reason" not in enriched
+
+
+def test_enrich_follow_receipt_from_source_text_when_no_evidence() -> None:
+    raw = _build_receipt(
+        url="https://example.org/follow/2",
+        extracted_evidence=None,
+        unresolved_uncertainty=["initial_uncertainty"],
+    )
+    enriched = follow_depth.enrich_follow_receipt_with_depth(
+        raw,
+        source_text="   Source text with newlines\nand multi-spaces   ",
+        max_excerpt_chars=100,
+    )
+    assert enriched["status"] == "enriched"
+    assert enriched["excerpt_source"] == "source_text"
+    assert enriched["evidence_excerpt"] == "Source text with newlines and multi-spaces"
+    assert enriched["evidence_summary"] == "derived_from_bounded_source_text"
+    assert "excerpt_derived_without_explicit_extracted_evidence" in enriched["unresolved_uncertainty"]
+
+
+def test_enrich_follow_receipt_with_no_excerpt_data() -> None:
+    raw = _build_receipt(url="https://example.org/follow/3", extracted_evidence=None)
+    enriched = follow_depth.enrich_follow_receipt_with_depth(raw)
+    assert enriched["status"] == "no_excerpt_available"
+    assert enriched["failure_reason"] == "no_extracted_evidence_or_source_text"
+
+
+def test_enrich_review_packet_receipts_tracks_counts() -> None:
+    follow_receipts = [
+        _build_receipt(
+            url="https://example.org/follow/1",
+            extracted_evidence=["evidence one"],
+        ),
+        _build_receipt(
+            url="https://example.org/follow/2",
+            extracted_evidence=None,
+        ),
+    ]
+    review_packet = {
+        "packet_id": "packet-123",
+        "follow_receipts": follow_receipts,
+    }
+    enriched = follow_depth.enrich_review_packet_follow_depth(
+        review_packet,
+        source_text_by_url={"https://example.org/follow/2": "Replacement source text"},
+    )
+    assert enriched["schema_version"] == follow_depth.FOLLOW_DEPTH_SCHEMA_VERSION
+    assert enriched["packet_id"] == "packet-123"
+    assert enriched["receipt_count"] == 2
+    assert enriched["enriched_count"] == 2
+    assert enriched["no_excerpt_count"] == 0
+    assert {receipt["status"] for receipt in enriched["receipts"]} == {"enriched"}
+    assert enriched["receipts"][1]["excerpt_source"] == "source_text"
+

--- a/tests/test_wikidata_review_packet_reviewer_actions.py
+++ b/tests/test_wikidata_review_packet_reviewer_actions.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.ontology.wikidata_review_packet_reviewer_actions import (
+    WIKIDATA_REVIEW_PACKET_REVIEWER_ACTIONS_SCHEMA_VERSION,
+    build_wikidata_review_packet_reviewer_actions,
+)
+
+
+def _load_nat_packet_fixture(name: str) -> dict:
+    fixture_path = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "wikidata"
+        / name
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def test_build_reviewer_actions_for_structured_split_packet() -> None:
+    packet = _load_nat_packet_fixture("wikidata_nat_review_packet_Q10416948_sidecar_20260402.json")
+    actions = build_wikidata_review_packet_reviewer_actions(packet)
+
+    assert actions["schema_version"] == WIKIDATA_REVIEW_PACKET_REVIEWER_ACTIONS_SCHEMA_VERSION
+    assert actions["packet_id"] == packet["packet_id"]
+    assert actions["review_entity_qid"] == "Q10416948"
+    assert actions["likely_decision"] == "review_structured_split"
+    assert actions["smallest_next_check"]["check_id"] == "confirm_first_split_axis"
+    assert "split_plan_requires_review" in actions["why_this_row_is_in_review"]
+    assert "split_axes_detected=2" in actions["why_this_row_is_in_review"]
+    assert actions["can_execute_edits"] is False
+
+
+def test_build_reviewer_actions_for_review_only_packet() -> None:
+    packet = _load_nat_packet_fixture("wikidata_nat_review_packet_Q56404383_sidecar_20260402.json")
+    actions = build_wikidata_review_packet_reviewer_actions(packet)
+
+    assert actions["likely_decision"] == "review_only"
+    assert actions["smallest_next_check"]["check_id"] == "resolve_one_page_question"
+    assert any(reason == "split_status=review_only" for reason in actions["why_this_row_is_in_review"])
+    assert "uncertainty=page_open_questions" in actions["why_this_row_is_in_review"]
+
+
+def test_build_reviewer_actions_requires_split_context_and_reviewer_view() -> None:
+    with pytest.raises(ValueError, match="split_review_context"):
+        build_wikidata_review_packet_reviewer_actions({"reviewer_view": {}})
+    with pytest.raises(ValueError, match="reviewer_view"):
+        build_wikidata_review_packet_reviewer_actions({"split_review_context": {}})

--- a/tests/test_wikidata_review_packet_semantics.py
+++ b/tests/test_wikidata_review_packet_semantics.py
@@ -64,3 +64,25 @@ def test_review_packet_semantic_layer_exposes_missing_evidence_boundary() -> Non
     }
     assert "no_claim_boundary_mapping_for_candidate_units" in layer["missing_evidence"]
     assert "query_rows_not_expanded_into_fetched_semantic_units" in layer["missing_evidence"]
+
+
+def test_review_packet_semantic_layer_includes_helper_surfaces_and_non_authoritative_variant_comparison() -> None:
+    payload = build_wikidata_review_packet(
+        source_unit_payload=_load_nat_wdu_sandbox_source_unit_fixture(),
+        split_plan_payload=_load_nat_cohort_a_split_plan_fixture(),
+        split_plan_id="split://Q10403939|P5991",
+        include_semantic_decomposition=True,
+    )
+
+    layer = payload["semantic_decomposition"]
+    assert layer["follow_depth"]["receipt_count"] == len(payload["follow_receipts"])
+    assert layer["claim_boundaries"]["schema_version"].startswith("sl.wikidata_review_packet.claim_boundaries")
+    assert layer["cross_source_alignment"]["schema_version"].startswith(
+        "sl.wikidata_review_packet.cross_source_alignment"
+    )
+    assert "consensus_level" in layer["cross_source_alignment"]
+    assert layer["reviewer_actions"]["can_execute_edits"] is False
+    assert layer["variant_comparison"]["non_authoritative"] is True
+    assert "no_comparisons_provided" not in layer["variant_comparison"]["diagnostic_flags"]
+    assert layer["variant_comparison"]["comparisons"]
+    assert layer["variant_comparison"]["comparisons"][0]["comparison_id"] == "split://Q10422059|P5991"

--- a/tests/test_wikidata_review_packet_variant_compare.py
+++ b/tests/test_wikidata_review_packet_variant_compare.py
@@ -1,0 +1,91 @@
+from typing import Mapping, Sequence
+
+from src.ontology.wikidata_review_packet_variant_compare import (
+    compare_review_packet_variants,
+)
+
+
+def _base_variant() -> dict[str, object]:
+    return {
+        "candidate_id": "Q1|P5991|1",
+        "classification": "split_required",
+        "suggested_action": "review_structured_split",
+        "merged_split_axes": [
+            {"property": "__value__", "cardinality": 2, "reason": "multi_value"},
+            {"property": "P3831", "cardinality": 1, "reason": "role"},
+        ],
+    }
+
+
+def _variant_with_axes(axes: Sequence[Mapping[str, object]]) -> dict[str, object]:
+    return {
+        "candidate_id": "Q1|P5991|2",
+        "classification": "split_required",
+        "suggested_action": "review_structured_split",
+        "merged_split_axes": [dict(axis) for axis in axes],
+    }
+
+
+def test_compare_review_packet_variants_agreement() -> None:
+    primary = _base_variant()
+    comparison = _variant_with_axes(
+        [
+            {"property": "__value__", "cardinality": 2, "reason": "multi_value"},
+            {"property": "P3831", "cardinality": 1, "reason": "role"},
+        ]
+    )
+
+    surface = compare_review_packet_variants(
+        primary_variant=primary,
+        comparison_variants=[comparison],
+    )
+
+    assert surface["primary_candidate_id"] == "Q1|P5991|1"
+    assert surface["diagnostic_flags"] == []
+    assert surface["comparisons"][0]["status"] == "agreement"
+    assert "__value__" in surface["comparisons"][0]["agreements"]
+
+
+def test_compare_review_packet_variants_disagreement_and_limits() -> None:
+    primary = _base_variant()
+    comparison_a = _variant_with_axes(
+        [
+            {"property": "__value__", "cardinality": 3, "reason": "multi_value"},
+            {"property": "P3831", "cardinality": 1, "reason": "role"},
+        ]
+    )
+    comparison_b = _variant_with_axes(
+        [
+            {"property": "__value__", "cardinality": 2, "reason": "multi_value"},
+            {"property": "P3831", "cardinality": 1, "reason": "role"},
+        ]
+    )
+    comparison_c = _variant_with_axes(
+        [
+            {"property": "__value__", "cardinality": 2, "reason": "multi_value"},
+            {"property": "P3831", "cardinality": 2, "reason": "role"},
+        ]
+    )
+
+    surface = compare_review_packet_variants(
+        primary_variant=primary,
+        comparison_variants=[comparison_a, comparison_b, comparison_c],
+        max_variants=2,
+    )
+
+    comparisons = surface["comparisons"]
+    assert len(comparisons) == 2
+    assert comparisons[0]["status"] == "disagreement"
+    assert "__value__" in comparisons[0]["disagreements"]
+    assert comparisons[1]["status"] == "agreement"
+    assert surface["diagnostic_flags"] == []
+
+
+def test_compare_review_packet_variants_missing_axes() -> None:
+    surface = compare_review_packet_variants(
+        primary_variant={"candidate_id": "Q1|P5991|1"},
+        comparison_variants=[],
+    )
+
+    assert "primary_variant_missing_axes" in surface["diagnostic_flags"]
+    assert "no_comparisons_provided" in surface["diagnostic_flags"]


### PR DESCRIPTION
This continues the Nat Wikidata review-packet work with the non-company axis split and the reviewer-packet grounding improvements.

What changed:
- Added explicit review-first lanes for Cohort B (reconciled non-business `instance of`), Cohort C (non-GHG / missing `P459`), Cohort D (no `instance of`), and Cohort E (unreconciled `instance of`).
- Expanded Nat reviewer-packet coverage to `15 / 53`, including the new wider-online rows `Q1785637` and `Q738421`.
- Added the corresponding planning notes and fixtures for the new lanes.

Why:
- The company tranche is now just calibration.
- The next highest-yield work is the structurally different non-company axis, which is more likely to change reviewer behavior and surface new uncertainty.

Impact:
- Nat now has explicit review-first lanes for the non-company axis.
- The packet coverage surface is broader and remains fail-closed.
- The repo now has a clearer path from packet grounding to the next review cohorts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added operator commands for cohorts C, D, and E to generate evidence packets, diagnostic reports, and control indexes
  * Introduced automation graduation evaluation system with multi-gate promotion criteria and repeated-run validation
  * Added grounding depth evidence packaging with attachment, batch, and scorecard support
  * Expanded semantic decomposition with follow receipt enrichment, claim boundaries, and cross-source alignment analysis
  * Added cohort E diagnostics for axis disagreement tracking and reconciliation support

* **Documentation**
  * Documented comprehensive governance framework with graduation criteria and fail-closed control surfaces
  * Added operator guidance for review-first packetization and evidence workflows across cohorts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->