### PR TITLE
Introduce generic semantic algebra and factorized PNF spine

### DIFF
--- a/docs/planning/generic_semantic_algebra_refactor_20260718.md
+++ b/docs/planning/generic_semantic_algebra_refactor_20260718.md
@@ -1,0 +1,73 @@
+# Generic semantic algebra refactor
+
+This tranche establishes the reusable centre beneath entity resolution, PNF,
+language reduction, evidence reconciliation, and proof fixtures.
+
+## Architectural rule
+
+No domain or corpus may introduce a separate semantic pipeline where the result
+can be represented as a grammar-generated typed alternative, factor constraint,
+typed meet, residual, pressure assessment, or factor refinement.
+
+Domain and registry adapters may contribute observations, type declarations,
+grammar declarations, capabilities, evidence, closure policy, and authority
+policy. They may not silently select interpretations.
+
+GWB and AU are proof corpora. They are not annotation profiles, parser modes, or
+media adapters. Media adapters are selected by generic capability such as PDF,
+plain text, HTML, or structured records.
+
+## Added reusable layers
+
+- `src/policy/carriers`: canonical JSON, hashing, reference normalization,
+  schema validation, and authority validation.
+- `src/policy/algebra`: typed alternatives, factors, constraints, typed meets,
+  pressure envelopes, residual transitions, and factor refinements.
+- `src/language`: immutable annotation layers, one annotation graph, and
+  declarative branch-preserving reduction grammars.
+- `src/pnf`: factorized PNF graph, closure contracts, and backend-free demand
+  projection.
+- `src/resolution`: generic external snapshot envelope, meet-product
+  reconciliation, and shared proof-report generation.
+- `src/ingestion/media_refs.py`: immutable text-span and segment references.
+- `src/ingestion/media_adapter_contract.py`: capability-oriented media adapter
+  protocol with no corpus-specific adapters.
+- `tests/factories`: minimal valid semantic carrier factories.
+
+## Compatibility and migration boundary
+
+This tranche deliberately does not delete or rename the existing
+`src/policy/entity_resolution.py`, `src/ingestion/section_parser.py`, or
+`src/pdf_ingest.py`. They remain compatibility implementations while callers are
+migrated to the reusable modules under parity tests.
+
+The safe migration sequence is:
+
+1. replace local `_text`, `_refs`, JSON, and digest helpers with
+   `src.policy.carriers` imports;
+2. project existing PartialPNF slots into `Factor` values and preserve the
+   current public serialized form through an adapter;
+3. make existing entity/event reconciliation emit `TypedMeet` coordinates;
+4. make refinement consume and return `Factor`/`FactorRefinement` while
+   preserving old entry points;
+5. project spaCy-derived facts into immutable `AnnotationLayer` values before
+   removing mutable token-extension writes;
+6. move page normalization behind a dedicated generic PDF stage and prove the
+   omitted-lines fixture behaviour;
+7. migrate canonical units to `TextSpanRef` and `SegmentRef` after artifact
+   parity is demonstrated;
+8. split the legacy entity-resolution and PDF modules only after import and
+   serialization parity tests pass.
+
+This avoids a flag-day package conversion and prevents the new algebra from
+becoming another monolith.
+
+## Non-authority guarantees
+
+- deterministic ordering is serialization-only;
+- grammars expand alternatives and never rank them;
+- annotation layers do not resolve entities or mutate PNF;
+- typed meets assess compatibility and do not establish claim truth;
+- snapshot envelopes carry evidence only;
+- PNF demand projection is backend-free;
+- proof reports carry no editing authority.

--- a/src/ingestion/media_adapter_contract.py
+++ b/src/ingestion/media_adapter_contract.py
@@ -1,0 +1,38 @@
+"""Capability-oriented media adapter contract.
+
+Adapters are selected by media type/capability (PDF, text, HTML, etc.), never by
+corpus identity. GWB and AU remain proof corpora, not adapter implementations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+
+from src.policy.carriers.canonical import canonical_refs, require_text
+
+
+@dataclass(frozen=True)
+class MediaAdapterCapability:
+    adapter_ref: str
+    media_types: tuple[str, ...]
+    produces: tuple[str, ...] = ("canonical_text", "segments", "units")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "adapter_ref": require_text(self.adapter_ref, "adapter_ref"),
+            "media_types": list(canonical_refs(self.media_types)),
+            "produces": list(canonical_refs(self.produces)),
+        }
+
+
+class MediaAdapter(Protocol):
+    capability: MediaAdapterCapability
+
+    def adapt(
+        self,
+        *,
+        source_ref: str,
+        payload: bytes | str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]: ...

--- a/src/ingestion/media_refs.py
+++ b/src/ingestion/media_refs.py
@@ -1,0 +1,45 @@
+"""Reusable immutable references for canonical media artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.policy.carriers.canonical import require_text
+
+
+@dataclass(frozen=True)
+class TextSpanRef:
+    text_id: str
+    start_char: int
+    end_char: int
+
+    def to_dict(self) -> dict[str, object]:
+        if self.start_char < 0 or self.end_char <= self.start_char:
+            raise ValueError("text span must be non-empty and non-negative")
+        return {
+            "text_id": require_text(self.text_id, "text_id"),
+            "start_char": self.start_char,
+            "end_char": self.end_char,
+        }
+
+
+@dataclass(frozen=True)
+class SegmentRef:
+    text_id: str
+    segment_id: str
+    order_index: int
+    page: int | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        if self.order_index < 0:
+            raise ValueError("segment order_index must be non-negative")
+        row: dict[str, object] = {
+            "text_id": require_text(self.text_id, "text_id"),
+            "segment_id": require_text(self.segment_id, "segment_id"),
+            "order_index": self.order_index,
+        }
+        if self.page is not None:
+            if self.page < 1:
+                raise ValueError("page must be positive")
+            row["page"] = self.page
+        return row

--- a/src/language/__init__.py
+++ b/src/language/__init__.py
@@ -1,0 +1,16 @@
+"""Generic language annotations and grammar reductions."""
+
+from .annotations import AnnotationLayer, RelationAnnotation, SpanAnnotation, TokenAnnotation
+from .grammars import ReductionGrammar, ReductionResult, apply_reduction_grammar
+from .graph import AnnotationGraph
+
+__all__ = [
+    "AnnotationGraph",
+    "AnnotationLayer",
+    "ReductionGrammar",
+    "ReductionResult",
+    "RelationAnnotation",
+    "SpanAnnotation",
+    "TokenAnnotation",
+    "apply_reduction_grammar",
+]

