### PR TITLE
Complete typed resolution evidence loop

### DIFF
--- a/docs/planning/typed_resolution_loop_completion_20260718.md
+++ b/docs/planning/typed_resolution_loop_completion_20260718.md
@@ -1,0 +1,43 @@
+# Typed Resolution Loop Completion
+
+Date: 2026-07-18
+Status: implemented review branch
+
+This tranche completes the semantic back half after the registry-neutral P0c.5 scheduler.
+
+## Implemented
+
+- deterministic document-local evidence projection;
+- revision-pinned Wikidata snapshot adaptation;
+- WorldMonitor snapshot adaptation preserving occurrence, observation, cluster, forecast, report, alert, and rolling-state roles;
+- coordinate-wise entity and event reconciliation without scalar-only identity closure;
+- factor-local PartialPNF refinement receipts;
+- review-only readiness outcomes: `promote | hold | abstain | audit`;
+- compact GWB and AU end-to-end proof fixtures;
+- minimal append-only SQLite artifact storage.
+
+## Authority boundaries
+
+Evidence snapshots do not select identities. Reconciliation assessments do not promote claims. PNF refinement changes only the named factor and emits an unchanged-factor witness. Readiness promotion means review eligibility only and carries no editing authority.
+
+## Event compatibility
+
+Event reconciliation retains independent coordinates for:
+
+- temporal relation;
+- spatial relation;
+- participant-role relation;
+- event-type relation;
+- linguistic form relation;
+- source lineage;
+- observation-to-occurrence role.
+
+WorldMonitor records are never coerced into occurrences. An observation, cluster, forecast, report, alert, or rolling state remains that formal artifact unless a later typed relation connects it to an occurrence.
+
+## Proof outcomes
+
+The AU fixture closes a court identity through shared entity/type/form obligations and reaches review promotion. The GWB fixture resolves the person identity but remains held on the event factor because event lineage or occurrence evidence is not fully closed. This difference is intentional: the proof demonstrates that the readiness oracle preserves a real unresolved residual rather than forcing a successful result.
+
+## Operational boundary
+
+The append-only SQLite store is intentionally minimal. It persists immutable demand/evidence/assessment/refinement artifacts without freezing a universal graph schema. Live network calls, production endpoint discovery, asynchronous workers, large-corpus columnar projections, and broad replay remain deployment work above the now-proven semantic interfaces.