--- a/src/language/annotations.py
+++ b/src/language/annotations.py
@@ -1,0 +1,114 @@
+"""Immutable projections over a shared token stream.
+
+The token stream may be produced by spaCy or another tokenizer. Annotation
+layers never mutate token extension attributes and never select semantic
+interpretations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from src.policy.carriers.canonical import canonical_mapping, canonical_refs, require_text
+
+
+@dataclass(frozen=True)
+class TokenAnnotation:
+    token_index: int
+    annotation_type: str
+    value: Any
+    provenance_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        if self.token_index < 0:
+            raise ValueError("token_index must be non-negative")
+        return {
+            "token_index": self.token_index,
+            "annotation_type": require_text(self.annotation_type, "annotation_type"),
+            "value": self.value,
+            "provenance_refs": list(canonical_refs(self.provenance_refs)),
+        }
+
+
+@dataclass(frozen=True)
+class SpanAnnotation:
+    span_ref: str
+    start_token: int
+    end_token: int
+    annotation_type: str
+    value: Any
+    provenance_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        if self.start_token < 0 or self.end_token <= self.start_token:
+            raise ValueError("span token range must be non-empty")
+        return {
+            "span_ref": require_text(self.span_ref, "span_ref"),
+            "start_token": self.start_token,
+            "end_token": self.end_token,
+            "annotation_type": require_text(self.annotation_type, "annotation_type"),
+            "value": self.value,
+            "provenance_refs": list(canonical_refs(self.provenance_refs)),
+        }
+
+
+@dataclass(frozen=True)
+class RelationAnnotation:
+    relation_ref: str
+    relation_type: str
+    left_ref: str
+    right_ref: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    provenance_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "relation_ref": require_text(self.relation_ref, "relation_ref"),
+            "relation_type": require_text(self.relation_type, "relation_type"),
+            "left_ref": require_text(self.left_ref, "left_ref"),
+            "right_ref": require_text(self.right_ref, "right_ref"),
+            "payload": canonical_mapping(self.payload),
+            "provenance_refs": list(canonical_refs(self.provenance_refs)),
+        }
+
+
+@dataclass(frozen=True)
+class AnnotationLayer:
+    layer_ref: str
+    tokenizer_ref: str
+    text_sha256: str
+    token_annotations: tuple[TokenAnnotation, ...] = ()
+    span_annotations: tuple[SpanAnnotation, ...] = ()
+    relation_annotations: tuple[RelationAnnotation, ...] = ()
+    provenance_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": "sl.annotation_layer.v0_1",
+            "layer_ref": require_text(self.layer_ref, "layer_ref"),
+            "tokenizer_ref": require_text(self.tokenizer_ref, "tokenizer_ref"),
+            "text_sha256": require_text(self.text_sha256, "text_sha256"),
+            "token_annotations": [
+                row.to_dict()
+                for row in sorted(
+                    self.token_annotations,
+                    key=lambda value: (value.token_index, value.annotation_type),
+                )
+            ],
+            "span_annotations": [
+                row.to_dict()
+                for row in sorted(
+                    self.span_annotations,
+                    key=lambda value: (value.start_token, value.end_token, value.span_ref),
+                )
+            ],
+            "relation_annotations": [
+                row.to_dict()
+                for row in sorted(
+                    self.relation_annotations, key=lambda value: value.relation_ref
+                )
+            ],
+            "provenance_refs": list(canonical_refs(self.provenance_refs)),
+            "authority": "annotation_only",
+        }

--- a/src/language/grammars.py
+++ b/src/language/grammars.py
@@ -1,0 +1,105 @@
+"""Declarative grammar values over the shared annotation graph."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from src.policy.algebra import Factor, FactorConstraint, TypedAlternative
+from src.policy.carriers.canonical import canonical_mapping, canonical_refs, require_text
+
+from .graph import AnnotationGraph
+
+
+@dataclass(frozen=True)
+class ReductionGrammar:
+    grammar_ref: str
+    required_span_types: tuple[str, ...]
+    required_relation_types: tuple[str, ...] = ()
+    output_factor_type: str = "semantic.unknown"
+    output_type_ref: str = "semantic.unknown"
+    factor_bindings: Mapping[str, Any] = field(default_factory=dict)
+    residuals_on_failure: tuple[str, ...] = ()
+    provenance_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "grammar_ref": require_text(self.grammar_ref, "grammar_ref"),
+            "required_span_types": list(canonical_refs(self.required_span_types)),
+            "required_relation_types": list(canonical_refs(self.required_relation_types)),
+            "output_factor_type": require_text(
+                self.output_factor_type, "output_factor_type"
+            ),
+            "output_type_ref": require_text(self.output_type_ref, "output_type_ref"),
+            "factor_bindings": canonical_mapping(self.factor_bindings),
+            "residuals_on_failure": list(canonical_refs(self.residuals_on_failure)),
+            "provenance_refs": list(canonical_refs(self.provenance_refs)),
+            "authority": "grammar_only",
+        }
+
+
+@dataclass(frozen=True)
+class ReductionResult:
+    grammar_ref: str
+    matched: bool
+    factor: Factor[Any]
+    annotation_refs: tuple[str, ...] = ()
+
+
+def apply_reduction_grammar(
+    *, graph: AnnotationGraph, grammar: ReductionGrammar, factor_ref: str
+) -> ReductionResult:
+    """Apply structural requirements without selecting among semantic branches.
+
+    Every matching span becomes a separate typed alternative. A grammar match
+    therefore expands a factor; it never ranks alternatives or resolves identity.
+    """
+
+    required_spans = set(grammar.required_span_types)
+    required_relations = set(grammar.required_relation_types)
+    spans = tuple(
+        row for row in graph.span_annotations() if row.annotation_type in required_spans
+    )
+    relation_types = {row.relation_type for row in graph.relation_annotations()}
+    matched = bool(spans) and required_relations.issubset(relation_types)
+    if not matched:
+        return ReductionResult(
+            grammar_ref=grammar.grammar_ref,
+            matched=False,
+            factor=Factor(
+                factor_ref=factor_ref,
+                factor_type=grammar.output_factor_type,
+                residuals=grammar.residuals_on_failure,
+                closure_state="open",
+                metadata={"grammar_ref": grammar.grammar_ref},
+            ),
+        )
+    alternatives = tuple(
+        TypedAlternative(
+            alternative_ref=f"{factor_ref}:{row.span_ref}:{grammar.output_type_ref}",
+            value={"span_ref": row.span_ref, "annotation_value": row.value},
+            type_ref=grammar.output_type_ref,
+            derivation_refs=(grammar.grammar_ref, row.span_ref),
+            authority_state="candidate_only",
+        )
+        for row in spans
+    )
+    constraint = FactorConstraint(
+        constraint_ref=f"constraint:{factor_ref}:{grammar.grammar_ref}",
+        constraint_type="grammar_match",
+        payload={"factor_bindings": dict(grammar.factor_bindings)},
+        provenance_refs=grammar.provenance_refs,
+    )
+    return ReductionResult(
+        grammar_ref=grammar.grammar_ref,
+        matched=True,
+        factor=Factor(
+            factor_ref=factor_ref,
+            factor_type=grammar.output_factor_type,
+            alternatives=alternatives,
+            constraints=(constraint,),
+            closure_state="locally_closed",
+            metadata={"grammar_ref": grammar.grammar_ref},
+        ),
+        annotation_refs=tuple(row.span_ref for row in spans),
+    )

--- a/src/language/graph.py
+++ b/src/language/graph.py
@@ -1,0 +1,35 @@
+"""One shared graph view over immutable language annotation layers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .annotations import AnnotationLayer, RelationAnnotation, SpanAnnotation, TokenAnnotation
+
+
+@dataclass(frozen=True)
+class AnnotationGraph:
+    graph_ref: str
+    layers: tuple[AnnotationLayer, ...]
+
+    def token_annotations(self, annotation_type: str | None = None) -> tuple[TokenAnnotation, ...]:
+        rows = tuple(row for layer in self.layers for row in layer.token_annotations)
+        if annotation_type is not None:
+            rows = tuple(row for row in rows if row.annotation_type == annotation_type)
+        return tuple(sorted(rows, key=lambda row: (row.token_index, row.annotation_type)))
+
+    def span_annotations(self, annotation_type: str | None = None) -> tuple[SpanAnnotation, ...]:
+        rows = tuple(row for layer in self.layers for row in layer.span_annotations)
+        if annotation_type is not None:
+            rows = tuple(row for row in rows if row.annotation_type == annotation_type)
+        return tuple(
+            sorted(rows, key=lambda row: (row.start_token, row.end_token, row.span_ref))
+        )
+
+    def relation_annotations(
+        self, relation_type: str | None = None
+    ) -> tuple[RelationAnnotation, ...]:
+        rows = tuple(row for layer in self.layers for row in layer.relation_annotations)
+        if relation_type is not None:
+            rows = tuple(row for row in rows if row.relation_type == relation_type)
+        return tuple(sorted(rows, key=lambda row: row.relation_ref))

--- a/src/pnf/__init__.py
+++ b/src/pnf/__init__.py
@@ -1,0 +1,12 @@
+"""Factorized PNF graph primitives."""
+
+from .graph import PNFGraph
+from .closure import ClosureContract, assess_pnf_closure
+from .demands import derive_resolution_demands
+
+__all__ = [
+    "ClosureContract",
+    "PNFGraph",
+    "assess_pnf_closure",
+    "derive_resolution_demands",
+]

--- a/src/pnf/closure.py
+++ b/src/pnf/closure.py
@@ -1,0 +1,53 @@
+"""Declared closure contracts over factorized PNF graphs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.policy.algebra import PressureAssessment, PressureKind
+from src.policy.carriers.canonical import canonical_refs, require_text
+
+from .graph import PNFGraph
+
+
+@dataclass(frozen=True)
+class ClosureContract:
+    contract_ref: str
+    required_factor_types: tuple[str, ...]
+    accepted_closure_states: tuple[str, ...] = ("closed", "locally_closed")
+
+
+def assess_pnf_closure(
+    graph: PNFGraph, contract: ClosureContract
+) -> tuple[PressureAssessment, ...]:
+    accepted = set(canonical_refs(contract.accepted_closure_states))
+    factors_by_type: dict[str, list] = {}
+    for factor in graph.factors:
+        factors_by_type.setdefault(factor.factor_type, []).append(factor)
+    assessments: list[PressureAssessment] = []
+    for factor_type in canonical_refs(contract.required_factor_types):
+        factors = factors_by_type.get(factor_type, [])
+        if not factors:
+            assessments.append(
+                PressureAssessment(
+                    target_ref=f"{graph.graph_ref}:{factor_type}",
+                    pressure_kind=PressureKind.CLOSURE,
+                    state="missing_factor",
+                    reasons=("required_factor_missing",),
+                    requested_actions=("construct_factor",),
+                )
+            )
+            continue
+        for factor in factors:
+            closed = factor.closure_state in accepted and not factor.residuals
+            assessments.append(
+                PressureAssessment(
+                    target_ref=factor.factor_ref,
+                    pressure_kind=PressureKind.CLOSURE,
+                    state="closed" if closed else "open",
+                    reasons=() if closed else tuple(factor.residuals) or ("closure_state_open",),
+                    requested_actions=() if closed else ("derive_resolution_demand",),
+                )
+            )
+    require_text(contract.contract_ref, "contract_ref")
+    return tuple(assessments)