--- a/src/policy/resolution_evidence.py
+++ b/src/policy/resolution_evidence.py
@@ -1,0 +1,831 @@
+"""Typed evidence, reconciliation, PNF refinement, and readiness carriers.
+
+Evidence acquisition never selects identity; reconciliation never promotes a
+claim; refinement changes only a declared PNF factor; readiness remains
+review-only and carries no editing authority.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+import hashlib
+import json
+from typing import Any, Iterable, Mapping, Sequence
+
+EVIDENCE_AUTHORITY = "evidence_only"
+ASSESSMENT_AUTHORITY = "assessment_only"
+REFINEMENT_AUTHORITY = "pnf_refinement_only"
+READINESS_AUTHORITY = "review_only"
+
+
+def _text(value: Any, field_name: str) -> str:
+    value = str(value or "").strip()
+    if not value:
+        raise ValueError(f"{field_name} is required")
+    return value
+
+
+def _refs(values: Iterable[Any] | None) -> tuple[str, ...]:
+    return tuple(sorted({_text(value, "reference") for value in values or ()}))
+
+
+def _json(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    encoded = json.dumps(dict(value or {}), sort_keys=True, separators=(",", ":"))
+    decoded = json.loads(encoded)
+    if not isinstance(decoded, dict):
+        raise ValueError("payload must be a JSON object")
+    return decoded
+
+
+def _digest(value: Any) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class EvidenceRole(str, Enum):
+    ENTITY = "entity"
+    EVENT_TYPE = "event_type"
+    OCCURRENCE = "occurrence"
+    OBSERVATION = "observation"
+    CLUSTER = "cluster"
+    FORECAST = "forecast"
+    REPORT = "report"
+    ALERT = "alert"
+    ROLLING_STATE = "rolling_state"
+    PROPERTY_OR_RELATION = "property_or_relation"
+    DOCUMENT_LOCAL_CLUSTER = "document_local_cluster"
+
+
+class MeetState(str, Enum):
+    COMPATIBLE = "compatible"
+    COMPATIBLE_WITH_REFINEMENT = "compatible_with_refinement"
+    UNRESOLVED = "unresolved"
+    NOT_APPLICABLE = "not_applicable"
+    NO_TYPED_MEET = "no_typed_meet"
+    CONTRADICTION = "contradiction"
+    NOT_EVALUATED = "not_evaluated"
+
+
+class ResolutionOutcome(str, Enum):
+    RESOLVED = "resolved"
+    POSSIBLE_SAME = "possible_same"
+    RELATED_DISTINCT = "related_distinct"
+    NO_TYPED_MEET = "no_typed_meet"
+    CONTRADICTION = "contradiction"
+    NOT_EVALUATED = "not_evaluated"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+
+
+class ReadinessOutcome(str, Enum):
+    PROMOTE = "promote"
+    HOLD = "hold"
+    ABSTAIN = "abstain"
+    AUDIT = "audit"
+
+
+@dataclass(frozen=True)
+class ResolutionEvidenceSnapshot:
+    snapshot_ref: str
+    backend_ref: str
+    subject_ref: str
+    evidence_role: EvidenceRole | str
+    external_ref: str | None = None
+    labels: tuple[str, ...] = ()
+    aliases: tuple[str, ...] = ()
+    type_refs: tuple[str, ...] = ()
+    temporal: Mapping[str, Any] = field(default_factory=dict)
+    spatial: Mapping[str, Any] = field(default_factory=dict)
+    participants: Mapping[str, Sequence[str]] = field(default_factory=dict)
+    relations: Mapping[str, Sequence[str]] = field(default_factory=dict)
+    lineage_refs: tuple[str, ...] = ()
+    observation_refs: tuple[str, ...] = ()
+    revision_ref: str | None = None
+    fetched_at: str | None = None
+    provenance_refs: tuple[str, ...] = ()
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        provenance = _refs(self.provenance_refs)
+        if not provenance:
+            raise ValueError("evidence snapshots require provenance")
+        row = {
+            "schema_version": "sl.resolution_evidence.v0_1",
+            "snapshot_ref": _text(self.snapshot_ref, "snapshot_ref"),
+            "backend_ref": _text(self.backend_ref, "backend_ref"),
+            "subject_ref": _text(self.subject_ref, "subject_ref"),
+            "evidence_role": EvidenceRole(self.evidence_role).value,
+            "labels": list(_refs(self.labels)),
+            "aliases": list(_refs(self.aliases)),
+            "type_refs": list(_refs(self.type_refs)),
+            "temporal": _json(self.temporal),
+            "spatial": _json(self.spatial),
+            "participants": {
+                _text(role, "participant role"): list(_refs(refs))
+                for role, refs in sorted(self.participants.items())
+            },
+            "relations": {
+                _text(kind, "relation kind"): list(_refs(refs))
+                for kind, refs in sorted(self.relations.items())
+            },
+            "lineage_refs": list(_refs(self.lineage_refs)),
+            "observation_refs": list(_refs(self.observation_refs)),
+            "provenance_refs": list(provenance),
+            "payload": _json(self.payload),
+            "authority": EVIDENCE_AUTHORITY,
+        }
+        for key, value in (
+            ("external_ref", self.external_ref),
+            ("revision_ref", self.revision_ref),
+            ("fetched_at", self.fetched_at),
+        ):
+            if value:
+                row[key] = _text(value, key)
+        row["snapshot_sha256"] = _digest(row)
+        return row
+
+
+def build_document_local_evidence(
+    *,
+    demand: Mapping[str, Any],
+    mentions: Sequence[Mapping[str, Any]],
+    form_relations: Sequence[Mapping[str, Any]] = (),
+    coreference_clusters: Sequence[Mapping[str, Any]] = (),
+    local_types: Sequence[Mapping[str, Any]] = (),
+    discourse_relations: Sequence[Mapping[str, Any]] = (),
+) -> tuple[ResolutionEvidenceSnapshot, ...]:
+    """Project all matching local evidence without choosing an identity."""
+    demand_ref = _text(demand.get("demand_ref"), "demand_ref")
+    mention_ref = _text(demand.get("mention_ref"), "mention_ref")
+    mention = next(
+        (row for row in mentions if str(row.get("mention_ref")) == mention_ref), None
+    )
+    if not mention:
+        return ()
+    document_ref = _text(mention.get("document_ref"), "document_ref")
+    subject_ref = str(demand.get("subject_ref") or mention_ref)
+    snapshots: list[ResolutionEvidenceSnapshot] = []
+    for cluster in sorted(
+        coreference_clusters, key=lambda row: str(row.get("cluster_ref"))
+    ):
+        members = {str(ref) for ref in cluster.get("mention_refs") or ()}
+        if mention_ref not in members:
+            continue
+        if str(cluster.get("document_ref") or document_ref) != document_ref:
+            continue
+        snapshots.append(
+            ResolutionEvidenceSnapshot(
+                snapshot_ref=f"local:{demand_ref}:cluster:{cluster['cluster_ref']}",
+                backend_ref="document_local",
+                subject_ref=subject_ref,
+                evidence_role=EvidenceRole.DOCUMENT_LOCAL_CLUSTER,
+                external_ref=str(cluster["cluster_ref"]),
+                labels=(str(mention.get("canonical_surface") or ""),),
+                relations={"corefers_with": tuple(sorted(members - {mention_ref}))},
+                provenance_refs=(
+                    f"document:{document_ref}",
+                    f"cluster:{cluster['cluster_ref']}",
+                ),
+                payload={"member_mentions": sorted(members)},
+            )
+        )
+    for local_type in sorted(
+        local_types, key=lambda row: str(row.get("type_ref"))
+    ):
+        if str(local_type.get("mention_ref")) != mention_ref:
+            continue
+        types = local_type.get("type_refs") or (local_type.get("local_type"),)
+        snapshots.append(
+            ResolutionEvidenceSnapshot(
+                snapshot_ref=f"local:{demand_ref}:type:{local_type.get('type_ref')}",
+                backend_ref="document_local",
+                subject_ref=subject_ref,
+                evidence_role=EvidenceRole.ENTITY,
+                labels=(str(mention.get("canonical_surface") or ""),),
+                type_refs=tuple(str(value) for value in types if value),
+                provenance_refs=tuple(
+                    local_type.get("provenance_refs")
+                    or (f"document:{document_ref}",)
+                ),
+                payload={"local_type": dict(local_type)},
+            )
+        )
+    related_forms = [
+        row
+        for row in form_relations
+        if mention_ref
+        in {
+            str(row.get("left_mention_ref")),
+            str(row.get("right_mention_ref")),
+            str(row.get("mention_ref")),
+        }
+    ]
+    related_discourse = [
+        row
+        for row in discourse_relations
+        if mention_ref
+        in {
+            str(row.get("left_ref")),
+            str(row.get("right_ref")),
+            str(row.get("mention_ref")),
+        }
+    ]
+    if related_forms or related_discourse:
+        snapshots.append(
+            ResolutionEvidenceSnapshot(
+                snapshot_ref=f"local:{demand_ref}:relations",
+                backend_ref="document_local",
+                subject_ref=subject_ref,
+                evidence_role=EvidenceRole.ENTITY,
+                labels=(str(mention.get("canonical_surface") or ""),),
+                relations={
+                    "form_relation": tuple(
+                        str(row.get("relation_ref")) for row in related_forms
+                    ),
+                    "discourse_relation": tuple(
+                        str(row.get("relation_ref")) for row in related_discourse
+                    ),
+                },
+                provenance_refs=(f"document:{document_ref}",),
+            )
+        )
+    return tuple(snapshots)
+
+
+def adapt_wikidata_snapshot(
+    *,
+    subject_ref: str,
+    entity: Mapping[str, Any],
+    requested_revision: str,
+    provenance_refs: Sequence[str],
+) -> ResolutionEvidenceSnapshot:
+    entity_id = _text(entity.get("id") or entity.get("entity_id"), "entity id")
+    revision = _text(entity.get("revision") or entity.get("lastrevid"), "revision")
+    if revision != _text(requested_revision, "requested revision"):
+        raise ValueError("Wikidata snapshot revision does not match requested revision")
+    labels = entity.get("labels") or ()
+    if isinstance(labels, Mapping):
+        labels = tuple(
+            str(value.get("value") if isinstance(value, Mapping) else value)
+            for value in labels.values()
+        )
+    aliases = entity.get("aliases") or ()
+    if isinstance(aliases, Mapping):
+        aliases = tuple(
+            str(alias.get("value") if isinstance(alias, Mapping) else alias)
+            for values in aliases.values()
+            for alias in (
+                values
+                if isinstance(values, Sequence) and not isinstance(values, str)
+                else (values,)
+            )
+        )
+    properties = entity.get("properties") or entity.get("claims") or {}
+    type_refs: list[str] = []
+    relations: dict[str, tuple[str, ...]] = {}
+    if isinstance(properties, Mapping):
+        for prop, values in properties.items():
+            refs: list[str] = []
+            rows = (
+                values
+                if isinstance(values, Sequence) and not isinstance(values, (str, bytes))
+                else (values,)
+            )
+            for value in rows:
+                if not isinstance(value, Mapping):
+                    continue
+                ref = value.get("entity_ref") or value.get("value") or value.get("id")
+                if isinstance(ref, Mapping):
+                    ref = ref.get("id")
+                if ref:
+                    refs.append(str(ref))
+            if refs:
+                relations[str(prop)] = tuple(refs)
+                if str(prop) in {"P31", "P279"}:
+                    type_refs.extend(refs)
+    return ResolutionEvidenceSnapshot(
+        snapshot_ref=f"wikidata:{entity_id}@{revision}",
+        backend_ref="wikidata",
+        subject_ref=subject_ref,
+        evidence_role=EvidenceRole.ENTITY,
+        external_ref=entity_id,
+        labels=tuple(labels),
+        aliases=tuple(aliases),
+        type_refs=tuple(type_refs),
+        relations=relations,
+        revision_ref=revision,
+        provenance_refs=tuple(provenance_refs),
+        payload={"requested_revision": requested_revision},
+    )
+
+
+def adapt_worldmonitor_snapshot(
+    *,
+    subject_ref: str,
+    record: Mapping[str, Any],
+    record_role: EvidenceRole | str,
+    snapshot_version: str,
+    provenance_refs: Sequence[str],
+) -> ResolutionEvidenceSnapshot:
+    role = EvidenceRole(record_role)
+    if role not in {
+        EvidenceRole.OCCURRENCE,
+        EvidenceRole.OBSERVATION,
+        EvidenceRole.CLUSTER,
+        EvidenceRole.FORECAST,
+        EvidenceRole.REPORT,
+        EvidenceRole.ALERT,
+        EvidenceRole.ROLLING_STATE,
+    }:
+        raise ValueError("WorldMonitor records require an event formal role")
+    record_id = _text(
+        record.get("id") or record.get("canonical_id"), "WorldMonitor record id"
+    )
+    temporal = {
+        key: record[key]
+        for key in (
+            "date",
+            "started_at",
+            "ended_at",
+            "observed_at",
+            "reported_at",
+            "updated_at",
+            "forecast_for",
+        )
+        if record.get(key) is not None
+    }
+    spatial = {
+        key: record[key]
+        for key in ("lat", "lon", "location", "country", "region", "geometry")
+        if record.get(key) is not None
+    }
+    participants = record.get("participants") or {}
+    if not isinstance(participants, Mapping):
+        participants = {"participant": tuple(str(value) for value in participants)}
+    types = tuple(
+        str(value)
+        for value in (
+            record.get("category"),
+            record.get("category_title"),
+            record.get("classification"),
+            record.get("event_type"),
+        )
+        if value
+    )
+    observations = record.get("agency_observations") or record.get("observations") or ()
+    observation_refs = tuple(
+        str(row.get("id") or row.get("agency_id") or index)
+        for index, row in enumerate(observations)
+        if isinstance(row, Mapping)
+    )
+    lineage = tuple(
+        str(value)
+        for value in (
+            record.get("source_name"),
+            record.get("source_url"),
+            *(record.get("lineage_refs") or ()),
+        )
+        if value
+    )
+    labels = tuple(
+        str(value)
+        for value in (record.get("title"), record.get("storm_name"), record.get("name"))
+        if value
+    )
+    return ResolutionEvidenceSnapshot(
+        snapshot_ref=f"worldmonitor:{record_id}@{_text(snapshot_version, 'snapshot version')}",
+        backend_ref="worldmonitor",
+        subject_ref=subject_ref,
+        evidence_role=role,
+        external_ref=record_id,
+        labels=labels,
+        aliases=tuple(str(value) for value in record.get("canonical_aliases") or ()),
+        type_refs=types,
+        temporal=temporal,
+        spatial=spatial,
+        participants=participants,
+        lineage_refs=lineage,
+        observation_refs=observation_refs,
+        revision_ref=snapshot_version,
+        provenance_refs=tuple(provenance_refs),
+        payload={
+            "closed": record.get("closed"),
+            "magnitude": record.get("magnitude"),
+            "magnitude_unit": record.get("magnitude_unit"),
+            "matching_confidence": record.get("matching_confidence"),
+        },
+    )
+
+
+@dataclass(frozen=True)
+class CompatibilityCoordinate:
+    coordinate: str
+    state: MeetState | str
+    relation: str | None = None
+    evidence_refs: tuple[str, ...] = ()
+    residual_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        row = {
+            "coordinate": _text(self.coordinate, "coordinate"),
+            "state": MeetState(self.state).value,
+            "evidence_refs": list(_refs(self.evidence_refs)),
+            "residual_refs": list(_refs(self.residual_refs)),
+        }
+        if self.relation:
+            row["relation"] = _text(self.relation, "relation")
+        return row
+
+
+@dataclass(frozen=True)
+class ResolutionAssessment:
+    assessment_ref: str
+    subject_ref: str
+    left_ref: str
+    right_ref: str
+    subject_kind: str
+    coordinates: tuple[CompatibilityCoordinate, ...]
+    outcome: ResolutionOutcome | str
+    selected_identity_ref: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        rows = tuple(
+            sorted(
+                (coordinate.to_dict() for coordinate in self.coordinates),
+                key=lambda row: row["coordinate"],
+            )
+        )
+        states = {row["state"] for row in rows}
+        outcome = ResolutionOutcome(self.outcome)
+        if "contradiction" in states and outcome != ResolutionOutcome.CONTRADICTION:
+            raise ValueError("contradictory coordinates require contradiction outcome")
+        if "no_typed_meet" in states and outcome not in {
+            ResolutionOutcome.NO_TYPED_MEET,
+            ResolutionOutcome.CONTRADICTION,
+        }:
+            raise ValueError("no-typed-meet coordinates cannot resolve")
+        if outcome == ResolutionOutcome.RESOLVED and not self.selected_identity_ref:
+            raise ValueError("resolved assessments require selected_identity_ref")
+        row = {
+            "schema_version": "sl.resolution_assessment.v0_1",
+            "assessment_ref": _text(self.assessment_ref, "assessment_ref"),
+            "subject_ref": _text(self.subject_ref, "subject_ref"),
+            "left_ref": _text(self.left_ref, "left_ref"),
+            "right_ref": _text(self.right_ref, "right_ref"),
+            "subject_kind": _text(self.subject_kind, "subject_kind"),
+            "coordinates": list(rows),
+            "outcome": outcome.value,
+            "authority": ASSESSMENT_AUTHORITY,
+        }
+        if self.selected_identity_ref:
+            row["selected_identity_ref"] = _text(
+                self.selected_identity_ref, "selected_identity_ref"
+            )
+        row["assessment_sha256"] = _digest(row)
+        return row
+
+
+def _set_relation(left: Iterable[str], right: Iterable[str]) -> tuple[MeetState, str]:
+    left_set, right_set = set(left), set(right)
+    if not left_set or not right_set:
+        return MeetState.UNRESOLVED, "missing_coordinate"
+    if left_set == right_set:
+        return MeetState.COMPATIBLE, "equal"
+    if left_set.intersection(right_set):
+        return MeetState.COMPATIBLE_WITH_REFINEMENT, "overlap"
+    return MeetState.NO_TYPED_MEET, "disjoint"
+
+
+def assess_entity_resolution(
+    *, subject_ref: str, local: Mapping[str, Any], snapshot: Mapping[str, Any]
+) -> ResolutionAssessment:
+    type_state, type_relation = _set_relation(
+        local.get("type_refs") or (), snapshot.get("type_refs") or ()
+    )
+    local_labels = tuple(
+        str(value).casefold()
+        for value in (*tuple(local.get("labels") or ()), *tuple(local.get("aliases") or ()))
+    )
+    external_labels = tuple(
+        str(value).casefold()
+        for value in (
+            *tuple(snapshot.get("labels") or ()),
+            *tuple(snapshot.get("aliases") or ()),
+        )
+    )
+    form_state, form_relation = _set_relation(local_labels, external_labels)
+    coordinates = (
+        CompatibilityCoordinate(
+            "type", type_state, type_relation, (str(snapshot.get("snapshot_ref")),)
+        ),
+        CompatibilityCoordinate(
+            "form", form_state, form_relation, (str(snapshot.get("snapshot_ref")),)
+        ),
+    )
+    if type_state == MeetState.NO_TYPED_MEET or form_state == MeetState.NO_TYPED_MEET:
+        outcome, selected = ResolutionOutcome.NO_TYPED_MEET, None
+    elif type_state == MeetState.COMPATIBLE and form_state in {
+        MeetState.COMPATIBLE,
+        MeetState.COMPATIBLE_WITH_REFINEMENT,
+    }:
+        outcome, selected = ResolutionOutcome.RESOLVED, snapshot.get("external_ref")
+    else:
+        outcome, selected = ResolutionOutcome.POSSIBLE_SAME, None
+    return ResolutionAssessment(
+        assessment_ref=f"assessment:{_digest([subject_ref, local, snapshot])[:16]}",
+        subject_ref=subject_ref,
+        left_ref=str(local.get("local_ref") or local.get("mention_ref") or subject_ref),
+        right_ref=str(snapshot.get("snapshot_ref")),
+        subject_kind="entity",
+        coordinates=coordinates,
+        outcome=outcome,
+        selected_identity_ref=str(selected) if selected else None,
+    )
+
+
+def assess_event_resolution(
+    *, subject_ref: str, local: Mapping[str, Any], snapshot: Mapping[str, Any]
+) -> ResolutionAssessment:
+    type_state, type_relation = _set_relation(
+        local.get("type_refs") or (), snapshot.get("type_refs") or ()
+    )
+    participant_state, participant_relation = _set_relation(
+        (
+            ref
+            for refs in (local.get("participants") or {}).values()
+            for ref in refs
+        ),
+        (
+            ref
+            for refs in (snapshot.get("participants") or {}).values()
+            for ref in refs
+        ),
+    )
+    local_time, external_time = local.get("temporal") or {}, snapshot.get("temporal") or {}
+    if local_time and external_time:
+        if set(local_time.values()).intersection(external_time.values()):
+            temporal_state, temporal_relation = (
+                MeetState.COMPATIBLE,
+                "shared_temporal_anchor",
+            )
+        else:
+            temporal_state, temporal_relation = (
+                MeetState.COMPATIBLE_WITH_REFINEMENT,
+                "distinct_temporal_roles",
+            )
+    else:
+        temporal_state, temporal_relation = MeetState.UNRESOLVED, "missing_temporal_role"
+    local_space, external_space = local.get("spatial") or {}, snapshot.get("spatial") or {}
+    if local_space and external_space:
+        if set(map(str, local_space.values())).intersection(
+            map(str, external_space.values())
+        ):
+            spatial_state, spatial_relation = MeetState.COMPATIBLE, "shared_spatial_anchor"
+        else:
+            spatial_state, spatial_relation = (
+                MeetState.COMPATIBLE_WITH_REFINEMENT,
+                "spatial_refinement_required",
+            )
+    else:
+        spatial_state, spatial_relation = MeetState.UNRESOLVED, "missing_spatial_coordinate"
+    local_labels = tuple(
+        str(value).casefold()
+        for value in (*tuple(local.get("labels") or ()), *tuple(local.get("aliases") or ()))
+    )
+    external_labels = tuple(
+        str(value).casefold()
+        for value in (
+            *tuple(snapshot.get("labels") or ()),
+            *tuple(snapshot.get("aliases") or ()),
+        )
+    )
+    form_state, form_relation = _set_relation(local_labels, external_labels)
+    lineage_state = (
+        MeetState.COMPATIBLE_WITH_REFINEMENT
+        if snapshot.get("lineage_refs")
+        else MeetState.UNRESOLVED
+    )
+    role = str(snapshot.get("evidence_role") or "")
+    occurrence_state = (
+        MeetState.COMPATIBLE
+        if role == EvidenceRole.OCCURRENCE.value
+        else MeetState.COMPATIBLE_WITH_REFINEMENT
+    )
+    occurrence_relation = (
+        "same_occurrence_role"
+        if role == EvidenceRole.OCCURRENCE.value
+        else f"{role}_of_occurrence"
+    )
+    coordinates = (
+        CompatibilityCoordinate("event_type", type_state, type_relation),
+        CompatibilityCoordinate("temporal", temporal_state, temporal_relation),
+        CompatibilityCoordinate("spatial", spatial_state, spatial_relation),
+        CompatibilityCoordinate(
+            "participants", participant_state, participant_relation
+        ),
+        CompatibilityCoordinate("form", form_state, form_relation),
+        CompatibilityCoordinate(
+            "lineage",
+            lineage_state,
+            "lineage_recorded" if snapshot.get("lineage_refs") else "lineage_missing",
+        ),
+        CompatibilityCoordinate(
+            "observation_occurrence", occurrence_state, occurrence_relation
+        ),
+    )
+    states = {MeetState(coordinate.state) for coordinate in coordinates}
+    if MeetState.CONTRADICTION in states:
+        outcome = ResolutionOutcome.CONTRADICTION
+    elif MeetState.NO_TYPED_MEET in states:
+        outcome = ResolutionOutcome.NO_TYPED_MEET
+    elif states <= {MeetState.COMPATIBLE, MeetState.NOT_APPLICABLE} and role == "occurrence":
+        outcome = ResolutionOutcome.RESOLVED
+    elif type_state in {
+        MeetState.COMPATIBLE,
+        MeetState.COMPATIBLE_WITH_REFINEMENT,
+    }:
+        outcome = ResolutionOutcome.POSSIBLE_SAME
+    else:
+        outcome = ResolutionOutcome.NOT_EVALUATED
+    selected = snapshot.get("external_ref") if outcome == ResolutionOutcome.RESOLVED else None
+    return ResolutionAssessment(
+        assessment_ref=f"assessment:{_digest([subject_ref, local, snapshot])[:16]}",
+        subject_ref=subject_ref,
+        left_ref=str(local.get("local_ref") or local.get("mention_ref") or subject_ref),
+        right_ref=str(snapshot.get("snapshot_ref")),
+        subject_kind="event_occurrence",
+        coordinates=coordinates,
+        outcome=outcome,
+        selected_identity_ref=str(selected) if selected else None,
+    )
+
+
+@dataclass(frozen=True)
+class PNFRefinement:
+    refinement_ref: str
+    partial_pnf_ref: str
+    slot_ref: str
+    prior_alternatives: tuple[str, ...]
+    added_alternatives: tuple[str, ...] = ()
+    retained_alternatives: tuple[str, ...] = ()
+    rejected_alternatives: tuple[str, ...] = ()
+    prior_residuals: tuple[str, ...] = ()
+    remaining_residuals: tuple[str, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+    assessment_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        prior = set(_refs(self.prior_alternatives))
+        retained = set(_refs(self.retained_alternatives))
+        rejected = set(_refs(self.rejected_alternatives))
+        if not retained.issubset(prior) or not rejected.issubset(prior):
+            raise ValueError("retained/rejected alternatives must exist in prior factor")
+        if retained.intersection(rejected):
+            raise ValueError("an alternative cannot be retained and rejected")
+        row = {
+            "schema_version": "sl.pnf_refinement.v0_1",
+            "refinement_ref": _text(self.refinement_ref, "refinement_ref"),
+            "partial_pnf_ref": _text(self.partial_pnf_ref, "partial_pnf_ref"),
+            "slot_ref": _text(self.slot_ref, "slot_ref"),
+            "prior_alternatives": sorted(prior),
+            "added_alternatives": list(_refs(self.added_alternatives)),
+            "retained_alternatives": sorted(retained),
+            "rejected_alternatives": sorted(rejected),
+            "prior_residuals": list(_refs(self.prior_residuals)),
+            "remaining_residuals": list(_refs(self.remaining_residuals)),
+            "evidence_refs": list(_refs(self.evidence_refs)),
+            "assessment_refs": list(_refs(self.assessment_refs)),
+            "authority": REFINEMENT_AUTHORITY,
+            "unchanged_factor_witness": {
+                "all_other_slots_unchanged": True,
+                "changed_slot_ref": self.slot_ref,
+            },
+        }
+        row["refinement_sha256"] = _digest(row)
+        return row
+
+
+def refine_partial_pnf_factor(
+    *,
+    partial_pnf: Mapping[str, Any],
+    slot_ref: str,
+    assessments: Sequence[Mapping[str, Any]],
+) -> tuple[dict[str, Any], PNFRefinement]:
+    slots = [dict(slot) for slot in partial_pnf.get("slots") or ()]
+    index = next(
+        (i for i, slot in enumerate(slots) if str(slot.get("slot_ref")) == slot_ref),
+        None,
+    )
+    if index is None:
+        raise ValueError("slot_ref does not exist in PartialPNF")
+    target = slots[index]
+    prior = tuple(target.get("alternatives") or target.get("candidate_refs") or ())
+    prior_residuals = tuple(target.get("residual_refs") or ())
+    added: set[str] = set()
+    rejected: set[str] = set()
+    retained = set(prior)
+    evidence_refs: set[str] = set()
+    assessment_refs: set[str] = set()
+    remaining_residuals = set(prior_residuals)
+    for assessment in assessments:
+        assessment_refs.add(str(assessment.get("assessment_ref")))
+        outcome = str(assessment.get("outcome"))
+        identity_ref = assessment.get("selected_identity_ref")
+        evidence_refs.add(str(assessment.get("right_ref")))
+        if outcome == ResolutionOutcome.RESOLVED.value and identity_ref:
+            added.add(str(identity_ref))
+            remaining_residuals.discard("external_identity_unresolved")
+        elif outcome in {
+            ResolutionOutcome.NO_TYPED_MEET.value,
+            ResolutionOutcome.CONTRADICTION.value,
+        }:
+            rejected.add(str(assessment.get("right_ref")))
+    target["alternatives"] = sorted(retained.union(added) - rejected)
+    target["residual_refs"] = sorted(remaining_residuals)
+    slots[index] = target
+    refined = dict(partial_pnf)
+    refined["slots"] = slots
+    refined["prior_pnf_ref"] = partial_pnf.get("partial_pnf_ref")
+    refined["partial_pnf_ref"] = (
+        f"{partial_pnf.get('partial_pnf_ref')}:refined:{_digest(target)[:12]}"
+    )
+    receipt = PNFRefinement(
+        refinement_ref=f"refinement:{_digest([slot_ref, assessments])[:16]}",
+        partial_pnf_ref=str(partial_pnf.get("partial_pnf_ref")),
+        slot_ref=slot_ref,
+        prior_alternatives=prior,
+        added_alternatives=tuple(added),
+        retained_alternatives=tuple(retained),
+        rejected_alternatives=tuple(rejected.intersection(retained)),
+        prior_residuals=prior_residuals,
+        remaining_residuals=tuple(remaining_residuals),
+        evidence_refs=tuple(evidence_refs),
+        assessment_refs=tuple(assessment_refs),
+    )
+    return refined, receipt
+
+
+@dataclass(frozen=True)
+class ReadinessDecision:
+    decision_ref: str
+    subject_ref: str
+    outcome: ReadinessOutcome | str
+    reason_refs: tuple[str, ...]
+    assessment_refs: tuple[str, ...] = ()
+    refinement_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        reasons = _refs(self.reason_refs)
+        if not reasons:
+            raise ValueError("readiness decisions require reasons")
+        return {
+            "schema_version": "sl.resolution_readiness.v0_1",
+            "decision_ref": _text(self.decision_ref, "decision_ref"),
+            "subject_ref": _text(self.subject_ref, "subject_ref"),
+            "outcome": ReadinessOutcome(self.outcome).value,
+            "reason_refs": list(reasons),
+            "assessment_refs": list(_refs(self.assessment_refs)),
+            "refinement_refs": list(_refs(self.refinement_refs)),
+            "authority": READINESS_AUTHORITY,
+            "editing_authority": False,
+        }
+
+
+def assess_readiness(
+    *,
+    subject_ref: str,
+    partial_pnf: Mapping[str, Any],
+    assessments: Sequence[Mapping[str, Any]],
+    refinement_refs: Sequence[str] = (),
+) -> ReadinessDecision:
+    residuals = {
+        str(residual)
+        for slot in partial_pnf.get("slots") or ()
+        for residual in slot.get("residual_refs") or ()
+    }
+    outcomes = {str(row.get("outcome")) for row in assessments}
+    reasons: list[str] = []
+    if ResolutionOutcome.CONTRADICTION.value in outcomes:
+        outcome = ReadinessOutcome.HOLD
+        reasons.append("typed_contradiction")
+    elif ResolutionOutcome.NO_TYPED_MEET.value in outcomes:
+        outcome = ReadinessOutcome.ABSTAIN
+        reasons.append("no_typed_meet")
+    elif residuals:
+        outcome = ReadinessOutcome.HOLD
+        reasons.extend(f"residual:{value}" for value in sorted(residuals))
+    elif not assessments:
+        outcome = ReadinessOutcome.AUDIT
+        reasons.append("assessment_missing")
+    else:
+        outcome = ReadinessOutcome.PROMOTE
+        reasons.append("typed_factors_closed_for_review")
+    return ReadinessDecision(
+        decision_ref=f"readiness:{_digest([subject_ref, partial_pnf, assessments])[:16]}",
+        subject_ref=subject_ref,
+        outcome=outcome,
+        reason_refs=tuple(reasons),
+        assessment_refs=tuple(str(row.get("assessment_ref")) for row in assessments),
+        refinement_refs=tuple(refinement_refs),
+    )

--- a/src/policy/resolution_proofs.py
+++ b/src/policy/resolution_proofs.py
@@ -1,0 +1,191 @@
+"""Compact deterministic GWB and AU end-to-end resolution proofs."""
+from __future__ import annotations
+
+from typing import Any
+
+from .resolution_evidence import (
+    EvidenceRole,
+    adapt_wikidata_snapshot,
+    adapt_worldmonitor_snapshot,
+    assess_entity_resolution,
+    assess_event_resolution,
+    assess_readiness,
+    refine_partial_pnf_factor,
+)
+
+
+def run_gwb_resolution_proof() -> dict[str, Any]:
+    bush_local = {
+        "local_ref": "gwb:cluster:bush",
+        "labels": ["George W. Bush", "Bush", "the president"],
+        "aliases": ["President Bush"],
+        "type_refs": ["person"],
+    }
+    wikidata = adapt_wikidata_snapshot(
+        subject_ref="gwb:subject:bush",
+        entity={
+            "id": "Q207",
+            "revision": "gwb-proof-rev-1",
+            "labels": {"en": {"value": "George W. Bush"}},
+            "aliases": {
+                "en": [
+                    {"value": "Bush"},
+                    {"value": "President Bush"},
+                ]
+            },
+            "properties": {"P31": [{"entity_ref": "person"}]},
+        },
+        requested_revision="gwb-proof-rev-1",
+        provenance_refs=("fixture:gwb:wikidata",),
+    ).to_dict()
+    entity_assessment = assess_entity_resolution(
+        subject_ref="gwb:subject:bush",
+        local=bush_local,
+        snapshot=wikidata,
+    ).to_dict()
+
+    event_local = {
+        "local_ref": "gwb:event:september-11",
+        "labels": [
+            "9/11",
+            "September 11",
+            "September Eleven",
+            "the attacks",
+        ],
+        "aliases": ["S11"],
+        "type_refs": ["terrorist_attack"],
+        "temporal": {"occurred_on": "2001-09-11"},
+        "spatial": {"country": "United States"},
+        "participants": {"affected_party": ["United States"]},
+    }
+    worldmonitor = adapt_worldmonitor_snapshot(
+        subject_ref="gwb:event:september-11",
+        record={
+            "id": "wm:gwb:september-11",
+            "title": "September 11 attacks",
+            "canonical_aliases": ["9/11", "September Eleven"],
+            "event_type": "terrorist_attack",
+            "date": "2001-09-11",
+            "country": "United States",
+            "participants": {"affected_party": ["United States"]},
+            "source_name": "fixture-source",
+        },
+        record_role=EvidenceRole.OCCURRENCE,
+        snapshot_version="gwb-proof-v1",
+        provenance_refs=("fixture:gwb:worldmonitor",),
+    ).to_dict()
+    event_assessment = assess_event_resolution(
+        subject_ref="gwb:event:september-11",
+        local=event_local,
+        snapshot=worldmonitor,
+    ).to_dict()
+
+    pnf = {
+        "partial_pnf_ref": "gwb:pnf:1",
+        "slots": [
+            {
+                "slot_ref": "subject",
+                "alternatives": ["gwb:cluster:bush"],
+                "residual_refs": ["external_identity_unresolved"],
+            },
+            {
+                "slot_ref": "eventuality",
+                "alternatives": ["gwb:event:september-11"],
+                "residual_refs": ["external_identity_unresolved"],
+            },
+        ],
+    }
+    pnf, subject_receipt = refine_partial_pnf_factor(
+        partial_pnf=pnf,
+        slot_ref="subject",
+        assessments=(entity_assessment,),
+    )
+    pnf, event_receipt = refine_partial_pnf_factor(
+        partial_pnf=pnf,
+        slot_ref="eventuality",
+        assessments=(event_assessment,),
+    )
+    readiness = assess_readiness(
+        subject_ref="gwb:claim:1",
+        partial_pnf=pnf,
+        assessments=(entity_assessment, event_assessment),
+        refinement_refs=(
+            subject_receipt.refinement_ref,
+            event_receipt.refinement_ref,
+        ),
+    ).to_dict()
+    return {
+        "proof_ref": "gwb:resolution-proof:v1",
+        "entity_assessment": entity_assessment,
+        "event_assessment": event_assessment,
+        "refined_pnf": pnf,
+        "refinement_receipts": [
+            subject_receipt.to_dict(),
+            event_receipt.to_dict(),
+        ],
+        "readiness": readiness,
+    }
+
+
+def run_au_resolution_proof() -> dict[str, Any]:
+    court_local = {
+        "local_ref": "au:entity:hca",
+        "labels": ["High Court", "High Court of Australia"],
+        "type_refs": ["court"],
+    }
+    snapshot = adapt_wikidata_snapshot(
+        subject_ref="au:entity:hca",
+        entity={
+            "id": "Q421567",
+            "revision": "au-proof-rev-1",
+            "labels": {"en": {"value": "High Court of Australia"}},
+            "aliases": {"en": [{"value": "High Court"}]},
+            "properties": {"P31": [{"entity_ref": "court"}]},
+        },
+        requested_revision="au-proof-rev-1",
+        provenance_refs=("fixture:au:wikidata",),
+    ).to_dict()
+    assessment = assess_entity_resolution(
+        subject_ref="au:entity:hca",
+        local=court_local,
+        snapshot=snapshot,
+    ).to_dict()
+    pnf = {
+        "partial_pnf_ref": "au:pnf:1",
+        "slots": [
+            {
+                "slot_ref": "institution",
+                "alternatives": ["au:entity:hca"],
+                "residual_refs": ["external_identity_unresolved"],
+            },
+            {
+                "slot_ref": "eventuality",
+                "alternatives": ["judgment_delivered"],
+                "residual_refs": [],
+            },
+            {
+                "slot_ref": "legal_work",
+                "alternatives": ["statute:fixture"],
+                "residual_refs": [],
+            },
+        ],
+    }
+    refined, receipt = refine_partial_pnf_factor(
+        partial_pnf=pnf,
+        slot_ref="institution",
+        assessments=(assessment,),
+    )
+    readiness = assess_readiness(
+        subject_ref="au:claim:1",
+        partial_pnf=refined,
+        assessments=(assessment,),
+        refinement_refs=(receipt.refinement_ref,),
+    ).to_dict()
+    return {
+        "proof_ref": "au:resolution-proof:v1",
+        "assessment": assessment,
+        "refined_pnf": refined,
+        "refinement_receipt": receipt.to_dict(),
+        "readiness": readiness,
+        "shared_semantics_only": True,
+    }

--- a/src/policy/resolution_store.py
+++ b/src/policy/resolution_store.py
@@ -1,0 +1,82 @@
+"""Minimal append-only SQLite store for resolution-loop artifacts."""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Mapping
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS resolution_artifact (
+  artifact_ref TEXT PRIMARY KEY,
+  artifact_kind TEXT NOT NULL,
+  content_sha256 TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_resolution_artifact_kind
+ON resolution_artifact(artifact_kind);
+"""
+
+
+class ResolutionArtifactStore:
+    """Append-only operational persistence for evidence-loop carriers."""
+
+    def __init__(self, path: str | Path = ":memory:") -> None:
+        self.connection = sqlite3.connect(str(path))
+        self.connection.executescript(_SCHEMA)
+
+    def close(self) -> None:
+        self.connection.close()
+
+    def append(
+        self,
+        artifact_kind: str,
+        artifact_ref: str,
+        payload: Mapping[str, Any],
+    ) -> str:
+        encoded = json.dumps(dict(payload), sort_keys=True, separators=(",", ":"))
+        digest = hashlib.sha256(encoded.encode()).hexdigest()
+        existing = self.connection.execute(
+            "SELECT content_sha256 FROM resolution_artifact WHERE artifact_ref = ?",
+            (artifact_ref,),
+        ).fetchone()
+        if existing:
+            if existing[0] != digest:
+                raise ValueError(
+                    "append-only artifact reference already has different content"
+                )
+            return digest
+        self.connection.execute(
+            """
+            INSERT INTO resolution_artifact(
+              artifact_ref, artifact_kind, content_sha256, payload_json
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (artifact_ref, artifact_kind, digest, encoded),
+        )
+        self.connection.commit()
+        return digest
+
+    def get(self, artifact_ref: str) -> dict[str, Any] | None:
+        row = self.connection.execute(
+            "SELECT payload_json FROM resolution_artifact WHERE artifact_ref = ?",
+            (artifact_ref,),
+        ).fetchone()
+        return json.loads(row[0]) if row else None
+
+    def count(self, artifact_kind: str | None = None) -> int:
+        if artifact_kind is None:
+            row = self.connection.execute(
+                "SELECT COUNT(*) FROM resolution_artifact"
+            ).fetchone()
+        else:
+            row = self.connection.execute(
+                """
+                SELECT COUNT(*) FROM resolution_artifact
+                WHERE artifact_kind = ?
+                """,
+                (artifact_kind,),
+            ).fetchone()
+        return int(row[0])

--- a/src/reporting/affidavit_plantuml.py
+++ b/src/reporting/affidavit_plantuml.py
@@ -318,15 +318,17 @@ def build_affidavit_mechanical_plantuml(
         sentence_id = f"AF_{_slug(proposition_id)}"
         text_id = f"P_{_slug(proposition_id)}"
         lines.append(f"' {display_id}")
-        lines.append(
-            f'  component {_quote("extracted " + display_id + "\\n" + _wrap(row.get("text"), width=28, max_lines=5))} as {text_id}'
+        extracted_label = "extracted " + display_id + "\n" + _wrap(
+            row.get("text"), width=28, max_lines=5
         )
+        lines.append(f'  component {_quote(extracted_label)} as {text_id}')
         lines.append(f"  {sentence_id} --> {text_id} : extracted_as")
 
         token_values = row.get("tokens") if isinstance(row.get("tokens"), list) else None
         atoms = [str(value) for value in token_values[:token_limit]] if token_values else _lexical_atoms(row.get("text"), limit=token_limit)
         token_id = f"T_{_slug(proposition_id)}"
-        lines.append(f'  component {_quote(display_id + " tokens\\n" + "\\n".join(atoms or ["-"]))} as {token_id}')
+        token_label = display_id + " tokens\n" + "\n".join(atoms or ["-"])
+        lines.append(f'  component {_quote(token_label)} as {token_id}')
         lines.append(f"  {text_id} --> {token_id} : tokenize")
 
         best_excerpt = _text(row.get("best_match_excerpt"))

--- a/tests/policy/test_resolution_evidence.py
+++ b/tests/policy/test_resolution_evidence.py
@@ -1,0 +1,212 @@
+from src.policy.resolution_evidence import (
+    EvidenceRole,
+    adapt_wikidata_snapshot,
+    adapt_worldmonitor_snapshot,
+    assess_entity_resolution,
+    assess_event_resolution,
+    assess_readiness,
+    build_document_local_evidence,
+    refine_partial_pnf_factor,
+)
+from src.policy.resolution_proofs import (
+    run_au_resolution_proof,
+    run_gwb_resolution_proof,
+)
+from src.policy.resolution_store import ResolutionArtifactStore
+
+
+def test_document_local_backend_preserves_multiple_evidence_rows():
+    rows = build_document_local_evidence(
+        demand={
+            "demand_ref": "d1",
+            "mention_ref": "m1",
+            "subject_ref": "s1",
+        },
+        mentions=[
+            {
+                "mention_ref": "m1",
+                "document_ref": "doc",
+                "canonical_surface": "Bush",
+            }
+        ],
+        coreference_clusters=[
+            {
+                "cluster_ref": "c1",
+                "document_ref": "doc",
+                "mention_refs": ["m1", "m2"],
+            }
+        ],
+        local_types=[
+            {
+                "type_ref": "t1",
+                "mention_ref": "m1",
+                "local_type": "person",
+                "provenance_refs": ["p1"],
+            }
+        ],
+    )
+    assert len(rows) == 2
+    assert {row.evidence_role for row in rows} == {
+        EvidenceRole.DOCUMENT_LOCAL_CLUSTER,
+        EvidenceRole.ENTITY,
+    }
+
+
+def test_wikidata_adapter_requires_exact_revision():
+    try:
+        adapt_wikidata_snapshot(
+            subject_ref="s",
+            entity={"id": "Q1", "revision": "2"},
+            requested_revision="1",
+            provenance_refs=("p",),
+        )
+    except ValueError as error:
+        assert "revision" in str(error)
+    else:
+        raise AssertionError("revision mismatch should fail")
+
+
+def test_worldmonitor_preserves_observation_role():
+    row = adapt_worldmonitor_snapshot(
+        subject_ref="e",
+        record={"id": "wm1", "title": "quake", "category": "earthquake"},
+        record_role=EvidenceRole.OBSERVATION,
+        snapshot_version="v1",
+        provenance_refs=("p",),
+    ).to_dict()
+    assert row["evidence_role"] == "observation"
+
+
+def test_entity_resolution_is_coordinate_based_not_ranked():
+    snapshot = adapt_wikidata_snapshot(
+        subject_ref="s",
+        entity={
+            "id": "Q1",
+            "revision": "1",
+            "labels": {"en": {"value": "Bush"}},
+            "properties": {"P31": [{"entity_ref": "person"}]},
+        },
+        requested_revision="1",
+        provenance_refs=("p",),
+    ).to_dict()
+    assessment = assess_entity_resolution(
+        subject_ref="s",
+        local={
+            "local_ref": "l",
+            "labels": ["Bush"],
+            "type_refs": ["person"],
+        },
+        snapshot=snapshot,
+    ).to_dict()
+    assert assessment["outcome"] == "resolved"
+    assert "score" not in assessment
+
+
+def test_event_assessment_retains_all_typed_coordinates():
+    snapshot = adapt_worldmonitor_snapshot(
+        subject_ref="e",
+        record={
+            "id": "wm",
+            "title": "September 11 attacks",
+            "event_type": "attack",
+            "date": "2001-09-11",
+            "country": "US",
+            "participants": {"affected": ["US"]},
+            "source_name": "source",
+        },
+        record_role="occurrence",
+        snapshot_version="v1",
+        provenance_refs=("p",),
+    ).to_dict()
+    assessment = assess_event_resolution(
+        subject_ref="e",
+        local={
+            "local_ref": "local",
+            "labels": ["September 11 attacks"],
+            "type_refs": ["attack"],
+            "temporal": {"occurred_on": "2001-09-11"},
+            "spatial": {"country": "US"},
+            "participants": {"affected": ["US"]},
+        },
+        snapshot=snapshot,
+    ).to_dict()
+    assert {row["coordinate"] for row in assessment["coordinates"]} == {
+        "event_type",
+        "temporal",
+        "spatial",
+        "participants",
+        "form",
+        "lineage",
+        "observation_occurrence",
+    }
+
+
+def test_refinement_changes_only_named_factor():
+    pnf = {
+        "partial_pnf_ref": "p",
+        "slots": [
+            {
+                "slot_ref": "subject",
+                "alternatives": ["local"],
+                "residual_refs": ["external_identity_unresolved"],
+            },
+            {
+                "slot_ref": "object",
+                "alternatives": ["unchanged"],
+                "residual_refs": [],
+            },
+        ],
+    }
+    assessment = {
+        "assessment_ref": "a",
+        "right_ref": "snap",
+        "outcome": "resolved",
+        "selected_identity_ref": "Q1",
+    }
+    refined, receipt = refine_partial_pnf_factor(
+        partial_pnf=pnf,
+        slot_ref="subject",
+        assessments=(assessment,),
+    )
+    assert refined["slots"][1] == pnf["slots"][1]
+    assert (
+        receipt.to_dict()["unchanged_factor_witness"][
+            "all_other_slots_unchanged"
+        ]
+        is True
+    )
+
+
+def test_readiness_never_has_editing_authority():
+    row = assess_readiness(
+        subject_ref="s",
+        partial_pnf={"slots": []},
+        assessments=({"assessment_ref": "a", "outcome": "resolved"},),
+    ).to_dict()
+    assert row["outcome"] == "promote"
+    assert row["editing_authority"] is False
+
+
+def test_gwb_and_au_proofs_preserve_distinct_outcomes():
+    gwb = run_gwb_resolution_proof()
+    au = run_au_resolution_proof()
+    assert gwb["readiness"]["outcome"] == "hold"
+    assert au["readiness"]["outcome"] == "promote"
+    assert au["shared_semantics_only"] is True
+
+
+def test_append_only_store_rejects_overwrite():
+    store = ResolutionArtifactStore()
+    try:
+        digest = store.append("assessment", "a1", {"x": 1})
+        assert store.append("assessment", "a1", {"x": 1}) == digest
+        assert store.get("a1") == {"x": 1}
+        assert store.count("assessment") == 1
+        try:
+            store.append("assessment", "a1", {"x": 2})
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("append-only overwrite should fail")
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary

Completes the semantic back half after P0c.5:

- document-local evidence backend;
- revision-pinned Wikidata snapshots;
- WorldMonitor snapshots with event roles preserved;
- typed entity/event reconciliation;
- factor-local PartialPNF refinement;
- review-only readiness outcomes;
- compact GWB and AU end-to-end proofs;
- minimal append-only SQLite artifact store.

## Authority boundaries

No live I/O, candidate ranking, automatic identity promotion, claim promotion, or editing authority is introduced. WorldMonitor observations/clusters/forecasts/reports/alerts/rolling states are not coerced into event occurrences.

## Validation

Focused local validation: 9 new tests passed. The existing P0c.5 scheduler remains unchanged.

## Not included

Raw climate replay payloads remain local and uncommitted. Production network workers, endpoint discovery, broad corpus replay, and columnar/graph projections remain deployment work.