--- a/src/pnf/demands.py
+++ b/src/pnf/demands.py
@@ -1,0 +1,38 @@
+"""Backend-free demand projection from open PNF factors."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.policy.carriers.canonical import canonical_sha256
+
+from .graph import PNFGraph
+
+
+def derive_resolution_demands(graph: PNFGraph) -> tuple[dict[str, Any], ...]:
+    demands: list[dict[str, Any]] = []
+    for factor in sorted(graph.factors, key=lambda row: row.factor_ref):
+        if not factor.residuals or factor.closure_state in {"closed", "not_required"}:
+            continue
+        semantic_key = {
+            "document_ref": graph.document_ref,
+            "factor_ref": factor.factor_ref,
+            "factor_type": factor.factor_type,
+            "residuals": sorted(factor.residuals),
+            "constraint_refs": sorted(
+                constraint.constraint_ref for constraint in factor.constraints
+            ),
+        }
+        demands.append(
+            {
+                "schema_version": "sl.factor_resolution_demand.v0_1",
+                "demand_ref": f"demand:{canonical_sha256(semantic_key)}",
+                "graph_ref": graph.graph_ref,
+                "factor_ref": factor.factor_ref,
+                "factor_type": factor.factor_type,
+                "requested_facets": sorted(factor.residuals),
+                "semantic_key": semantic_key,
+                "authority": "candidate_only",
+            }
+        )
+    return tuple(demands)

--- a/src/pnf/graph.py
+++ b/src/pnf/graph.py
@@ -1,0 +1,61 @@
+"""PNF as a graph of reusable factors and declared relations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+from src.policy.algebra import Factor, FactorConstraint
+from src.policy.carriers.canonical import canonical_refs, require_text
+
+
+@dataclass(frozen=True)
+class PNFGraph:
+    graph_ref: str
+    document_ref: str
+    factors: tuple[Factor[Any], ...]
+    constraints: tuple[FactorConstraint, ...] = ()
+    relation_refs: tuple[str, ...] = ()
+    residuals: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        refs = [factor.factor_ref for factor in self.factors]
+        if len(refs) != len(set(refs)):
+            raise ValueError("PNF graph factors require unique references")
+
+    def factor(self, factor_ref: str) -> Factor[Any]:
+        for factor in self.factors:
+            if factor.factor_ref == factor_ref:
+                return factor
+        raise KeyError(factor_ref)
+
+    def replace_factor(self, factor: Factor[Any]) -> "PNFGraph":
+        if factor.factor_ref not in {row.factor_ref for row in self.factors}:
+            raise ValueError("cannot replace an unknown PNF factor")
+        return replace(
+            self,
+            factors=tuple(
+                factor if row.factor_ref == factor.factor_ref else row
+                for row in self.factors
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": "sl.pnf_graph.v0_1",
+            "graph_ref": require_text(self.graph_ref, "graph_ref"),
+            "document_ref": require_text(self.document_ref, "document_ref"),
+            "factors": [
+                row.to_dict()
+                for row in sorted(self.factors, key=lambda value: value.factor_ref)
+            ],
+            "constraints": [
+                row.to_dict()
+                for row in sorted(
+                    self.constraints, key=lambda value: value.constraint_ref
+                )
+            ],
+            "relation_refs": list(canonical_refs(self.relation_refs)),
+            "residuals": list(canonical_refs(self.residuals)),
+            "authority": "candidate_only",
+        }

--- a/src/policy/algebra/__init__.py
+++ b/src/policy/algebra/__init__.py
@@ -1,0 +1,19 @@
+"""Generic algebra for branch-preserving semantic compilation."""
+
+from .alternatives import TypedAlternative
+from .factors import Factor, FactorConstraint
+from .meets import MeetState, TypedMeet
+from .pressures import PressureAssessment, PressureKind
+from .refinements import FactorRefinement, ResidualTransition
+
+__all__ = [
+    "Factor",
+    "FactorConstraint",
+    "FactorRefinement",
+    "MeetState",
+    "PressureAssessment",
+    "PressureKind",
+    "ResidualTransition",
+    "TypedAlternative",
+    "TypedMeet",
+]

--- a/src/policy/algebra/alternatives.py
+++ b/src/policy/algebra/alternatives.py
@@ -1,0 +1,44 @@
+"""Branch-preserving typed alternatives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Generic, Mapping, TypeVar
+
+from src.policy.carriers.canonical import (
+    canonical_mapping,
+    canonical_refs,
+    require_text,
+)
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class TypedAlternative(Generic[T]):
+    alternative_ref: str
+    value: T
+    type_ref: str
+    derivation_refs: tuple[str, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+    authority_state: str = "candidate_only"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        authority = require_text(self.authority_state, "authority_state")
+        if authority not in {
+            "candidate_only",
+            "evidence_only",
+            "assessment_only",
+            "pnf_refinement_only",
+        }:
+            raise ValueError("typed alternatives cannot carry promotion authority")
+        return {
+            "alternative_ref": require_text(self.alternative_ref, "alternative_ref"),
+            "value": self.value,
+            "type_ref": require_text(self.type_ref, "type_ref"),
+            "derivation_refs": list(canonical_refs(self.derivation_refs)),
+            "evidence_refs": list(canonical_refs(self.evidence_refs)),
+            "authority_state": authority,
+            "metadata": canonical_mapping(self.metadata),
+        }

--- a/src/policy/algebra/factors.py
+++ b/src/policy/algebra/factors.py
@@ -1,0 +1,123 @@
+"""Immutable factors shared by PNF, entity, event, and reference compilation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Any, Generic, Mapping, TypeVar
+
+from src.policy.carriers.canonical import canonical_mapping, canonical_refs, require_text
+
+from .alternatives import TypedAlternative
+
+T = TypeVar("T")
+
+_CLOSURE_STATES = {
+    "open",
+    "locally_closed",
+    "closed",
+    "requires_local_typing",
+    "requires_external_resolution",
+    "not_required",
+}
+
+
+@dataclass(frozen=True)
+class FactorConstraint:
+    constraint_ref: str
+    constraint_type: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    provenance_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "constraint_ref": require_text(self.constraint_ref, "constraint_ref"),
+            "constraint_type": require_text(self.constraint_type, "constraint_type"),
+            "payload": canonical_mapping(self.payload),
+            "provenance_refs": list(canonical_refs(self.provenance_refs)),
+        }
+
+
+@dataclass(frozen=True)
+class Factor(Generic[T]):
+    factor_ref: str
+    factor_type: str
+    alternatives: tuple[TypedAlternative[T], ...] = ()
+    constraints: tuple[FactorConstraint, ...] = ()
+    residuals: tuple[str, ...] = ()
+    closure_state: str = "open"
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        require_text(self.factor_ref, "factor_ref")
+        require_text(self.factor_type, "factor_type")
+        if self.closure_state not in _CLOSURE_STATES:
+            raise ValueError(f"unsupported factor closure state: {self.closure_state}")
+        refs = [item.alternative_ref for item in self.alternatives]
+        if len(refs) != len(set(refs)):
+            raise ValueError("factor alternatives require unique references")
+
+    def to_dict(self) -> dict[str, Any]:
+        alternatives = sorted(
+            (item.to_dict() for item in self.alternatives),
+            key=lambda row: row["alternative_ref"],
+        )
+        constraints = sorted(
+            (item.to_dict() for item in self.constraints),
+            key=lambda row: row["constraint_ref"],
+        )
+        return {
+            "factor_ref": self.factor_ref,
+            "factor_type": self.factor_type,
+            "alternatives": alternatives,
+            "constraints": constraints,
+            "residuals": list(canonical_refs(self.residuals)),
+            "closure_state": self.closure_state,
+            "metadata": canonical_mapping(self.metadata),
+        }
+
+    def add_alternatives(self, *alternatives: TypedAlternative[T]) -> "Factor[T]":
+        by_ref = {item.alternative_ref: item for item in self.alternatives}
+        for item in alternatives:
+            existing = by_ref.get(item.alternative_ref)
+            if existing is not None and existing.to_dict() != item.to_dict():
+                raise ValueError("cannot replace an alternative through add_alternatives")
+            by_ref[item.alternative_ref] = item
+        return replace(self, alternatives=tuple(by_ref[key] for key in sorted(by_ref)))
+
+    def retain_alternatives(self, refs: tuple[str, ...]) -> "Factor[T]":
+        retained = set(canonical_refs(refs))
+        unknown = retained.difference(item.alternative_ref for item in self.alternatives)
+        if unknown:
+            raise ValueError(f"cannot retain unknown alternatives: {sorted(unknown)}")
+        return replace(
+            self,
+            alternatives=tuple(
+                item for item in self.alternatives if item.alternative_ref in retained
+            ),
+        )
+
+    def reject_alternatives(self, refs: tuple[str, ...]) -> "Factor[T]":
+        rejected = set(canonical_refs(refs))
+        return replace(
+            self,
+            alternatives=tuple(
+                item for item in self.alternatives if item.alternative_ref not in rejected
+            ),
+        )
+
+    def transition_residuals(
+        self,
+        *,
+        remove: tuple[str, ...] = (),
+        add: tuple[str, ...] = (),
+        closure_state: str | None = None,
+    ) -> "Factor[T]":
+        residuals = set(self.residuals)
+        residuals.difference_update(canonical_refs(remove))
+        residuals.update(canonical_refs(add))
+        next_state = closure_state or self.closure_state
+        return replace(
+            self,
+            residuals=tuple(sorted(residuals)),
+            closure_state=next_state,
+        )

--- a/src/policy/algebra/meets.py
+++ b/src/policy/algebra/meets.py
@@ -1,0 +1,55 @@
+"""Typed compatibility meets shared by entity, event, form, and PNF reasoning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Generic, TypeVar
+
+from src.policy.carriers.canonical import canonical_refs, require_text
+
+M = TypeVar("M")
+
+
+class MeetState(str, Enum):
+    COMPATIBLE = "compatible"
+    COMPATIBLE_WITH_REFINEMENT = "compatible_with_refinement"
+    UNRESOLVED = "unresolved"
+    NOT_APPLICABLE = "not_applicable"
+    NO_TYPED_MEET = "no_typed_meet"
+    CONTRADICTION = "contradiction"
+    NOT_EVALUATED = "not_evaluated"
+
+
+@dataclass(frozen=True)
+class TypedMeet(Generic[M]):
+    meet_ref: str
+    left_ref: str
+    right_ref: str
+    meet_type: str
+    state: MeetState | str
+    result_alternatives: tuple[M, ...] = ()
+    refinement_ref: str | None = None
+    evidence_refs: tuple[str, ...] = ()
+    residual_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        state = MeetState(self.state).value
+        row: dict[str, object] = {
+            "meet_ref": require_text(self.meet_ref, "meet_ref"),
+            "left_ref": require_text(self.left_ref, "left_ref"),
+            "right_ref": require_text(self.right_ref, "right_ref"),
+            "meet_type": require_text(self.meet_type, "meet_type"),
+            "state": state,
+            "result_alternatives": list(self.result_alternatives),
+            "evidence_refs": list(canonical_refs(self.evidence_refs)),
+            "residual_refs": list(canonical_refs(self.residual_refs)),
+            "authority": "assessment_only",
+        }
+        if self.refinement_ref:
+            row["refinement_ref"] = require_text(
+                self.refinement_ref, "refinement_ref"
+            )
+        if state in {MeetState.NO_TYPED_MEET.value, MeetState.CONTRADICTION.value} and self.result_alternatives:
+            raise ValueError("failed typed meets cannot emit result alternatives")
+        return row

--- a/src/policy/algebra/pressures.py
+++ b/src/policy/algebra/pressures.py
@@ -1,0 +1,31 @@
+"""Shared pressure envelope with separate coverage and closure semantics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from src.policy.carriers.canonical import canonical_refs, require_text
+
+
+class PressureKind(str, Enum):
+    COVERAGE = "coverage"
+    CLOSURE = "closure"
+
+
+@dataclass(frozen=True)
+class PressureAssessment:
+    target_ref: str
+    pressure_kind: PressureKind | str
+    state: str
+    reasons: tuple[str, ...] = ()
+    requested_actions: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "target_ref": require_text(self.target_ref, "target_ref"),
+            "pressure_kind": PressureKind(self.pressure_kind).value,
+            "state": require_text(self.state, "pressure state"),
+            "reasons": list(canonical_refs(self.reasons)),
+            "requested_actions": list(canonical_refs(self.requested_actions)),
+        }

--- a/src/policy/algebra/refinements.py
+++ b/src/policy/algebra/refinements.py
@@ -1,0 +1,67 @@
+"""Immutable factor refinements and residual transitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, TypeVar
+
+from src.policy.carriers.canonical import canonical_refs, require_text
+
+from .factors import Factor
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class ResidualTransition:
+    residual_ref: str
+    prior_state: str
+    resulting_state: str
+    evidence_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "residual_ref": require_text(self.residual_ref, "residual_ref"),
+            "prior_state": require_text(self.prior_state, "prior_state"),
+            "resulting_state": require_text(self.resulting_state, "resulting_state"),
+            "evidence_refs": list(canonical_refs(self.evidence_refs)),
+        }
+
+
+@dataclass(frozen=True)
+class FactorRefinement(Generic[T]):
+    refinement_ref: str
+    prior_factor: Factor[T]
+    resulting_factor: Factor[T]
+    added_alternative_refs: tuple[str, ...] = ()
+    retained_alternative_refs: tuple[str, ...] = ()
+    rejected_alternative_refs: tuple[str, ...] = ()
+    residual_transitions: tuple[ResidualTransition, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        if self.prior_factor.factor_ref != self.resulting_factor.factor_ref:
+            raise ValueError("factor refinement cannot change factor identity")
+        groups = [
+            set(canonical_refs(self.added_alternative_refs)),
+            set(canonical_refs(self.retained_alternative_refs)),
+            set(canonical_refs(self.rejected_alternative_refs)),
+        ]
+        if groups[0].intersection(groups[2]):
+            raise ValueError("an alternative cannot be both added and rejected")
+        return {
+            "refinement_ref": require_text(self.refinement_ref, "refinement_ref"),
+            "prior_factor": self.prior_factor.to_dict(),
+            "resulting_factor": self.resulting_factor.to_dict(),
+            "added_alternative_refs": sorted(groups[0]),
+            "retained_alternative_refs": sorted(groups[1]),
+            "rejected_alternative_refs": sorted(groups[2]),
+            "residual_transitions": [
+                row.to_dict()
+                for row in sorted(
+                    self.residual_transitions, key=lambda value: value.residual_ref
+                )
+            ],
+            "evidence_refs": list(canonical_refs(self.evidence_refs)),
+            "authority": "pnf_refinement_only",
+        }

--- a/src/policy/carriers/__init__.py
+++ b/src/policy/carriers/__init__.py
@@ -1,0 +1,13 @@
+"""Small, reusable helpers for deterministic policy carriers."""
+
+from .canonical import canonical_json, canonical_refs, canonical_sha256, require_text
+from .validation import require_authority, require_schema
+
+__all__ = [
+    "canonical_json",
+    "canonical_refs",
+    "canonical_sha256",
+    "require_authority",
+    "require_schema",
+    "require_text",
+]

--- a/src/policy/carriers/canonical.py
+++ b/src/policy/carriers/canonical.py
@@ -1,0 +1,60 @@
+"""Canonical JSON, hashing, and reference normalization for policy carriers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+def require_text(value: Any, field: str) -> str:
+    """Return a non-empty normalized string or fail with a field-specific error."""
+
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError(f"{field} is required")
+    return normalized
+
+
+def canonical_refs(values: Iterable[Any] | None) -> tuple[str, ...]:
+    """Return unique, non-empty references in deterministic serialization order."""
+
+    return tuple(sorted({require_text(value, "reference") for value in values or ()}))
+
+
+def canonical_json(value: Any) -> Any:
+    """Return a detached, JSON-safe value with deterministic mapping key order.
+
+    The returned value contains no aliases to caller-owned mutable containers.
+    Ordering of alternatives remains representational only; this function does
+    not rank or select semantic alternatives.
+    """
+
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as error:
+        raise ValueError("carrier value must be JSON-serializable") from error
+    return json.loads(encoded)
+
+
+def canonical_mapping(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    normalized = canonical_json(dict(value or {}))
+    if not isinstance(normalized, dict):
+        raise ValueError("carrier payload must be a mapping")
+    return normalized
+
+
+def canonical_sha256(value: Any) -> str:
+    encoded = json.dumps(
+        canonical_json(value),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()

--- a/src/policy/carriers/validation.py
+++ b/src/policy/carriers/validation.py
@@ -1,0 +1,20 @@
+"""Validation helpers shared by immutable policy carriers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .canonical import require_text
+
+
+def require_schema(carrier: Mapping[str, Any], expected: str) -> None:
+    actual = require_text(carrier.get("schema_version"), "schema_version")
+    if actual != expected:
+        raise ValueError(f"expected schema {expected}, got {actual}")
+
+
+def require_authority(carrier: Mapping[str, Any], expected: str) -> None:
+    actual = require_text(carrier.get("authority"), "authority")
+    if actual != expected:
+        raise ValueError(f"expected authority {expected}, got {actual}")

--- a/src/resolution/__init__.py
+++ b/src/resolution/__init__.py
@@ -1,6 +1,13 @@
 """Registry-neutral resolution primitives."""
 
-from .snapshots import ExternalSnapshotEnvelope
+from .proof_reports import ProofFixture, build_proof_report
 from .reconciliation import ReconciliationAssessment, reconcile_meets
+from .snapshots import ExternalSnapshotEnvelope
 
-__all__ = ["ExternalSnapshotEnvelope", "ReconciliationAssessment", "reconcile_meets"]
+__all__ = [
+    "ExternalSnapshotEnvelope",
+    "ProofFixture",
+    "ReconciliationAssessment",
+    "build_proof_report",
+    "reconcile_meets",
+]

--- a/src/resolution/__init__.py
+++ b/src/resolution/__init__.py
@@ -1,0 +1,6 @@
+"""Registry-neutral resolution primitives."""
+
+from .snapshots import ExternalSnapshotEnvelope
+from .reconciliation import ReconciliationAssessment, reconcile_meets
+
+__all__ = ["ExternalSnapshotEnvelope", "ReconciliationAssessment", "reconcile_meets"]

--- a/src/resolution/proof_reports.py
+++ b/src/resolution/proof_reports.py
@@ -1,0 +1,66 @@
+"""Shared proof reports for corpus fixtures.
+
+GWB, AU, and later corpora provide fixture data only. They do not select a
+semantic pipeline or media adapter.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
+
+from src.policy.carriers.canonical import canonical_json, canonical_refs, canonical_sha256, require_text
+
+
+@dataclass(frozen=True)
+class ProofFixture:
+    fixture_ref: str
+    corpus_ref: str
+    document_ref: str
+    media_type: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "fixture_ref": require_text(self.fixture_ref, "fixture_ref"),
+            "corpus_ref": require_text(self.corpus_ref, "corpus_ref"),
+            "document_ref": require_text(self.document_ref, "document_ref"),
+            "media_type": require_text(self.media_type, "media_type"),
+            "metadata": canonical_json(dict(self.metadata)),
+        }
+
+
+def build_proof_report(
+    *,
+    fixture: ProofFixture,
+    mentions: Sequence[Mapping[str, Any]] = (),
+    form_alternatives: Sequence[Mapping[str, Any]] = (),
+    local_types: Sequence[Mapping[str, Any]] = (),
+    demands: Sequence[Mapping[str, Any]] = (),
+    evidence: Sequence[Mapping[str, Any]] = (),
+    typed_meets: Sequence[Mapping[str, Any]] = (),
+    refinements: Sequence[Mapping[str, Any]] = (),
+    readiness: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    sections = {
+        "mentions": canonical_json(list(mentions)),
+        "form_alternatives": canonical_json(list(form_alternatives)),
+        "local_types": canonical_json(list(local_types)),
+        "demands": canonical_json(list(demands)),
+        "evidence": canonical_json(list(evidence)),
+        "typed_meets": canonical_json(list(typed_meets)),
+        "pnf_refinements": canonical_json(list(refinements)),
+        "readiness": canonical_json(dict(readiness or {})),
+    }
+    row = {
+        "schema_version": "sl.resolution_proof_report.v0_1",
+        "fixture": fixture.to_dict(),
+        "sections": sections,
+        "authority_boundary": {
+            "editing_authority": False,
+            "identity_resolution_establishes_claim_truth": False,
+        },
+        "provenance_refs": list(canonical_refs((fixture.fixture_ref, fixture.document_ref))),
+    }
+    row["report_sha256"] = canonical_sha256(row)
+    return row

--- a/src/resolution/reconciliation.py
+++ b/src/resolution/reconciliation.py
@@ -1,0 +1,65 @@
+"""Derive structural reconciliation outcomes from typed meet products."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.policy.algebra import MeetState, TypedMeet
+from src.policy.carriers.canonical import canonical_refs, require_text
+
+
+@dataclass(frozen=True)
+class ReconciliationAssessment:
+    assessment_ref: str
+    subject_ref: str
+    meets: tuple[TypedMeet, ...]
+    outcome: str
+    residual_refs: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": "sl.reconciliation_assessment.v0_1",
+            "assessment_ref": require_text(self.assessment_ref, "assessment_ref"),
+            "subject_ref": require_text(self.subject_ref, "subject_ref"),
+            "meets": [
+                row.to_dict()
+                for row in sorted(self.meets, key=lambda value: value.meet_ref)
+            ],
+            "outcome": require_text(self.outcome, "outcome"),
+            "residual_refs": list(canonical_refs(self.residual_refs)),
+            "authority": "assessment_only",
+        }
+
+
+def reconcile_meets(
+    *, assessment_ref: str, subject_ref: str, meets: tuple[TypedMeet, ...]
+) -> ReconciliationAssessment:
+    states = {MeetState(meet.state) for meet in meets}
+    residuals = tuple(
+        sorted({ref for meet in meets for ref in meet.residual_refs})
+    )
+    if MeetState.CONTRADICTION in states:
+        outcome = "contradiction"
+    elif MeetState.NO_TYPED_MEET in states:
+        outcome = "no_typed_meet"
+    elif not meets or MeetState.NOT_EVALUATED in states:
+        outcome = "not_evaluated"
+    elif states.issubset({MeetState.COMPATIBLE, MeetState.NOT_APPLICABLE}):
+        outcome = "resolved"
+    elif states.issubset(
+        {
+            MeetState.COMPATIBLE,
+            MeetState.COMPATIBLE_WITH_REFINEMENT,
+            MeetState.NOT_APPLICABLE,
+        }
+    ):
+        outcome = "compatible_with_refinement"
+    else:
+        outcome = "possible_same"
+    return ReconciliationAssessment(
+        assessment_ref=assessment_ref,
+        subject_ref=subject_ref,
+        meets=meets,
+        outcome=outcome,
+        residual_refs=residuals,
+    )

--- a/src/resolution/snapshots.py
+++ b/src/resolution/snapshots.py
@@ -1,0 +1,50 @@
+"""Generic immutable snapshot envelope with backend-specific typed payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Generic, Mapping, TypeVar
+
+from src.policy.carriers.canonical import (
+    canonical_mapping,
+    canonical_refs,
+    canonical_sha256,
+    require_text,
+)
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class ExternalSnapshotEnvelope(Generic[T]):
+    snapshot_ref: str
+    backend_ref: str
+    external_ref: str
+    version_ref: str
+    formal_role: str
+    payload: T
+    fetched_at: str | None = None
+    provenance_refs: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        provenance = canonical_refs(self.provenance_refs)
+        if not provenance:
+            raise ValueError("external snapshots require provenance")
+        row: dict[str, Any] = {
+            "schema_version": "sl.external_snapshot_envelope.v0_1",
+            "snapshot_ref": require_text(self.snapshot_ref, "snapshot_ref"),
+            "backend_ref": require_text(self.backend_ref, "backend_ref"),
+            "external_ref": require_text(self.external_ref, "external_ref"),
+            "version_ref": require_text(self.version_ref, "version_ref"),
+            "formal_role": require_text(self.formal_role, "formal_role"),
+            "payload": self.payload,
+            "provenance_refs": list(provenance),
+            "metadata": canonical_mapping(self.metadata),
+            "authority": "evidence_only",
+        }
+        if self.fetched_at:
+            row["fetched_at"] = require_text(self.fetched_at, "fetched_at")
+        row["payload_sha256"] = canonical_sha256(self.payload)
+        row["snapshot_sha256"] = canonical_sha256(row)
+        return row

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,0 +1,5 @@
+"""Reusable factories for valid minimal semantic carriers."""
+
+from .semantic import factor, typed_alternative, typed_meet, worldmonitor_snapshot
+
+__all__ = ["factor", "typed_alternative", "typed_meet", "worldmonitor_snapshot"]

--- a/tests/factories/semantic.py
+++ b/tests/factories/semantic.py
@@ -1,0 +1,72 @@
+"""Factories keep tests focused on invariants rather than carrier boilerplate."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.policy.algebra import Factor, MeetState, TypedAlternative, TypedMeet
+from src.resolution import ExternalSnapshotEnvelope
+
+
+def typed_alternative(
+    ref: str = "alternative:test",
+    *,
+    value: Any = "value",
+    type_ref: str = "type:test",
+) -> TypedAlternative[Any]:
+    return TypedAlternative(
+        alternative_ref=ref,
+        value=value,
+        type_ref=type_ref,
+        derivation_refs=("fixture:semantic",),
+    )
+
+
+def factor(
+    ref: str = "factor:test",
+    *,
+    factor_type: str = "pnf.subject",
+    alternatives: tuple[TypedAlternative[Any], ...] | None = None,
+    residuals: tuple[str, ...] = (),
+    closure_state: str = "open",
+) -> Factor[Any]:
+    return Factor(
+        factor_ref=ref,
+        factor_type=factor_type,
+        alternatives=alternatives or (),
+        residuals=residuals,
+        closure_state=closure_state,
+    )
+
+
+def typed_meet(
+    ref: str = "meet:test",
+    *,
+    state: MeetState | str = MeetState.COMPATIBLE,
+    meet_type: str = "type_lattice_meet",
+    residual_refs: tuple[str, ...] = (),
+) -> TypedMeet[Any]:
+    return TypedMeet(
+        meet_ref=ref,
+        left_ref="left:test",
+        right_ref="right:test",
+        meet_type=meet_type,
+        state=state,
+        residual_refs=residual_refs,
+    )
+
+
+def worldmonitor_snapshot(
+    *,
+    role: str = "observation",
+    payload: Any | None = None,
+) -> ExternalSnapshotEnvelope[Any]:
+    return ExternalSnapshotEnvelope(
+        snapshot_ref=f"worldmonitor:test@v1:{role}",
+        backend_ref="worldmonitor",
+        external_ref="worldmonitor:test",
+        version_ref="v1",
+        formal_role=role,
+        payload=payload or {"event_type": "event:test"},
+        provenance_refs=("fixture:worldmonitor:v1",),
+    )

--- a/tests/policy/test_generic_semantic_algebra.py
+++ b/tests/policy/test_generic_semantic_algebra.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import pytest
+
+from src.ingestion.media_adapter_contract import MediaAdapterCapability
+from src.ingestion.media_refs import SegmentRef, TextSpanRef
+from src.language import (
+    AnnotationGraph,
+    AnnotationLayer,
+    ReductionGrammar,
+    SpanAnnotation,
+    apply_reduction_grammar,
+)
+from src.pnf import ClosureContract, PNFGraph, assess_pnf_closure, derive_resolution_demands
+from src.policy.algebra import (
+    Factor,
+    FactorRefinement,
+    MeetState,
+    TypedAlternative,
+    TypedMeet,
+)
+from src.policy.carriers import canonical_sha256
+from src.resolution import ExternalSnapshotEnvelope, reconcile_meets
+
+
+def alternative(ref: str, value: object) -> TypedAlternative:
+    return TypedAlternative(
+        alternative_ref=ref,
+        value=value,
+        type_ref="type:test",
+        derivation_refs=("grammar:test",),
+    )
+
+
+def test_factor_serialization_is_deterministic_not_semantic_order() -> None:
+    factor = Factor(
+        factor_ref="factor:test",
+        factor_type="pnf.subject",
+        alternatives=(alternative("z", "Bush"), alternative("a", "the president")),
+    )
+    assert [row["alternative_ref"] for row in factor.to_dict()["alternatives"]] == [
+        "a",
+        "z",
+    ]
+    assert {row["value"] for row in factor.to_dict()["alternatives"]} == {
+        "Bush",
+        "the president",
+    }
+
+
+def test_factor_operations_preserve_immutability() -> None:
+    prior = Factor(
+        factor_ref="factor:event",
+        factor_type="pnf.eventuality",
+        alternatives=(alternative("date", "September 11"),),
+        residuals=("event_identity_unresolved",),
+    )
+    resulting = prior.add_alternatives(
+        alternative("event", "September 11 attacks")
+    ).transition_residuals(
+        remove=("event_identity_unresolved",), closure_state="closed"
+    )
+    assert [row.alternative_ref for row in prior.alternatives] == ["date"]
+    assert {row.alternative_ref for row in resulting.alternatives} == {"date", "event"}
+    assert resulting.residuals == ()
+
+
+def test_factor_refinement_cannot_change_factor_identity() -> None:
+    with pytest.raises(ValueError):
+        FactorRefinement(
+            refinement_ref="refinement:bad",
+            prior_factor=Factor("factor:a", "pnf.subject"),
+            resulting_factor=Factor("factor:b", "pnf.subject"),
+        ).to_dict()
+
+
+def test_typed_meet_product_derives_structural_outcome() -> None:
+    assessment = reconcile_meets(
+        assessment_ref="assessment:event",
+        subject_ref="event:local",
+        meets=(
+            TypedMeet(
+                meet_ref="meet:time",
+                left_ref="event:local",
+                right_ref="wm:event",
+                meet_type="temporal_interval_meet",
+                state=MeetState.COMPATIBLE,
+            ),
+            TypedMeet(
+                meet_ref="meet:lineage",
+                left_ref="event:local",
+                right_ref="wm:event",
+                meet_type="lineage_meet",
+                state=MeetState.COMPATIBLE_WITH_REFINEMENT,
+                residual_refs=("source_lineage_unresolved",),
+            ),
+        ),
+    )
+    assert assessment.outcome == "compatible_with_refinement"
+    assert assessment.residual_refs == ("source_lineage_unresolved",)
+
+
+def test_annotation_reduction_is_branch_preserving() -> None:
+    layer = AnnotationLayer(
+        layer_ref="layer:shared",
+        tokenizer_ref="spacy:test",
+        text_sha256="abc",
+        span_annotations=(
+            SpanAnnotation("span:date", 0, 2, "calendar_expression", "September 11"),
+            SpanAnnotation("span:title", 0, 2, "title_shape", "September Eleven"),
+        ),
+    )
+    result = apply_reduction_grammar(
+        graph=AnnotationGraph("graph:text", (layer,)),
+        grammar=ReductionGrammar(
+            grammar_ref="grammar:temporal-or-title",
+            required_span_types=("calendar_expression", "title_shape"),
+            output_factor_type="pnf.temporal_context",
+            output_type_ref="semantic.form",
+        ),
+        factor_ref="factor:temporal-context",
+    )
+    assert result.matched is True
+    assert len(result.factor.alternatives) == 2
+
+
+def test_pnf_graph_refines_one_factor_and_demands_open_factor() -> None:
+    subject = Factor("factor:subject", "pnf.subject", closure_state="closed")
+    event = Factor(
+        "factor:event",
+        "pnf.eventuality",
+        residuals=("external_identity",),
+        closure_state="requires_external_resolution",
+    )
+    graph = PNFGraph("pnf:gwb", "document:gwb", (subject, event))
+    demands = derive_resolution_demands(graph)
+    assert [row["factor_ref"] for row in demands] == ["factor:event"]
+    refined_event = event.transition_residuals(
+        remove=("external_identity",), closure_state="closed"
+    )
+    refined = graph.replace_factor(refined_event)
+    assert refined.factor("factor:subject") is subject
+    assert refined.factor("factor:event").closure_state == "closed"
+
+
+def test_closure_contract_keeps_pressure_semantics_separate() -> None:
+    graph = PNFGraph(
+        "pnf:test",
+        "document:test",
+        (Factor("factor:subject", "pnf.subject", residuals=("type_missing",)),),
+    )
+    pressures = assess_pnf_closure(
+        graph,
+        ClosureContract("contract:test", ("pnf.subject", "pnf.object")),
+    )
+    assert {row.pressure_kind.value for row in pressures} == {"closure"}
+    assert {row.state for row in pressures} == {"open", "missing_factor"}
+
+
+def test_snapshot_envelope_preserves_backend_specific_payload() -> None:
+    envelope = ExternalSnapshotEnvelope(
+        snapshot_ref="worldmonitor:event:1@v1",
+        backend_ref="worldmonitor",
+        external_ref="event:1",
+        version_ref="v1",
+        formal_role="observation",
+        payload={"observed_at": "2026-07-18", "agency": "source-a"},
+        provenance_refs=("worldmonitor:snapshot:v1",),
+    ).to_dict()
+    assert envelope["formal_role"] == "observation"
+    assert envelope["payload"]["agency"] == "source-a"
+    assert envelope["payload_sha256"] == canonical_sha256(envelope["payload"])
+
+
+def test_media_contract_is_capability_not_corpus_specific() -> None:
+    capability = MediaAdapterCapability(
+        adapter_ref="media:pdf",
+        media_types=("application/pdf",),
+    ).to_dict()
+    assert capability["adapter_ref"] == "media:pdf"
+    assert "gwb" not in str(capability).lower()
+    assert "au" not in str(capability).lower()
+    assert TextSpanRef("text:1", 0, 3).to_dict()["end_char"] == 3
+    assert SegmentRef("text:1", "segment:1", 0, page=1).to_dict()["page"] == 1


### PR DESCRIPTION
## Summary

Introduces the reusable algebraic and language substrate requested after the typed resolution loop:

- shared deterministic carrier canonicalisation and validation;
- branch-preserving `TypedAlternative`;
- immutable generic `Factor`, constraints, operations, pressure assessments, typed meets, and factor refinements;
- one immutable language annotation graph and declarative reduction grammar carrier;
- factorized `PNFGraph`, closure contracts, and backend-free demand projection;
- generic external snapshot envelope and meet-product reconciliation;
- corpus-neutral media adapter capability plus immutable text/segment references;
- reusable semantic fixture factories and shared proof report generation;
- focused invariant tests and migration documentation.

## Corpus and adapter boundary

GWB and AU remain proof corpora. They are not parser profiles, annotation profiles, or source-specific media adapters. Media adapters are capability-oriented (`application/pdf`, plain text, HTML, structured records). Corpora may provide metadata, declared registries, fixtures, and readiness policies only.

## Compatibility strategy

This is a stacked refactor PR based on `codex/complete-resolution-loop`. It deliberately does not delete or rename `src/policy/entity_resolution.py`, `src/ingestion/section_parser.py`, or `src/pdf_ingest.py`. Those remain compatibility implementations until callers and serialized artifacts have parity tests against the new reusable modules.

The included migration note specifies the safe sequence for replacing local canonicalisation helpers, projecting existing PartialPNF slots into generic factors, emitting typed meets from current reconcilers, projecting spaCy facts into immutable annotation layers, isolating PDF page normalization, and only then splitting the legacy monoliths.

## Authority boundaries

- deterministic order is serialization-only;
- grammars expand branches and never rank them;
- annotations do not resolve identity or mutate PNF;
- typed meets assess compatibility but do not establish claim truth;
- snapshots carry evidence only;
- demands remain backend-free;
- proof reports have no editing authority.

## Validation

Added focused tests for deterministic branch preservation, immutable factor operations, typed meet products, annotation reductions, factor-local PNF replacement, separate closure pressure, snapshot role preservation, and corpus-neutral media capabilities.

Connector-only implementation means repository CI still needs to run the suite and Ruff checks on the branch.