### PR TITLE
Route legal adjunct acquisition from PNF demands

### DIFF
--- a/.github/workflows/external-enrichment.yml
+++ b/.github/workflows/external-enrichment.yml
@@ -7,6 +7,8 @@ on:
       - "src/ontology/wikimedia_providers.py"
       - "src/pnf/external_enrichment_projection.py"
       - "src/pnf/external_reconciliation.py"
+      - "src/pnf/legal_adjunct.py"
+      - "src/pnf/legal_probe.py"
       - "src/ingestion/web_fetch.py"
       - "src/ingestion/link_follow.py"
       - "src/ingestion/corpus_source_projection.py"
@@ -15,13 +17,18 @@ on:
       - "src/sources/national_archives/brexit_legal_follow_lane.py"
       - "src/storage/postgres/enrichment_planner.py"
       - "src/storage/postgres/enrichment_store.py"
+      - "src/storage/postgres/legal_adjunct_planner.py"
       - "database/postgres_migrations/014_external_pnf_enrichment.sql"
       - "scripts/run_wikimedia_enrichment.py"
       - "scripts/run_legal_follow.py"
       - "scripts/run_complete_tranche.py"
+      - "scripts/run_legal_pnf_probe.py"
+      - "tests/fixtures/legal_pnf_probe/**"
       - "tests/ingestion/test_web_fetch_and_follow.py"
       - "tests/ontology/test_wikimedia_providers.py"
       - "tests/pnf/test_external_enrichment.py"
+      - "tests/pnf/test_legal_adjunct.py"
+      - "tests/pnf/test_legal_probe.py"
       - "tests/runtime/test_complete_tranche_pipeline.py"
       - "tests/sources/test_legal_follow.py"
       - "tests/storage/test_external_enrichment_planner.py"
@@ -34,6 +41,8 @@ on:
       - "src/ontology/wikimedia_providers.py"
       - "src/pnf/external_enrichment_projection.py"
       - "src/pnf/external_reconciliation.py"
+      - "src/pnf/legal_adjunct.py"
+      - "src/pnf/legal_probe.py"
       - "src/ingestion/web_fetch.py"
       - "src/ingestion/link_follow.py"
       - "src/ingestion/corpus_source_projection.py"
@@ -42,13 +51,18 @@ on:
       - "src/sources/national_archives/brexit_legal_follow_lane.py"
       - "src/storage/postgres/enrichment_planner.py"
       - "src/storage/postgres/enrichment_store.py"
+      - "src/storage/postgres/legal_adjunct_planner.py"
       - "database/postgres_migrations/014_external_pnf_enrichment.sql"
       - "scripts/run_wikimedia_enrichment.py"
       - "scripts/run_legal_follow.py"
       - "scripts/run_complete_tranche.py"
+      - "scripts/run_legal_pnf_probe.py"
+      - "tests/fixtures/legal_pnf_probe/**"
       - "tests/ingestion/test_web_fetch_and_follow.py"
       - "tests/ontology/test_wikimedia_providers.py"
       - "tests/pnf/test_external_enrichment.py"
+      - "tests/pnf/test_legal_adjunct.py"
+      - "tests/pnf/test_legal_probe.py"
       - "tests/runtime/test_complete_tranche_pipeline.py"
       - "tests/sources/test_legal_follow.py"
       - "tests/storage/test_external_enrichment_planner.py"
@@ -101,6 +115,8 @@ jobs:
             src/ontology/wikimedia_providers.py \
             src/pnf/external_enrichment_projection.py \
             src/pnf/external_reconciliation.py \
+            src/pnf/legal_adjunct.py \
+            src/pnf/legal_probe.py \
             src/ingestion/web_fetch.py \
             src/ingestion/link_follow.py \
             src/ingestion/corpus_source_projection.py \
@@ -109,12 +125,16 @@ jobs:
             src/sources/national_archives/brexit_legal_follow_lane.py \
             src/storage/postgres/enrichment_planner.py \
             src/storage/postgres/enrichment_store.py \
+            src/storage/postgres/legal_adjunct_planner.py \
             scripts/run_wikimedia_enrichment.py \
             scripts/run_legal_follow.py \
             scripts/run_complete_tranche.py \
+            scripts/run_legal_pnf_probe.py \
             tests/ingestion/test_web_fetch_and_follow.py \
             tests/ontology/test_wikimedia_providers.py \
             tests/pnf/test_external_enrichment.py \
+            tests/pnf/test_legal_adjunct.py \
+            tests/pnf/test_legal_probe.py \
             tests/runtime/test_complete_tranche_pipeline.py \
             tests/sources/test_legal_follow.py \
             tests/storage/test_external_enrichment_planner.py \
@@ -126,6 +146,8 @@ jobs:
           set -o pipefail
           uv run pytest -x -vv \
             tests/pnf/test_external_enrichment.py \
+            tests/pnf/test_legal_adjunct.py \
+            tests/pnf/test_legal_probe.py \
             tests/ontology/test_wikimedia_providers.py \
             tests/storage/test_external_enrichment_planner.py \
             tests/storage/test_external_enrichment_postgres.py \

--- a/docs/planning/legal_pnf_probe_and_entity_resolution_20260721.md
+++ b/docs/planning/legal_pnf_probe_and_entity_resolution_20260721.md
@@ -1,0 +1,184 @@
+# Legal PNF probe and entity-resolution policy
+
+## Parser doctrine
+
+The probe preserves the repository-wide semantic boundary:
+
+```text
+one media adapter
+→ one canonical text substrate
+→ one parser spine
+→ PNF
+```
+
+There is no legal parser, legal extraction profile, source-family parser, or
+verb-to-law map.  Legal IR is projected from legal PNF revisions.
+
+## Probe purpose
+
+The probe answers an empirical question before further semantic work is added:
+
+> What does the ordinary PNF compiler actually construct when given legislation,
+> judgments, pleadings, submissions, and administrative decisions?
+
+The executable entry point is:
+
+```bash
+python scripts/run_legal_pnf_probe.py \
+  --input-directory tests/fixtures/legal_pnf_probe \
+  --output-dir /tmp/legal-pnf-probe \
+  --compare-legacy
+```
+
+It emits, for every canonical document:
+
+```text
+compilation.json
+parser_observations.json
+pnf_graph.json
+refined_pnf_graph.json
+legal_ir.json
+legacy_obligations.json
+comparison_ledger.json
+entity_resolution_decisions.json
+wikidata_plan.json
+```
+
+and a corpus-level `coverage_scorecard.json`.
+
+## Differential status
+
+The legacy `RuleAtom` and `ObligationAtom` lanes are diagnostic oracles only.
+They may expose coverage gaps, but they do not overwrite or promote PNF.
+
+For each structural coordinate the ledger records:
+
+```text
+PNF present?
+Legal IR present?
+legacy observation present?
+coverage state
+open residuals
+```
+
+A legacy-only observation creates an explicit residual such as:
+
+```text
+legacy_modality_candidate_not_reconstructed_in_pnf
+legacy_exception_candidate_not_reconstructed_in_pnf
+```
+
+No automatic conversion from the legacy result into legal PNF is performed.
+
+## Wikidata: when and why
+
+Wikidata is a candidate identity and context provider.  It is not a legal source,
+legal authority, or applicability engine.
+
+The system should not call Wikidata merely because a proper noun or named entity
+appears.  A lookup is warranted only where all of the following hold:
+
+1. the factor is entity-shaped;
+2. identity remains open (`external_identity_unresolved` or a legal identity
+   residual);
+3. the factor fills or blocks a legal coordinate, for example:
+   - bearer/actor;
+   - court or tribunal;
+   - party;
+   - institution or decision-maker;
+   - jurisdiction;
+   - legal authority;
+4. a stable source surface is available;
+5. no reusable fresh candidate snapshot already satisfies the same lookup key;
+6. provider budget remains available.
+
+This is represented by:
+
+```text
+PNF factor
+× Legal IR role use
+× unresolved identity pressure
+→ LegalEntityResolutionDecision
+→ candidate-only ExternalLookupDemand
+```
+
+The decision states one of:
+
+```text
+candidate_lookup_warranted
+not_warranted
+blocked_missing_surface
+```
+
+A location or person mentioned in a legal document but unused by a legal PNF role
+does not trigger the legal-resolution pass.  It may still be handled by the
+ordinary external-enrichment planner if its independent world-model identity is
+material.
+
+## Two registry passes
+
+The intended tranche architecture has two bounded registry opportunities:
+
+### Ordinary world/PNF pass
+
+Runs after local PNF and provisional world construction.  It handles ordinary
+entity and lexical pressure, including aliases, offices, organizations, places,
+and lexical senses.
+
+### Legal-materiality pass
+
+Runs only after legal-corpus PNF and Legal IR exist.  It handles identities whose
+resolution became material to legal comparison, such as the precise court,
+statutory office, institution, party, or jurisdiction filling a legal role.
+
+The second pass must deduplicate against the first pass by semantic lookup key and
+reuse existing provider snapshots.  It must not refetch or create a second local
+entity solely because the demand arose later.
+
+## Authority boundaries
+
+The following implications are forbidden:
+
+```text
+Wikidata candidate → local identity closure
+Wikidata entity type → legal actor-class closure
+Wikidata office/jurisdiction claim → legal applicability
+Legal IR observation → promoted rule
+Legacy obligation observation → PNF legal fact
+Empty lookup → no legal entity or no applicable law
+```
+
+Every provider result remains candidate-only and revision-pinned.  Review or a
+separate governed promotion gate is required for identity closure.
+
+## Probe fixture genres
+
+The initial fixture covers:
+
+- obligation, prohibition, permission and exclusion;
+- power and entitlement;
+- defence, exception and burden language;
+- holdings, distinguishing, orders and disposition;
+- commencement, repeal and amendment.
+
+The fixture is intentionally small and hand-auditable.  Its purpose is to expose
+which structures already emerge from generic PNF and which require improvements
+to generic PNF composition.
+
+## Next semantic work after measurement
+
+Probe results should determine the implementation order.  Expected areas include:
+
+```text
+modal scope
+normative versus epistemic modality
+negation composition
+condition and exception attachment
+holding-content wrappers
+burden bearer and standard
+commencement/amendment/repeal transitions
+legal time and rule-version intervals
+```
+
+These improvements belong in generic PNF construction.  Legal IR should continue
+to normalize and project those structures, not rediscover them.

--- a/docs/planning/pnf_legal_adjunct_loop_20260720.md
+++ b/docs/planning/pnf_legal_adjunct_loop_20260720.md
@@ -1,0 +1,242 @@
+# PNF-driven legal adjunct and Legal IR loop
+
+Date: 2026-07-20
+
+## Parser doctrine
+
+The repository doctrine is exact:
+
+```text
+one media adapter
+  -> one canonical text substrate
+  -> one parser spine
+  -> PNF
+```
+
+There is no legal parser, source-family parser, normative extraction profile, or
+verb-to-law router. Source provenance is retained as evidence metadata but does
+not select semantic interpretation.
+
+All semantic structures—including obligation, prohibition, permission, power,
+liability, entitlement, condition, exception, burden, judicial holding,
+distinguishing treatment, commencement, amendment, and repeal—must arise from
+PNF construction and refinement.
+
+Legal IR is downstream:
+
+```text
+legal source bytes
+  -> same media adapter
+  -> same canonical text substrate
+  -> same parser spine
+  -> legal-corpus PNF
+  -> Legal IR projection
+```
+
+Legal IR is an operational ABI over PNF state. It does not own an independent
+semantic interpretation.
+
+## Two acquisition classes
+
+Seed acquisition and adjunct acquisition are distinct.
+
+### Seed acquisition
+
+Seed acquisition supplies the initial tranche from explicit files, URLs,
+declared source-family manifests, or an explicit broad jurisdiction follow.
+The complete runner no longer broad-crawls legal profiles for GWB or AU merely
+because a legal profile exists. Broad legal follow occurs only when requested
+with `--seed-legal-follow`, or when a tranche such as Brexit has no local seed
+corpus and requires a bounded seed.
+
+### PNF-demanded legal adjunct acquisition
+
+After deterministic local compilation and provisional world construction:
+
+```text
+ordinary PNF
+  -> explicit legal residual/facet
+  -> NormativeInteractionDemand
+  -> LegalSourcePlan
+  -> exact endpoint selection
+  -> bounded legal source acquisition
+  -> same adapter/parser/PNF path
+  -> Legal IR projection
+  -> typed reconciliation and pressure
+```
+
+A predicate lemma does not create legal work. In particular:
+
+```text
+predicate = drive
+requested facets = {local_type_unresolved}
+```
+
+produces no legal demand.
+
+A legal demand requires an explicit trigger such as:
+
+```text
+legal.relevance_unresolved
+legal.authority_absent
+legal.applicability_unresolved
+legal.interpretation_unresolved
+```
+
+and a structural signature supplied by PNF:
+
+```text
+legal.interaction_signature:<signature-ref>
+```
+
+Acquisition readiness additionally requires:
+
+```text
+legal.jurisdiction:<jurisdiction>
+legal.source_role:<role>
+legal.authority_level:<level>
+```
+
+Optional facets include:
+
+```text
+legal.time:<time-or-version-envelope>
+legal.provider_profile:<declared-endpoint-ref>
+legal.request:<requested-authority-facet>
+```
+
+Missing jurisdiction, source role, authority level, or structural signature
+blocks acquisition. The planner does not broaden a blocked demand.
+
+## Algebra
+
+Let:
+
+- `N_W` be world/factual PNF;
+- `D_L` be normative interaction demands;
+- `P_L` be legal source plans;
+- `B_L` be acquired legal source artifacts;
+- `N_L` be legal-corpus PNF;
+- `IR_L` be Legal IR projected from `N_L`.
+
+Then:
+
+```text
+N_W -> D_L -> P_L -> B_L -> N_L -> IR_L
+```
+
+and reconciliation is:
+
+```text
+N_W x IR_L -> LegalTypedMeet
+```
+
+A typed meet has separate coordinates for:
+
+```text
+structural fibre
+jurisdiction
+time
+actor
+conduct
+object
+circumstance
+exception
+burden
+```
+
+Cross-fibre comparison returns `NO_TYPED_MEET`. Same-fibre comparison remains a
+candidate assessment. It does not close applicability, violation, wrong,
+liability, burden, or remedy.
+
+## Authority laws
+
+The implementation enforces these non-collapse laws:
+
+```text
+legal relevance candidate != applicability
+applicability != violation
+candidate WrongType != liability
+court-held proposition != universal truth
+provider candidate != identity
+empty legal retrieval != unregulated conduct
+Legal IR projection != promoted legal conclusion
+```
+
+## Endpoint selection
+
+`follow_legal_source_plan(...)` is deliberately narrow. It accepts a ready
+`LegalSourcePlan`, selects only endpoints whose declared jurisdiction,
+`source_role`, `authority_level`, and optional endpoint ref match the plan, and
+limits following to those endpoint hosts.
+
+For example, an AU request for:
+
+```text
+source_role = primary_legislation
+authority_level = official
+provider_profile = au:federal-register
+```
+
+cannot expand into AustLII merely because AustLII is present in the broader AU
+profile.
+
+The original `follow_legal_sources(...)` remains available for explicit seed
+corpus construction. It is not the PNF relevance mechanism.
+
+## Complete tranche order v0.2
+
+```text
+1. source inventory
+2. explicit/required seed acquisition
+3. canonical projection
+4. deterministic local PNF compilation
+5. provisional local world/braid
+6. registry demand planning
+7. legal adjunct demand planning
+8. bounded registry acquisition
+9. bounded typed legal acquisition
+10. adjunct compilation through the same parser spine
+11. Legal IR projection from legal PNF
+12. typed reconciliation and pressure
+13. review packets
+14. immutable checkpoint
+```
+
+The legal loop may later repeat under explicit iteration, budget, freshness,
+new-information, and no-repeat build-key bounds. The current runner performs one
+bounded adjunct pass.
+
+## Current implementation boundary
+
+Implemented:
+
+- `src/pnf/legal_adjunct.py`
+  - PNF-derived normative demands;
+  - legal source plans;
+  - Legal IR projection;
+  - fibre-safe legal typed meets.
+- `src/storage/postgres/legal_adjunct_planner.py`
+  - persisted demand-facet planning;
+  - legal-PNF row loading for Legal IR projection.
+- `src/sources/legal_follow.py`
+  - exact typed endpoint selection;
+  - bounded plan execution without profile broadening.
+- `scripts/run_complete_tranche.py`
+  - seed/acquisition separation;
+  - post-PNF legal planning;
+  - adjunct re-entry through the same compiler;
+  - Legal IR and review checkpoints.
+
+Still open:
+
+- richer PNF composition that constructs all normative, exception, burden,
+  authority, and legal-transition factors from parser observations;
+- persisted normalized tables for legal plans, Legal IR observations, typed
+  applicability coordinates, and legal pressure receipts;
+- declaration-driven structural signature indexes over the reusable legal
+  corpus;
+- WrongType, Hohfeldian norm, protected-interest, remedy, and value-frame
+  candidate projections;
+- bounded iterative acquisition/refinement beyond one pass;
+- operator promotion/rejection UI.

--- a/scripts/run_complete_tranche.py
+++ b/scripts/run_complete_tranche.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Run the complete ordered GWB, AU, or Brexit tranche pipeline.
 
-Local compilation and provisional world projection always complete before any
-Wikimedia request. External candidates are reconciled into review packets but
-never promoted to identity or canonical world entities by this runner.
+Parser doctrine is fixed: one media adapter, one canonical text substrate, one
+parser spine, then PNF. Local compilation and provisional world projection
+complete before registry or PNF-demanded legal acquisition. Wikidata,
+Wiktionary, legal-source, and Legal IR outputs remain candidate/review surfaces.
 """
 
 from __future__ import annotations
@@ -26,12 +27,13 @@ from src.ontology.wikimedia_providers import (  # noqa: E402
     WikimediaMicrobatchRunner,
     WiktionaryProvider,
 )
-from src.pnf.external_reconciliation import (  # noqa: E402
-    build_reconciliation_checkpoint,
-)
 from src.pnf.external_enrichment_projection import (  # noqa: E402
     summarize_external_lookup_plan,
 )
+from src.pnf.external_reconciliation import (  # noqa: E402
+    build_reconciliation_checkpoint,
+)
+from src.pnf.legal_adjunct import project_legal_ir  # noqa: E402
 from src.policy.corpus_compilation import default_compiler_context  # noqa: E402
 from src.policy.postgres_corpus_compilation import compile_directory_postgres  # noqa: E402
 from src.runtime.tranche_pipeline import (  # noqa: E402
@@ -41,13 +43,20 @@ from src.runtime.tranche_pipeline import (  # noqa: E402
     inventory_profile,
     profile_for_tranche,
 )
-from src.sources.legal_follow import follow_legal_sources  # noqa: E402
+from src.sources.legal_follow import (  # noqa: E402
+    follow_legal_source_plan,
+    follow_legal_sources,
+)
 from src.storage.postgres import PostgresCompilerStore  # noqa: E402
 from src.storage.postgres.enrichment_planner import (  # noqa: E402
     load_external_lookup_demands,
 )
 from src.storage.postgres.enrichment_store import (  # noqa: E402
     persist_external_enrichment_results,
+)
+from src.storage.postgres.legal_adjunct_planner import (  # noqa: E402
+    load_legal_pnf_rows,
+    load_legal_source_plans,
 )
 
 
@@ -58,11 +67,17 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--output-root", type=Path, required=True)
     parser.add_argument("--offline", action="store_true")
     parser.add_argument("--skip-legal-follow", action="store_true")
+    parser.add_argument(
+        "--seed-legal-follow",
+        action="store_true",
+        help="Explicitly add a broad jurisdiction profile as seed corpus before PNF.",
+    )
     parser.add_argument("--follow-depth", type=int, default=1)
     parser.add_argument("--follow-documents", type=int, default=20)
     parser.add_argument("--max-source-files", type=int)
     parser.add_argument("--max-file-bytes", type=int)
     parser.add_argument("--plan-limit", type=int, default=1_000)
+    parser.add_argument("--legal-plan-limit", type=int, default=500)
     parser.add_argument("--microbatch-size", type=int, default=16)
     parser.add_argument("--request-budget-per-provider", type=int, default=64)
     parser.add_argument("--candidate-limit", type=int, default=5)
@@ -104,7 +119,7 @@ def _write_follow_sources(result: Any, output_dir: Path) -> tuple[Path, dict[str
             }
         )
     manifest = {
-        "schema_version": "sl.tranche_source_acquisition.v0_1",
+        "schema_version": "sl.tranche_source_acquisition.v0_2",
         "documents": documents,
         "receipts": [row.to_dict() for row in result.receipts],
         "discovered_urls": list(result.discovered_urls),
@@ -163,7 +178,7 @@ def _local_world_summary(cursor: Any, corpus_ref: str, profile: Any) -> dict[str
     )
     proposition_count = factor_types.get("semantic.embedded_proposition", 0)
     return {
-        "schema_version": "sl.local_world_checkpoint.v0_1",
+        "schema_version": "sl.local_world_checkpoint.v0_2",
         "corpus_ref": corpus_ref,
         "profile_ref": profile.profile_ref,
         "factor_types": factor_types,
@@ -207,23 +222,31 @@ def _run_one(args: argparse.Namespace, tranche: str) -> dict[str, Any]:
         if family.path and (ROOT / family.path).exists()
     ]
     acquisition_manifest: dict[str, Any] = {
-        "schema_version": "sl.tranche_source_acquisition.v0_1",
+        "schema_version": "sl.tranche_seed_acquisition.v0_2",
         "documents": [],
         "receipts": [],
         "network_performed": False,
+        "mode": "explicit_seed_only",
         "authority": "source_acquisition_only",
     }
-    if profile.legal_follow_profile and not args.skip_legal_follow and not args.offline:
+    seed_follow_required = not source_roots and bool(profile.legal_follow_profile)
+    seed_follow_requested = args.seed_legal_follow and bool(profile.legal_follow_profile)
+    if (
+        (seed_follow_required or seed_follow_requested)
+        and not args.skip_legal_follow
+        and not args.offline
+    ):
         followed = follow_legal_sources(
             profile.legal_follow_profile,
             max_depth=args.follow_depth,
             max_documents=args.follow_documents,
         )
         followed_root, acquisition_manifest = _write_follow_sources(
-            followed, output_dir / "followed_sources"
+            followed, output_dir / "seed_followed_sources"
         )
         source_roots.append(followed_root)
         acquisition_manifest["network_performed"] = True
+        acquisition_manifest["mode"] = "explicit_or_required_seed"
     acquisition_path = output_dir / "source_acquisition.json"
     _json_write(acquisition_path, acquisition_manifest)
     receipts.append(
@@ -236,6 +259,9 @@ def _run_one(args: argparse.Namespace, tranche: str) -> dict[str, Any]:
                 "network_performed": acquisition_manifest["network_performed"],
                 "source_root_count": len(source_roots),
                 "followed_document_count": len(acquisition_manifest.get("documents") or ()),
+                "broad_legal_follow_was_explicit_or_required": bool(
+                    acquisition_manifest["network_performed"]
+                ),
             },
         )
     )
@@ -340,6 +366,37 @@ def _run_one(args: argparse.Namespace, tranche: str) -> dict[str, Any]:
         )
         artifacts["external_enrichment_plan"] = str(plan_path)
 
+        with store.transaction() as cursor:
+            legal_plans = load_legal_source_plans(
+                cursor,
+                corpus_ref=compilation.corpus_ref,
+                limit=args.legal_plan_limit,
+            )
+        legal_plan_payload = {
+            "schema_version": "sl.legal_adjunct_plan.v0_1",
+            "corpus_ref": compilation.corpus_ref,
+            "plans": [row.to_dict() for row in legal_plans],
+            "summary": {
+                "plan_count": len(legal_plans),
+                "ready_count": sum(row.state == "ready" for row in legal_plans),
+                "blocked_count": sum(row.state != "ready" for row in legal_plans),
+            },
+            "authority": "planning_only",
+            "network_performed": False,
+        }
+        legal_plan_path = output_dir / "legal_adjunct_plan.json"
+        _json_write(legal_plan_path, legal_plan_payload)
+        receipts.append(
+            PhaseReceipt(
+                TranchePhase.LEGAL_ADJUNCT_DEMAND_PLANNING,
+                "completed",
+                (compilation.corpus_ref, str(local_world_path)),
+                (str(legal_plan_path),),
+                legal_plan_payload["summary"],
+            )
+        )
+        artifacts["legal_adjunct_plan"] = str(legal_plan_path)
+
         enrichment_output: dict[str, Any] = {
             "schema_version": "sl.wikimedia_enrichment_run.v0_2",
             "plan": plan,
@@ -382,26 +439,198 @@ def _run_one(args: argparse.Namespace, tranche: str) -> dict[str, Any]:
         )
         artifacts["external_enrichment"] = str(enrichment_path)
 
+        legal_roots: list[Path] = []
+        legal_acquisitions: list[dict[str, Any]] = []
+        if not args.offline and not args.skip_legal_follow:
+            for index, source_plan in enumerate(legal_plans, start=1):
+                result = follow_legal_source_plan(
+                    source_plan,
+                    max_depth=args.follow_depth,
+                    max_documents=args.follow_documents,
+                )
+                if result is None:
+                    legal_acquisitions.append(
+                        {
+                            "demand_ref": source_plan.demand_ref,
+                            "plan_key": source_plan.plan_key,
+                            "state": source_plan.state,
+                            "documents": [],
+                            "authority": "no_acquisition_performed",
+                        }
+                    )
+                    continue
+                root, manifest = _write_follow_sources(
+                    result,
+                    output_dir / "legal_adjunct_sources" / f"{index:04d}",
+                )
+                legal_roots.append(root)
+                legal_acquisitions.append(
+                    {
+                        "demand_ref": source_plan.demand_ref,
+                        "plan_key": source_plan.plan_key,
+                        "state": "acquired",
+                        "manifest": manifest,
+                        "authority": "source_acquisition_only",
+                    }
+                )
+        legal_acquisition_payload = {
+            "schema_version": "sl.legal_adjunct_acquisition.v0_1",
+            "plans": [row.to_dict() for row in legal_plans],
+            "acquisitions": legal_acquisitions,
+            "network_performed": bool(legal_roots),
+            "authority": "source_acquisition_only",
+        }
+        legal_acquisition_path = output_dir / "legal_adjunct_acquisition.json"
+        _json_write(legal_acquisition_path, legal_acquisition_payload)
+        receipts.append(
+            PhaseReceipt(
+                TranchePhase.LEGAL_ADJUNCT_ACQUISITION,
+                "completed" if legal_roots else ("skipped_offline" if args.offline else "no_ready_plans"),
+                (str(legal_plan_path),),
+                (str(legal_acquisition_path),),
+                {
+                    "ready_plan_count": sum(row.state == "ready" for row in legal_plans),
+                    "acquired_source_root_count": len(legal_roots),
+                    "network_performed": bool(legal_roots),
+                },
+            )
+        )
+        artifacts["legal_adjunct_acquisition"] = str(legal_acquisition_path)
+
+        adjunct_corpus_ref = ""
+        adjunct_compile_payload: dict[str, Any] = {
+            "schema_version": "sl.legal_adjunct_pnf_compilation.v0_1",
+            "corpus_ref": "",
+            "document_refs": [],
+            "demand_refs": [],
+            "failure_refs": [],
+            "state": "no_acquired_documents",
+            "same_parser_spine": True,
+        }
+        if legal_roots:
+            adjunct_projection = project_source_families(
+                legal_roots,
+                output_dir=output_dir / "legal_adjunct_projection",
+                max_files=args.max_source_files,
+                max_file_bytes=args.max_file_bytes,
+            )
+            if adjunct_projection.documents:
+                adjunct_compilation = compile_directory_postgres(
+                    output_dir / "legal_adjunct_projection" / "canonical",
+                    context=default_compiler_context(),
+                    store=store,
+                    execution_phase="legal_adjunct_demand_planning",
+                )
+                adjunct_corpus_ref = adjunct_compilation.corpus_ref
+                adjunct_compile_payload.update(
+                    {
+                        "corpus_ref": adjunct_corpus_ref,
+                        "document_refs": list(adjunct_compilation.document_refs),
+                        "demand_refs": list(adjunct_compilation.demand_refs),
+                        "failure_refs": list(adjunct_compilation.failure_refs),
+                        "state": "completed",
+                        "projection_manifest": adjunct_projection.to_dict(),
+                    }
+                )
+        adjunct_compile_path = output_dir / "legal_adjunct_pnf_compilation.json"
+        _json_write(adjunct_compile_path, adjunct_compile_payload)
+        receipts.append(
+            PhaseReceipt(
+                TranchePhase.LEGAL_ADJUNCT_PNF_COMPILATION,
+                adjunct_compile_payload["state"],
+                (str(legal_acquisition_path),),
+                tuple(
+                    value
+                    for value in (adjunct_corpus_ref, str(adjunct_compile_path))
+                    if value
+                ),
+                {
+                    "document_count": len(adjunct_compile_payload["document_refs"]),
+                    "failure_count": len(adjunct_compile_payload["failure_refs"]),
+                    "same_parser_spine": True,
+                },
+            )
+        )
+        artifacts["legal_adjunct_pnf_compilation"] = str(adjunct_compile_path)
+
+        legal_ir_rows: tuple[Any, ...] = ()
+        if adjunct_corpus_ref:
+            with store.transaction() as cursor:
+                legal_pnf_rows = load_legal_pnf_rows(cursor, corpus_ref=adjunct_corpus_ref)
+            legal_ir_rows = project_legal_ir(legal_pnf_rows)
+        legal_ir_payload = {
+            "schema_version": "sl.legal_ir_projection.v0_1",
+            "source_corpus_ref": adjunct_corpus_ref,
+            "observations": [row.to_dict() for row in legal_ir_rows],
+            "summary": {
+                "observation_count": len(legal_ir_rows),
+                "projection_state": (
+                    "candidate_observations_available"
+                    if legal_ir_rows
+                    else "no_legal_pnf_factors_available"
+                ),
+            },
+            "authority": "pnf_projection_only",
+            "parser_profile_used": False,
+        }
+        legal_ir_path = output_dir / "legal_ir_projection.json"
+        _json_write(legal_ir_path, legal_ir_payload)
+        receipts.append(
+            PhaseReceipt(
+                TranchePhase.LEGAL_IR_PROJECTION,
+                "completed" if legal_ir_rows else "empty_projection",
+                (str(adjunct_compile_path),),
+                (str(legal_ir_path),),
+                legal_ir_payload["summary"],
+            )
+        )
+        artifacts["legal_ir_projection"] = str(legal_ir_path)
+
         reconciliation = build_reconciliation_checkpoint(enrichment_output)
+        reconciliation["legal_adjunct"] = {
+            "plans": [row.to_dict() for row in legal_plans],
+            "legal_ir_observations": legal_ir_payload["observations"],
+            "applicability_closed": False,
+            "violation_closed": False,
+            "liability_closed": False,
+            "authority": "typed_reconciliation_pending",
+        }
         reconciliation_path = output_dir / "external_reconciliation.json"
         _json_write(reconciliation_path, reconciliation)
         receipts.append(
             PhaseReceipt(
                 TranchePhase.TYPED_RECONCILIATION,
-                "completed" if enrichment_output["results"] else "no_provider_results",
-                (str(enrichment_path), str(local_world_path)),
+                "completed",
+                (str(enrichment_path), str(legal_ir_path), str(local_world_path)),
                 (str(reconciliation_path),),
-                reconciliation["summary"],
+                {
+                    **reconciliation["summary"],
+                    "legal_plan_count": len(legal_plans),
+                    "legal_ir_observation_count": len(legal_ir_rows),
+                    "legal_closure_count": 0,
+                },
             )
         )
         artifacts["external_reconciliation"] = str(reconciliation_path)
 
         review_path = output_dir / "review_packets.json"
         review_payload = {
-            "schema_version": "sl.tranche_review_surface.v0_1",
+            "schema_version": "sl.tranche_review_surface.v0_2",
             "corpus_ref": compilation.corpus_ref,
             "review_packets": reconciliation["review_packets"],
             "candidate_overlap_signals": reconciliation["candidate_overlap_signals"],
+            "legal_adjunct_review": {
+                "plans": [row.to_dict() for row in legal_plans],
+                "legal_ir_observations": legal_ir_payload["observations"],
+                "available_actions": (
+                    "retain_ambiguity",
+                    "request_more_evidence",
+                    "reject_candidate",
+                    "promote_with_authority",
+                    "abstain",
+                ),
+                "automatic_action": None,
+            },
             "authority": "review_required",
         }
         _json_write(review_path, review_payload)
@@ -414,6 +643,7 @@ def _run_one(args: argparse.Namespace, tranche: str) -> dict[str, Any]:
                 {
                     "review_packet_count": len(review_payload["review_packets"]),
                     "overlap_signal_count": len(review_payload["candidate_overlap_signals"]),
+                    "legal_plan_count": len(legal_plans),
                     "promotion_count": 0,
                 },
             )
@@ -428,7 +658,11 @@ def _run_one(args: argparse.Namespace, tranche: str) -> dict[str, Any]:
         "completed",
         tuple(receipt.receipt_ref for receipt in receipts),
         (str(checkpoint_path),),
-        {"phase_count": len(receipts) + 1, "world_entity_promotion_count": 0},
+        {
+            "phase_count": len(receipts) + 1,
+            "world_entity_promotion_count": 0,
+            "legal_promotion_count": 0,
+        },
     )
     checkpoint = checkpoint_payload(
         profile=profile,
@@ -445,7 +679,7 @@ def main() -> int:
     tranches = ("GWB", "AU", "BREXIT") if args.tranche == "ALL" else (args.tranche,)
     checkpoints = [_run_one(args, tranche) for tranche in tranches]
     summary = {
-        "schema_version": "sl.three_tranche_run.v0_1",
+        "schema_version": "sl.three_tranche_run.v0_2",
         "tranches": [row["profile"]["tranche"] for row in checkpoints],
         "checkpoint_refs": [
             row["phase_receipts"][-1]["receipt_ref"] for row in checkpoints

--- a/scripts/run_legal_pnf_probe.py
+++ b/scripts/run_legal_pnf_probe.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Run a bounded legal-document probe through the universal compiler spine.
+
+The probe preserves source/canonical coordinates, records parser observations and
+PNF graphs, projects Legal IR only from legal PNF factors, compares the legacy
+obligation lane as a diagnostic oracle, and optionally performs candidate-only
+Wikidata lookups that the legal entity-resolution policy warrants.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import sys
+from typing import Any, Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.ingestion.corpus_source_projection import project_source_families  # noqa: E402
+from src.obligations import (  # noqa: E402
+    extract_obligations_from_text,
+    obligation_to_dict,
+)
+from src.ontology.wikimedia_providers import (  # noqa: E402
+    WikidataProvider,
+    WikimediaMicrobatchRunner,
+)
+from src.pnf.legal_probe import build_legal_pnf_probe  # noqa: E402
+from src.policy.corpus_compilation import (  # noqa: E402
+    compile_document,
+    default_compiler_context,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--input-file", type=Path)
+    source.add_argument("--input-directory", type=Path)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--max-files", type=int, default=40)
+    parser.add_argument("--max-file-bytes", type=int, default=5_000_000)
+    parser.add_argument("--compare-legacy", action="store_true")
+    parser.add_argument("--run-wikidata", action="store_true")
+    parser.add_argument("--wikidata-candidate-limit", type=int, default=5)
+    parser.add_argument("--wikidata-request-budget", type=int, default=32)
+    parser.add_argument("--microbatch-size", type=int, default=8)
+    args = parser.parse_args()
+    if args.max_files < 1:
+        parser.error("--max-files must be positive")
+    if args.max_file_bytes < 1:
+        parser.error("--max-file-bytes must be positive")
+    if args.run_wikidata and not args.compare_legacy:
+        # Not semantically required, but keeps live probes deliberately explicit.
+        parser.error("--run-wikidata requires --compare-legacy for an auditable probe")
+    return args
+
+
+def _write_json(path: Path, value: Mapping[str, Any] | list[Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _document_ref(canonical_sha256: str) -> str:
+    payload = f"legal-pnf-probe|{canonical_sha256}".encode("utf-8")
+    return "document:" + hashlib.sha256(payload).hexdigest()
+
+
+def _compile_projection_row(row: Any, projection_root: Path) -> Mapping[str, Any]:
+    canonical_path = projection_root / row.canonical_path
+    canonical_text = canonical_path.read_text(encoding="utf-8")
+    compilation = compile_document(
+        {
+            "document_ref": _document_ref(row.canonical_sha256),
+            "source_ref": row.source_ref,
+            "media_type": "text/plain",
+            "content_sha256": row.canonical_sha256,
+            "canonical_text": canonical_text,
+        },
+        default_compiler_context(),
+    )
+    return compilation.to_dict()
+
+
+def _legacy_rows(text: str) -> list[dict[str, Any]]:
+    return [
+        obligation_to_dict(row)
+        for row in extract_obligations_from_text(
+            text,
+            references=[],
+            source_id="legal-pnf-probe",
+        )
+    ]
+
+
+def main() -> int:
+    args = _parse_args()
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    root = (args.input_file or args.input_directory).resolve()
+    projection_root = output_dir / "source_projection"
+    manifest = project_source_families(
+        [root],
+        output_dir=projection_root,
+        max_files=args.max_files,
+        max_file_bytes=args.max_file_bytes,
+    )
+    _write_json(projection_root / "manifest.json", manifest.to_dict())
+
+    probe_rows: list[dict[str, Any]] = []
+    wikidata_demands = []
+    for index, row in enumerate(manifest.documents, start=1):
+        compilation = _compile_projection_row(row, projection_root)
+        canonical_text = str((compilation.get("artifacts") or {}).get("canonical_text") or "")
+        legacy = _legacy_rows(canonical_text) if args.compare_legacy else []
+        probe = build_legal_pnf_probe(compilation, legacy_rows=legacy)
+        document_dir = output_dir / "documents" / f"{index:04d}_{row.canonical_sha256[:12]}"
+        artifacts = compilation.get("artifacts") or {}
+        _write_json(document_dir / "compilation.json", compilation)
+        _write_json(document_dir / "parser_observations.json", probe["parser_observations"])
+        _write_json(document_dir / "pnf_graph.json", probe["pnf_graph"])
+        _write_json(document_dir / "refined_pnf_graph.json", probe["refined_pnf_graph"])
+        _write_json(document_dir / "legal_ir.json", probe["legal_ir"])
+        _write_json(document_dir / "legacy_obligations.json", probe["legacy_observations"])
+        _write_json(document_dir / "comparison_ledger.json", probe["comparison_ledger"])
+        _write_json(
+            document_dir / "entity_resolution_decisions.json",
+            probe["entity_resolution_decisions"],
+        )
+        _write_json(document_dir / "wikidata_plan.json", probe["wikidata_lookup_demands"])
+        probe_rows.append(
+            {
+                "source_path": row.source_path,
+                "source_ref": row.source_ref,
+                "document_ref": compilation.get("document_ref"),
+                "probe_ref": probe["probe_ref"],
+                "summary": probe["summary"],
+                "document_output_dir": str(document_dir),
+                "parser_receipt": artifacts.get("parser_receipt") or {},
+            }
+        )
+        wikidata_demands.extend(probe["wikidata_lookup_demands"])
+
+    wikidata_output: dict[str, Any] = {
+        "network_performed": False,
+        "authority": "candidate_only",
+        "identity_closed": False,
+        "results": [],
+    }
+    if args.run_wikidata and wikidata_demands:
+        # Reconstruct typed demand objects from each probe to avoid broad lookups.
+        from src.ontology.external_enrichment import ExternalLookupDemand
+
+        demands = tuple(
+            ExternalLookupDemand(
+                demand_ref=str(row["demand_ref"]),
+                subject_ref=str(row["subject_ref"]),
+                surface=str(row["surface"]),
+                demand_kind=str(row["demand_kind"]),
+                local_type_refs=tuple(row.get("local_type_refs") or ()),
+                context_terms=tuple(row.get("context_terms") or ()),
+                priority=int(row.get("priority") or 0),
+                provenance_refs=tuple(row.get("provenance_refs") or ()),
+            )
+            for row in wikidata_demands
+        )
+        runner = WikimediaMicrobatchRunner(
+            [WikidataProvider(candidate_limit=args.wikidata_candidate_limit)],
+            microbatch_size=args.microbatch_size,
+            request_budget_per_provider=args.wikidata_request_budget,
+        )
+        results = runner.run(demands)
+        wikidata_output = {
+            "network_performed": True,
+            "authority": "candidate_only",
+            "identity_closed": False,
+            "results": [row.to_dict() for row in results],
+        }
+    _write_json(output_dir / "wikidata_results.json", wikidata_output)
+
+    summary = {
+        "schema_version": "sl.legal_pnf_probe_run.v0_1",
+        "source_projection": str(projection_root / "manifest.json"),
+        "documents": probe_rows,
+        "document_count": len(probe_rows),
+        "projection_failure_count": len(manifest.failures),
+        "legal_ir_observation_count": sum(
+            int(row["summary"]["legal_ir_observation_count"]) for row in probe_rows
+        ),
+        "coverage_gap_count": sum(
+            int(row["summary"]["coverage_gap_count"]) for row in probe_rows
+        ),
+        "wikidata_lookup_demand_count": len(wikidata_demands),
+        "wikidata_network_performed": wikidata_output["network_performed"],
+        "identity_closure_count": 0,
+        "legal_conclusion_promotion_count": 0,
+        "authority": "diagnostic_only",
+    }
+    _write_json(output_dir / "coverage_scorecard.json", summary)
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pnf/legal_adjunct.py
+++ b/src/pnf/legal_adjunct.py
@@ -1,0 +1,371 @@
+"""PNF-driven legal adjunct demand, Legal IR, and typed-meet algebra.
+
+There is no legal parser in this module. Every input is already a span-grounded
+PNF row produced by the one canonical parser spine. Legal IR is a downstream
+projection of those PNF rows, and acquisition plans are emitted only from
+explicit legal facets or explicit operator demands.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.ontology.external_enrichment import canonical_sha256
+
+LEGAL_ADJUNCT_CONTRACT = "pnf-legal-adjunct:v0_1"
+LEGAL_IR_PROJECTION_CONTRACT = "legal-ir-from-pnf:v0_1"
+
+_LEGAL_TRIGGER_FACETS = frozenset(
+    {
+        "legal.relevance_unresolved",
+        "legal.authority_absent",
+        "legal.applicability_unresolved",
+        "legal.interpretation_unresolved",
+    }
+)
+_LEGAL_PNF_TYPES = frozenset(
+    {
+        "semantic.normative_relation",
+        "semantic.legal_condition",
+        "semantic.legal_exception",
+        "semantic.legal_burden",
+        "semantic.legal_authority",
+        "semantic.legal_transition",
+        "semantic.judicial_treatment",
+    }
+)
+
+
+def _values_with_prefix(values: Iterable[str], prefix: str) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                value[len(prefix) :]
+                for value in values
+                if value.startswith(prefix) and value[len(prefix) :]
+            }
+        )
+    )
+
+
+@dataclass(frozen=True)
+class NormativeInteractionDemand:
+    """Typed request for legal evidence derived from PNF or an explicit call."""
+
+    demand_ref: str
+    origin_pnf_ref: str
+    interaction_signature_ref: str
+    jurisdiction_refs: tuple[str, ...]
+    temporal_refs: tuple[str, ...]
+    source_role_refs: tuple[str, ...]
+    authority_level_refs: tuple[str, ...]
+    requested_legal_facets: tuple[str, ...]
+    provider_profile_refs: tuple[str, ...]
+    open_slots: tuple[str, ...]
+    provenance_refs: tuple[str, ...]
+    priority: int = 50
+    explicit: bool = False
+
+    @property
+    def acquisition_ready(self) -> bool:
+        return bool(
+            self.jurisdiction_refs
+            and self.source_role_refs
+            and self.authority_level_refs
+            and not self.open_slots
+        )
+
+    @property
+    def plan_key(self) -> str:
+        return canonical_sha256(
+            {
+                "contract": LEGAL_ADJUNCT_CONTRACT,
+                "interaction_signature_ref": self.interaction_signature_ref,
+                "jurisdiction_refs": self.jurisdiction_refs,
+                "temporal_refs": self.temporal_refs,
+                "source_role_refs": self.source_role_refs,
+                "authority_level_refs": self.authority_level_refs,
+                "requested_legal_facets": self.requested_legal_facets,
+                "provider_profile_refs": self.provider_profile_refs,
+            }
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "acquisition_ready": self.acquisition_ready,
+            "plan_key": self.plan_key,
+            "authority": "demand_only",
+        }
+
+
+@dataclass(frozen=True)
+class LegalSourcePlan:
+    demand_ref: str
+    plan_key: str
+    jurisdiction_ref: str
+    source_role_refs: tuple[str, ...]
+    authority_level_refs: tuple[str, ...]
+    provider_profile_refs: tuple[str, ...]
+    requested_legal_facets: tuple[str, ...]
+    temporal_refs: tuple[str, ...]
+    state: str
+    blocked_reasons: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**asdict(self), "authority": "acquisition_plan_only"}
+
+
+@dataclass(frozen=True)
+class LegalIRObservation:
+    """Operational Legal IR row projected from one PNF revision."""
+
+    observation_ref: str
+    pnf_factor_ref: str
+    pnf_revision_ref: str
+    structural_signature_ref: str
+    predicate_ref: str
+    role_bindings: Mapping[str, str]
+    qualifier_state: Mapping[str, Any]
+    wrapper_state: Mapping[str, Any]
+    provenance_refs: tuple[str, ...]
+    residual_refs: tuple[str, ...]
+    projection_state: str = "candidate"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "role_bindings": dict(self.role_bindings),
+            "qualifier_state": dict(self.qualifier_state),
+            "wrapper_state": dict(self.wrapper_state),
+            "authority": "pnf_projection_only",
+        }
+
+
+@dataclass(frozen=True)
+class LegalTypedMeet:
+    world_pnf_ref: str
+    legal_ir_ref: str
+    structural_state: str
+    jurisdiction_state: str
+    temporal_state: str
+    actor_state: str
+    conduct_state: str
+    object_state: str
+    circumstance_state: str
+    exception_state: str
+    burden_state: str
+    residual_refs: tuple[str, ...]
+
+    @property
+    def applicability_closed(self) -> bool:
+        return False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "applicability_closed": False,
+            "violation_closed": False,
+            "liability_closed": False,
+            "authority": "typed_comparison_only",
+        }
+
+
+def project_normative_interaction_demands(
+    rows: Iterable[Mapping[str, Any]],
+) -> tuple[NormativeInteractionDemand, ...]:
+    """Project legal work only from explicit normalized legal facets.
+
+    A predicate lemma such as ``drive`` is insufficient. The source row must
+    carry a legal trigger facet, or be marked as an explicit operator request.
+    Namespaced facets supply jurisdiction, time, source role, authority level,
+    provider profile, and requested legal work without a hard-coded action map.
+    """
+
+    projected: dict[tuple[str, str], NormativeInteractionDemand] = {}
+    for row in rows:
+        facets = tuple(sorted({str(value) for value in row.get("requested_facets") or ()}))
+        explicit = bool(row.get("explicit_legal_request"))
+        if not explicit and not _LEGAL_TRIGGER_FACETS.intersection(facets):
+            continue
+        demand_ref = str(row.get("demand_ref") or "")
+        origin_ref = str(
+            row.get("factor_revision_ref")
+            or row.get("origin_pnf_ref")
+            or row.get("factor_ref")
+            or ""
+        )
+        signature_ref = str(row.get("structural_signature_ref") or "")
+        if not demand_ref or not origin_ref or not signature_ref:
+            continue
+        jurisdictions = _values_with_prefix(facets, "legal.jurisdiction:")
+        temporal_refs = _values_with_prefix(facets, "legal.time:")
+        source_roles = _values_with_prefix(facets, "legal.source_role:")
+        authority_levels = _values_with_prefix(facets, "legal.authority_level:")
+        providers = _values_with_prefix(facets, "legal.provider_profile:")
+        requested = tuple(
+            sorted(
+                _LEGAL_TRIGGER_FACETS.intersection(facets)
+                | set(_values_with_prefix(facets, "legal.request:"))
+            )
+        )
+        open_slots: list[str] = []
+        if not jurisdictions:
+            open_slots.append("jurisdiction_unresolved")
+        if not source_roles:
+            open_slots.append("source_role_unresolved")
+        if not authority_levels:
+            open_slots.append("authority_level_unresolved")
+        demand = NormativeInteractionDemand(
+            demand_ref=demand_ref,
+            origin_pnf_ref=origin_ref,
+            interaction_signature_ref=signature_ref,
+            jurisdiction_refs=jurisdictions,
+            temporal_refs=temporal_refs,
+            source_role_refs=source_roles,
+            authority_level_refs=authority_levels,
+            requested_legal_facets=requested,
+            provider_profile_refs=providers,
+            open_slots=tuple(open_slots),
+            provenance_refs=tuple(
+                sorted(
+                    {
+                        origin_ref,
+                        LEGAL_ADJUNCT_CONTRACT,
+                        *(str(value) for value in row.get("provenance_refs") or ()),
+                    }
+                )
+            ),
+            priority=int(row.get("priority") or (100 if explicit else 50)),
+            explicit=explicit,
+        )
+        projected[(demand.demand_ref, demand.plan_key)] = demand
+    return tuple(
+        sorted(
+            projected.values(),
+            key=lambda item: (-item.priority, item.demand_ref, item.plan_key),
+        )
+    )
+
+
+def plan_legal_sources(
+    demands: Iterable[NormativeInteractionDemand],
+) -> tuple[LegalSourcePlan, ...]:
+    plans: list[LegalSourcePlan] = []
+    for demand in demands:
+        blocked = demand.open_slots
+        plans.append(
+            LegalSourcePlan(
+                demand_ref=demand.demand_ref,
+                plan_key=demand.plan_key,
+                jurisdiction_ref=demand.jurisdiction_refs[0] if demand.jurisdiction_refs else "",
+                source_role_refs=demand.source_role_refs,
+                authority_level_refs=demand.authority_level_refs,
+                provider_profile_refs=demand.provider_profile_refs,
+                requested_legal_facets=demand.requested_legal_facets,
+                temporal_refs=demand.temporal_refs,
+                state="ready" if demand.acquisition_ready else "blocked_missing_context",
+                blocked_reasons=blocked,
+            )
+        )
+    return tuple(plans)
+
+
+def project_legal_ir(rows: Iterable[Mapping[str, Any]]) -> tuple[LegalIRObservation, ...]:
+    """Project Legal IR from already-constructed PNF rows.
+
+    Rows without a legal PNF factor type are ignored. This deliberately refuses
+    to infer legal meaning from source family, filename, or isolated lemmas.
+    """
+
+    projected: dict[str, LegalIRObservation] = {}
+    for row in rows:
+        factor_type = str(row.get("factor_type_ref") or "")
+        if factor_type not in _LEGAL_PNF_TYPES and not factor_type.startswith("semantic.legal."):
+            continue
+        factor_ref = str(row.get("factor_ref") or "")
+        revision_ref = str(row.get("factor_revision_ref") or "")
+        signature_ref = str(row.get("structural_signature_ref") or "")
+        predicate_ref = str(row.get("predicate_ref") or factor_type)
+        if not factor_ref or not revision_ref or not signature_ref:
+            continue
+        identity = {
+            "contract": LEGAL_IR_PROJECTION_CONTRACT,
+            "factor_ref": factor_ref,
+            "factor_revision_ref": revision_ref,
+            "structural_signature_ref": signature_ref,
+        }
+        observation_ref = "legal-ir-observation:" + canonical_sha256(identity)
+        projected[observation_ref] = LegalIRObservation(
+            observation_ref=observation_ref,
+            pnf_factor_ref=factor_ref,
+            pnf_revision_ref=revision_ref,
+            structural_signature_ref=signature_ref,
+            predicate_ref=predicate_ref,
+            role_bindings=dict(row.get("role_bindings") or {}),
+            qualifier_state=dict(row.get("qualifier_state") or {}),
+            wrapper_state=dict(row.get("wrapper_state") or {}),
+            provenance_refs=tuple(sorted(str(value) for value in row.get("provenance_refs") or ())),
+            residual_refs=tuple(sorted(str(value) for value in row.get("residual_refs") or ())),
+        )
+    return tuple(sorted(projected.values(), key=lambda item: item.observation_ref))
+
+
+def typed_legal_meet(
+    world_row: Mapping[str, Any],
+    legal_observation: LegalIRObservation,
+) -> LegalTypedMeet:
+    world_signature = str(world_row.get("structural_signature_ref") or "")
+    if not world_signature or world_signature != legal_observation.structural_signature_ref:
+        return LegalTypedMeet(
+            world_pnf_ref=str(world_row.get("factor_revision_ref") or world_row.get("factor_ref") or ""),
+            legal_ir_ref=legal_observation.observation_ref,
+            structural_state="NO_TYPED_MEET",
+            jurisdiction_state="not_evaluated",
+            temporal_state="not_evaluated",
+            actor_state="not_evaluated",
+            conduct_state="not_evaluated",
+            object_state="not_evaluated",
+            circumstance_state="not_evaluated",
+            exception_state="not_evaluated",
+            burden_state="not_evaluated",
+            residual_refs=("cross_fibre_incommensurable",),
+        )
+    coordinates = dict(world_row.get("legal_coordinates") or {})
+    return LegalTypedMeet(
+        world_pnf_ref=str(world_row.get("factor_revision_ref") or world_row.get("factor_ref") or ""),
+        legal_ir_ref=legal_observation.observation_ref,
+        structural_state="same_fibre_candidate",
+        jurisdiction_state=str(coordinates.get("jurisdiction_state") or "unresolved"),
+        temporal_state=str(coordinates.get("temporal_state") or "unresolved"),
+        actor_state=str(coordinates.get("actor_state") or "unresolved"),
+        conduct_state=str(coordinates.get("conduct_state") or "unresolved"),
+        object_state=str(coordinates.get("object_state") or "unresolved"),
+        circumstance_state=str(coordinates.get("circumstance_state") or "unresolved"),
+        exception_state=str(coordinates.get("exception_state") or "unresolved"),
+        burden_state=str(coordinates.get("burden_state") or "unresolved"),
+        residual_refs=tuple(
+            sorted(
+                {
+                    "legal_applicability_unresolved",
+                    "exception_status_unresolved",
+                    "burden_status_unresolved",
+                }
+            )
+        ),
+    )
+
+
+__all__ = [
+    "LEGAL_ADJUNCT_CONTRACT",
+    "LEGAL_IR_PROJECTION_CONTRACT",
+    "LegalIRObservation",
+    "LegalSourcePlan",
+    "LegalTypedMeet",
+    "NormativeInteractionDemand",
+    "plan_legal_sources",
+    "project_legal_ir",
+    "project_normative_interaction_demands",
+    "typed_legal_meet",
+]

--- a/src/pnf/legal_probe.py
+++ b/src/pnf/legal_probe.py
@@ -1,0 +1,412 @@
+"""Bounded differential probe for legal text through the universal PNF spine.
+
+This module does not parse text and does not infer legal meaning from filenames,
+source families, or a second legal grammar.  It consumes ordinary compiler
+artifacts, projects Legal IR from already-constructed PNF, compares optional
+legacy observations as a non-authoritative oracle, and plans candidate-only
+entity enrichment when unresolved identity materially blocks a legal object.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.ontology.external_enrichment import ExternalLookupDemand, canonical_sha256
+from src.pnf.legal_adjunct import LegalIRObservation, project_legal_ir
+
+LEGAL_PNF_PROBE_CONTRACT = "legal-pnf-probe:v0_1"
+LEGAL_ENTITY_RESOLUTION_POLICY = "legal-entity-resolution-policy:v0_1"
+
+_EXPECTED_COORDINATES = (
+    "actor",
+    "modality",
+    "conduct",
+    "object",
+    "condition",
+    "exception",
+    "jurisdiction",
+    "temporal_validity",
+    "authority_wrapper",
+)
+
+_ENTITY_ROLE_KEYS = frozenset(
+    {
+        "actor",
+        "bearer",
+        "court",
+        "decision_maker",
+        "institution",
+        "party",
+        "subject",
+        "jurisdiction",
+        "authority",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CoverageRow:
+    coordinate: str
+    pnf_present: bool
+    legal_ir_present: bool
+    legacy_present: bool
+    state: str
+    residual_refs: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LegalEntityResolutionDecision:
+    factor_ref: str
+    factor_revision_ref: str
+    surface: str
+    state: str
+    reasons: tuple[str, ...]
+    blocking_legal_ir_refs: tuple[str, ...]
+    requested_facets: tuple[str, ...]
+    provenance_refs: tuple[str, ...]
+
+    @property
+    def should_lookup(self) -> bool:
+        return self.state == "candidate_lookup_warranted"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "should_lookup": self.should_lookup,
+            "authority": "planning_only",
+            "identity_closed": False,
+        }
+
+
+def _factor_rows(artifacts: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    graph = artifacts.get("refined_pnf_graph") or artifacts.get("pnf_graph") or {}
+    return tuple(row for row in graph.get("factors") or () if isinstance(row, Mapping))
+
+
+def _alternative_type_refs(factor: Mapping[str, Any]) -> tuple[str, ...]:
+    refs: set[str] = set()
+    for alternative in factor.get("alternatives") or ():
+        if not isinstance(alternative, Mapping):
+            continue
+        type_ref = str(alternative.get("type_ref") or "")
+        if type_ref:
+            refs.add(type_ref)
+        value = alternative.get("value")
+        if isinstance(value, Mapping):
+            family = str(value.get("semantic_family") or "")
+            local_type = str(value.get("local_type") or "")
+            if family:
+                refs.add("semantic-family:" + family)
+            if local_type:
+                refs.add(local_type)
+    return tuple(sorted(refs))
+
+
+def _entity_shaped(factor: Mapping[str, Any]) -> bool:
+    factor_type = str(factor.get("factor_type") or factor.get("factor_type_ref") or "")
+    if factor_type == "semantic.mention_identity":
+        return True
+    refs = _alternative_type_refs(factor)
+    return any(
+        marker in ref.casefold()
+        for ref in refs
+        for marker in (
+            "semantic-family:entity",
+            "named_entity",
+            "proper_noun",
+            "person",
+            "organization",
+            "institution",
+            "jurisdiction",
+            "court",
+        )
+    )
+
+
+def _surface(factor: Mapping[str, Any], artifacts: Mapping[str, Any]) -> str:
+    metadata = factor.get("metadata") or {}
+    if isinstance(metadata, Mapping):
+        for key in ("canonical_surface", "surface", "text"):
+            if metadata.get(key):
+                return str(metadata[key]).strip()
+        mention_ref = str(metadata.get("mention_ref") or "")
+    else:
+        mention_ref = ""
+    mentions = (artifacts.get("licensing") or {}).get("mentions") or ()
+    for mention in mentions:
+        if not isinstance(mention, Mapping):
+            continue
+        if mention_ref and str(mention.get("mention_ref") or "") != mention_ref:
+            continue
+        value = str(mention.get("canonical_surface") or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _legal_role_references(
+    legal_ir: Sequence[LegalIRObservation],
+) -> dict[str, tuple[str, ...]]:
+    references: dict[str, set[str]] = {}
+    for observation in legal_ir:
+        for role, factor_ref in observation.role_bindings.items():
+            if role.casefold() not in _ENTITY_ROLE_KEYS:
+                continue
+            references.setdefault(str(factor_ref), set()).add(observation.observation_ref)
+    return {key: tuple(sorted(value)) for key, value in references.items()}
+
+
+def plan_legal_entity_resolution(
+    artifacts: Mapping[str, Any],
+    legal_ir: Sequence[LegalIRObservation],
+) -> tuple[LegalEntityResolutionDecision, ...]:
+    """Plan Wikidata work only when identity blocks a legal structure.
+
+    A proper noun or entity-shaped factor is not sufficient.  The factor must
+    retain external-identity pressure and be referenced by a legal PNF role, or
+    carry an explicit legal identity blocking residual.  The output is a lookup
+    proposal only and never closes identity.
+    """
+
+    role_refs = _legal_role_references(legal_ir)
+    decisions: list[LegalEntityResolutionDecision] = []
+    for factor in _factor_rows(artifacts):
+        factor_ref = str(factor.get("factor_ref") or "")
+        metadata = factor.get("metadata") or {}
+        revision_ref = str(
+            (metadata.get("factor_revision_ref") if isinstance(metadata, Mapping) else "")
+            or factor.get("factor_revision_ref")
+            or factor_ref
+        )
+        residuals = {str(value) for value in factor.get("residuals") or ()}
+        blockers = role_refs.get(factor_ref, ())
+        legal_blocker = bool(
+            residuals.intersection(
+                {
+                    "legal_entity_identity_unresolved",
+                    "legal_authority_identity_unresolved",
+                    "jurisdiction_identity_unresolved",
+                    "party_identity_unresolved",
+                }
+            )
+        )
+        reasons: list[str] = []
+        state = "not_warranted"
+        surface = _surface(factor, artifacts)
+        if not _entity_shaped(factor):
+            reasons.append("factor_not_entity_shaped")
+        elif "external_identity_unresolved" not in residuals and not legal_blocker:
+            reasons.append("external_identity_not_open")
+        elif not blockers and not legal_blocker:
+            reasons.append("identity_does_not_block_legal_structure")
+        elif not surface:
+            reasons.append("surface_unavailable")
+            state = "blocked_missing_surface"
+        else:
+            reasons.extend(("entity_identity_open", "legal_coordinate_blocked"))
+            state = "candidate_lookup_warranted"
+        decisions.append(
+            LegalEntityResolutionDecision(
+                factor_ref=factor_ref,
+                factor_revision_ref=revision_ref,
+                surface=surface,
+                state=state,
+                reasons=tuple(reasons),
+                blocking_legal_ir_refs=blockers,
+                requested_facets=("external_identity_unresolved",),
+                provenance_refs=(revision_ref, LEGAL_ENTITY_RESOLUTION_POLICY),
+            )
+        )
+    return tuple(sorted(decisions, key=lambda row: (row.state, row.factor_ref)))
+
+
+def legal_entity_lookup_demands(
+    decisions: Iterable[LegalEntityResolutionDecision],
+) -> tuple[ExternalLookupDemand, ...]:
+    demands: list[ExternalLookupDemand] = []
+    for decision in decisions:
+        if not decision.should_lookup:
+            continue
+        demand_ref = "legal-entity-demand:" + canonical_sha256(decision.to_dict())
+        demands.append(
+            ExternalLookupDemand(
+                demand_ref=demand_ref,
+                subject_ref=decision.factor_ref,
+                surface=decision.surface,
+                demand_kind="entity_identity",
+                local_type_refs=("semantic.legal_role_entity",),
+                context_terms=("legal_role",),
+                priority=90,
+                provenance_refs=decision.provenance_refs,
+            )
+        )
+    return tuple(sorted(demands, key=lambda row: (-row.priority, row.demand_ref)))
+
+
+def _legacy_features(legacy_rows: Sequence[Mapping[str, Any]]) -> set[str]:
+    features: set[str] = set()
+    for row in legacy_rows:
+        if row.get("actor"):
+            features.add("actor")
+        if row.get("modality") or row.get("type"):
+            features.add("modality")
+        if row.get("action"):
+            features.add("conduct")
+        if row.get("object") or row.get("obj"):
+            features.add("object")
+        if row.get("conditions"):
+            features.add("condition")
+        if any(
+            str(item.get("type") or "") in {"unless", "except", "exception"}
+            for item in row.get("conditions") or ()
+            if isinstance(item, Mapping)
+        ):
+            features.add("exception")
+        if row.get("scopes"):
+            features.add("jurisdiction")
+        if row.get("lifecycle"):
+            features.add("temporal_validity")
+        if row.get("references") or row.get("reference_identities"):
+            features.add("authority_wrapper")
+    return features
+
+
+def _pnf_features(factors: Sequence[Mapping[str, Any]]) -> set[str]:
+    features: set[str] = set()
+    for factor in factors:
+        factor_type = str(factor.get("factor_type") or factor.get("factor_type_ref") or "")
+        metadata = factor.get("metadata") or {}
+        role = str(metadata.get("role") or "") if isinstance(metadata, Mapping) else ""
+        if role in {"subject", "actor", "agent", "bearer"}:
+            features.add("actor")
+        if factor_type == "semantic.eventuality" or "conduct" in factor_type:
+            features.add("conduct")
+        if role in {"object", "patient", "theme"}:
+            features.add("object")
+        if factor_type == "semantic.normative_relation":
+            features.add("modality")
+        if factor_type == "semantic.legal_condition":
+            features.add("condition")
+        if factor_type == "semantic.legal_exception":
+            features.add("exception")
+        if factor_type in {"semantic.legal_authority", "semantic.judicial_treatment"}:
+            features.add("authority_wrapper")
+        if factor_type == "semantic.legal_transition":
+            features.add("temporal_validity")
+        if "jurisdiction" in factor_type or role == "jurisdiction":
+            features.add("jurisdiction")
+    return features
+
+
+def _legal_ir_features(rows: Sequence[LegalIRObservation]) -> set[str]:
+    features: set[str] = set()
+    for row in rows:
+        roles = {key.casefold() for key in row.role_bindings}
+        if roles.intersection({"actor", "bearer", "court", "party"}):
+            features.add("actor")
+        if roles.intersection({"conduct", "action", "predicate"}):
+            features.add("conduct")
+        if roles.intersection({"object", "patient", "theme"}):
+            features.add("object")
+        if row.qualifier_state.get("modality") or "normative" in row.predicate_ref:
+            features.add("modality")
+        if row.qualifier_state.get("condition_ref"):
+            features.add("condition")
+        if row.qualifier_state.get("exception_ref"):
+            features.add("exception")
+        if row.wrapper_state.get("jurisdiction_ref"):
+            features.add("jurisdiction")
+        if row.wrapper_state.get("validity_interval"):
+            features.add("temporal_validity")
+        if row.wrapper_state.get("authority_class"):
+            features.add("authority_wrapper")
+    return features
+
+
+def build_legal_pnf_probe(
+    compilation: Mapping[str, Any],
+    *,
+    legacy_rows: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    """Build a deterministic probe ledger from one document compilation."""
+
+    artifacts = compilation.get("artifacts") or compilation
+    factors = _factor_rows(artifacts)
+    legal_ir = project_legal_ir(factors)
+    pnf_features = _pnf_features(factors)
+    ir_features = _legal_ir_features(legal_ir)
+    legacy_features = _legacy_features(legacy_rows)
+    coverage: list[CoverageRow] = []
+    for coordinate in _EXPECTED_COORDINATES:
+        pnf_present = coordinate in pnf_features
+        ir_present = coordinate in ir_features
+        legacy_present = coordinate in legacy_features
+        residuals: list[str] = []
+        if legacy_present and not pnf_present:
+            residuals.append(f"legacy_{coordinate}_candidate_not_reconstructed_in_pnf")
+        if pnf_present and not ir_present and coordinate not in {"conduct", "actor", "object"}:
+            residuals.append(f"pnf_{coordinate}_not_projected_to_legal_ir")
+        state = (
+            "pnf_and_legal_ir"
+            if pnf_present and ir_present
+            else "pnf_only"
+            if pnf_present
+            else "legacy_only_gap"
+            if legacy_present
+            else "not_observed"
+        )
+        coverage.append(
+            CoverageRow(
+                coordinate=coordinate,
+                pnf_present=pnf_present,
+                legal_ir_present=ir_present,
+                legacy_present=legacy_present,
+                state=state,
+                residual_refs=tuple(residuals),
+            )
+        )
+    entity_decisions = plan_legal_entity_resolution(artifacts, legal_ir)
+    entity_demands = legal_entity_lookup_demands(entity_decisions)
+    payload = {
+        "schema_version": "sl.legal_pnf_probe.v0_1",
+        "contract_ref": LEGAL_PNF_PROBE_CONTRACT,
+        "document_ref": compilation.get("document_ref"),
+        "canonical_text": artifacts.get("canonical_text"),
+        "parser_receipt": artifacts.get("parser_receipt") or {},
+        "parser_observations": artifacts.get("semantic_annotation_layer") or {},
+        "relational_bundle": artifacts.get("relational_bundle") or {},
+        "pnf_graph": artifacts.get("pnf_graph") or {},
+        "refined_pnf_graph": artifacts.get("refined_pnf_graph") or {},
+        "legal_ir": [row.to_dict() for row in legal_ir],
+        "legacy_observations": list(legacy_rows),
+        "comparison_ledger": [row.to_dict() for row in coverage],
+        "entity_resolution_decisions": [row.to_dict() for row in entity_decisions],
+        "wikidata_lookup_demands": [row.to_dict() for row in entity_demands],
+        "summary": {
+            "pnf_factor_count": len(factors),
+            "legal_ir_observation_count": len(legal_ir),
+            "legacy_observation_count": len(legacy_rows),
+            "coverage_gap_count": sum(bool(row.residual_refs) for row in coverage),
+            "wikidata_lookup_demand_count": len(entity_demands),
+            "identity_closure_count": 0,
+            "legal_conclusion_promotion_count": 0,
+        },
+        "authority": "diagnostic_only",
+    }
+    payload["probe_ref"] = "legal-pnf-probe:" + canonical_sha256(payload)
+    return payload
+
+
+__all__ = [
+    "LEGAL_ENTITY_RESOLUTION_POLICY",
+    "LEGAL_PNF_PROBE_CONTRACT",
+    "CoverageRow",
+    "LegalEntityResolutionDecision",
+    "build_legal_pnf_probe",
+    "legal_entity_lookup_demands",
+    "plan_legal_entity_resolution",
+]

--- a/src/runtime/tranche_pipeline.py
+++ b/src/runtime/tranche_pipeline.py
@@ -3,6 +3,10 @@
 The contract is shared by GWB, AU and Brexit. Profiles may supply different
 source families and authority providers, but they cannot reorder the semantic
 phases or let network enrichment block deterministic local compilation.
+
+Parser doctrine is fixed: one media adapter, one canonical text substrate, one
+parser spine, then PNF. Legal IR and legal acquisition are downstream PNF
+operations; they are not source-family parser profiles.
 """
 
 from __future__ import annotations
@@ -15,7 +19,7 @@ from typing import Any, Mapping, Sequence
 from src.ontology.external_enrichment import canonical_sha256
 
 
-TRANCHE_PIPELINE_CONTRACT = "complete-tranche-pipeline:v0_1"
+TRANCHE_PIPELINE_CONTRACT = "complete-tranche-pipeline:v0_2"
 
 
 class TranchePhase(IntEnum):
@@ -25,14 +29,18 @@ class TranchePhase(IntEnum):
     LOCAL_PNF_COMPILATION = 40
     LOCAL_WORLD_PROJECTION = 50
     EXTERNAL_DEMAND_PLANNING = 60
+    LEGAL_ADJUNCT_DEMAND_PLANNING = 65
     EXTERNAL_ACQUISITION = 70
+    LEGAL_ADJUNCT_ACQUISITION = 75
+    LEGAL_ADJUNCT_PNF_COMPILATION = 77
+    LEGAL_IR_PROJECTION = 78
     TYPED_RECONCILIATION = 80
     REVIEW_PACKET = 90
     CHECKPOINT = 100
 
     @property
     def phase_ref(self) -> str:
-        return f"tranche-phase:{self.name.lower()}:v0_1"
+        return f"tranche-phase:{self.name.lower()}:v0_2"
 
 
 _PHASE_DEPENDENCIES: Mapping[TranchePhase, tuple[TranchePhase, ...]] = {
@@ -48,8 +56,26 @@ _PHASE_DEPENDENCIES: Mapping[TranchePhase, tuple[TranchePhase, ...]] = {
         TranchePhase.LOCAL_PNF_COMPILATION,
         TranchePhase.LOCAL_WORLD_PROJECTION,
     ),
+    TranchePhase.LEGAL_ADJUNCT_DEMAND_PLANNING: (
+        TranchePhase.LOCAL_PNF_COMPILATION,
+        TranchePhase.LOCAL_WORLD_PROJECTION,
+        TranchePhase.EXTERNAL_DEMAND_PLANNING,
+    ),
     TranchePhase.EXTERNAL_ACQUISITION: (TranchePhase.EXTERNAL_DEMAND_PLANNING,),
-    TranchePhase.TYPED_RECONCILIATION: (TranchePhase.EXTERNAL_ACQUISITION,),
+    TranchePhase.LEGAL_ADJUNCT_ACQUISITION: (
+        TranchePhase.LEGAL_ADJUNCT_DEMAND_PLANNING,
+        TranchePhase.EXTERNAL_ACQUISITION,
+    ),
+    TranchePhase.LEGAL_ADJUNCT_PNF_COMPILATION: (
+        TranchePhase.LEGAL_ADJUNCT_ACQUISITION,
+    ),
+    TranchePhase.LEGAL_IR_PROJECTION: (
+        TranchePhase.LEGAL_ADJUNCT_PNF_COMPILATION,
+    ),
+    TranchePhase.TYPED_RECONCILIATION: (
+        TranchePhase.EXTERNAL_ACQUISITION,
+        TranchePhase.LEGAL_IR_PROJECTION,
+    ),
     TranchePhase.REVIEW_PACKET: (TranchePhase.TYPED_RECONCILIATION,),
     TranchePhase.CHECKPOINT: (TranchePhase.REVIEW_PACKET,),
 }
@@ -223,8 +249,7 @@ def ordered_phases(*, include_network: bool = True) -> tuple[TranchePhase, ...]:
         if phase
         not in {
             TranchePhase.EXTERNAL_ACQUISITION,
-            TranchePhase.TYPED_RECONCILIATION,
-            TranchePhase.REVIEW_PACKET,
+            TranchePhase.LEGAL_ADJUNCT_ACQUISITION,
         }
     )
 
@@ -290,17 +315,24 @@ def checkpoint_payload(
 ) -> dict[str, Any]:
     validate_phase_receipts(receipts)
     return {
-        "schema_version": "sl.complete_tranche_checkpoint.v0_1",
+        "schema_version": "sl.complete_tranche_checkpoint.v0_2",
         "contract_ref": TRANCHE_PIPELINE_CONTRACT,
         "profile": profile.to_dict(),
         "phase_receipts": [row.to_dict() for row in receipts],
         "artifacts": dict(artifacts),
         "authority_boundaries": {
+            "one_media_adapter": True,
+            "one_canonical_text_substrate": True,
+            "one_parser_spine": True,
+            "pnf_is_semantic_center": True,
+            "legal_ir_is_pnf_projection": True,
             "source_mentions_preserved": True,
             "external_candidates_are_not_identity": True,
+            "legal_relevance_is_not_applicability": True,
+            "applicability_is_not_violation": True,
             "local_compilation_network_independent": True,
             "world_entity_promotion_performed": False,
-            "review_required_for_identity_closure": True,
+            "review_required_for_identity_or_legal_closure": True,
         },
     }
 

--- a/src/sources/legal_follow.py
+++ b/src/sources/legal_follow.py
@@ -1,4 +1,10 @@
-"""Equal-capability bounded legal source follow profiles for AU, GB, and US."""
+"""Equal-capability bounded legal source follow profiles for AU, GB, and US.
+
+This module is an acquisition backend, not a semantic classifier. Broad seeded
+follow remains available for explicit corpus construction. PNF-driven follow
+must supply a typed legal source plan and is restricted to endpoints matching
+its declared jurisdiction, source roles, authority levels, and provider refs.
+"""
 
 from __future__ import annotations
 
@@ -8,9 +14,10 @@ from urllib.parse import urlparse
 
 from src.ingestion.link_follow import FollowResult, LinkEdge, bounded_follow
 from src.ingestion.web_fetch import FetchPolicy, SessionLike
+from src.pnf.legal_adjunct import LegalSourcePlan
 
 
-LEGAL_FOLLOW_CONTRACT = "legal-source-follow:v0_2"
+LEGAL_FOLLOW_CONTRACT = "legal-source-follow:v0_3"
 
 
 @dataclass(frozen=True)
@@ -42,15 +49,7 @@ class LegalFollowProfile:
 
     @property
     def allowed_hosts(self) -> tuple[str, ...]:
-        return tuple(
-            sorted(
-                {
-                    str(urlparse(endpoint.url).hostname or "")
-                    for endpoint in self.endpoints
-                    if urlparse(endpoint.url).hostname
-                }
-            )
-        )
+        return _allowed_hosts(self.endpoints)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -219,14 +218,48 @@ def profile_for(jurisdiction: str) -> LegalFollowProfile:
         raise ValueError(f"unsupported legal follow jurisdiction: {jurisdiction}") from error
 
 
-def _profile_link_filter(profile: LegalFollowProfile, link: LinkEdge) -> bool:
+def _allowed_hosts(endpoints: Iterable[LegalSourceEndpoint]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                str(urlparse(endpoint.url).hostname or "")
+                for endpoint in endpoints
+                if urlparse(endpoint.url).hostname
+            }
+        )
+    )
+
+
+def _profile_link_filter(allowed_hosts: Iterable[str], link: LinkEdge) -> bool:
     host = str(urlparse(link.target_url).hostname or "").casefold()
-    allowed = {value.casefold() for value in profile.allowed_hosts}
+    allowed = {value.casefold() for value in allowed_hosts}
     return host in allowed or any(host.endswith("." + value) for value in allowed)
 
 
-def follow_legal_sources(
-    jurisdiction: str,
+def select_legal_endpoints(
+    plan: LegalSourcePlan,
+) -> tuple[LegalSourceEndpoint, ...]:
+    """Return exact endpoint matches for one ready PNF-derived plan."""
+
+    if plan.state != "ready" or not plan.jurisdiction_ref:
+        return ()
+    profile = profile_for(plan.jurisdiction_ref)
+    selected: list[LegalSourceEndpoint] = []
+    requested_profiles = set(plan.provider_profile_refs)
+    for endpoint in profile.endpoints:
+        if endpoint.source_role not in set(plan.source_role_refs):
+            continue
+        if endpoint.authority_level not in set(plan.authority_level_refs):
+            continue
+        if requested_profiles and endpoint.endpoint_ref not in requested_profiles:
+            continue
+        selected.append(endpoint)
+    return tuple(selected)
+
+
+def _follow_endpoints(
+    profile: LegalFollowProfile,
+    endpoints: tuple[LegalSourceEndpoint, ...],
     *,
     seed_urls: Iterable[str] = (),
     max_depth: int | None = None,
@@ -234,16 +267,14 @@ def follow_legal_sources(
     session: SessionLike | None = None,
     progress_stream: TextIO | None = None,
 ) -> FollowResult:
-    """Run the same bounded fetch/follow capability for each jurisdiction."""
-
-    profile = profile_for(jurisdiction)
     seeds = tuple(seed_urls) or tuple(
         endpoint.url
-        for endpoint in profile.endpoints
+        for endpoint in endpoints
         if endpoint.access_mode in {"html", "atom_api"}
     )
+    allowed_hosts = _allowed_hosts(endpoints)
     policy = FetchPolicy(
-        allowed_hosts=profile.allowed_hosts,
+        allowed_hosts=allowed_hosts,
         allowed_content_types=(
             "text/html",
             "application/xhtml+xml",
@@ -257,10 +288,55 @@ def follow_legal_sources(
         seeds,
         policy=policy,
         max_depth=profile.max_depth if max_depth is None else max_depth,
-        max_documents=(
-            profile.max_documents if max_documents is None else max_documents
-        ),
-        link_filter=lambda link: _profile_link_filter(profile, link),
+        max_documents=profile.max_documents if max_documents is None else max_documents,
+        link_filter=lambda link: _profile_link_filter(allowed_hosts, link),
+        session=session,
+        progress_stream=progress_stream,
+    )
+
+
+def follow_legal_sources(
+    jurisdiction: str,
+    *,
+    seed_urls: Iterable[str] = (),
+    max_depth: int | None = None,
+    max_documents: int | None = None,
+    session: SessionLike | None = None,
+    progress_stream: TextIO | None = None,
+) -> FollowResult:
+    """Run explicit broad bounded source discovery for one jurisdiction."""
+
+    profile = profile_for(jurisdiction)
+    return _follow_endpoints(
+        profile,
+        profile.endpoints,
+        seed_urls=seed_urls,
+        max_depth=max_depth,
+        max_documents=max_documents,
+        session=session,
+        progress_stream=progress_stream,
+    )
+
+
+def follow_legal_source_plan(
+    plan: LegalSourcePlan,
+    *,
+    max_depth: int | None = None,
+    max_documents: int | None = None,
+    session: SessionLike | None = None,
+    progress_stream: TextIO | None = None,
+) -> FollowResult | None:
+    """Execute one typed PNF-derived acquisition plan without broadening it."""
+
+    endpoints = select_legal_endpoints(plan)
+    if not endpoints:
+        return None
+    profile = profile_for(plan.jurisdiction_ref)
+    return _follow_endpoints(
+        profile,
+        endpoints,
+        max_depth=max_depth,
+        max_documents=max_documents,
         session=session,
         progress_stream=progress_stream,
     )
@@ -274,6 +350,8 @@ __all__ = [
     "LegalSourceEndpoint",
     "PROFILES",
     "US_PROFILE",
+    "follow_legal_source_plan",
     "follow_legal_sources",
     "profile_for",
+    "select_legal_endpoints",
 ]

--- a/src/storage/postgres/legal_adjunct_planner.py
+++ b/src/storage/postgres/legal_adjunct_planner.py
@@ -107,8 +107,74 @@ def load_legal_source_plans(
     )
 
 
+def load_legal_pnf_rows(
+    cursor: Any,
+    *,
+    corpus_ref: str,
+) -> tuple[dict[str, Any], ...]:
+    """Load only PNF factors already typed as legal for Legal IR projection."""
+
+    cursor.execute(
+        """
+        SELECT
+            factor.factor_ref,
+            revision.factor_revision_ref,
+            factor.factor_type_ref,
+            COALESCE(
+                ARRAY_AGG(DISTINCT alternative.type_ref)
+                    FILTER (WHERE alternative.type_ref IS NOT NULL),
+                ARRAY[]::TEXT[]
+            ) AS alternative_types
+        FROM algebra.factor AS factor
+        JOIN algebra.factor_revision AS revision
+          ON revision.factor_ref = factor.factor_ref
+        LEFT JOIN algebra.factor_revision_alternative AS link
+          ON link.factor_revision_ref = revision.factor_revision_ref
+        LEFT JOIN algebra.alternative AS alternative
+          ON alternative.alternative_ref = link.alternative_ref
+        WHERE EXISTS (
+            SELECT 1
+            FROM corpus.document_occurrence AS occurrence
+            WHERE occurrence.corpus_ref = %s
+              AND occurrence.document_ref = factor.document_ref
+        )
+          AND (
+              left(factor.factor_type_ref, length('semantic.legal.')) = 'semantic.legal.'
+              OR factor.factor_type_ref IN (
+                  'semantic.normative_relation',
+                  'semantic.legal_condition',
+                  'semantic.legal_exception',
+                  'semantic.legal_burden',
+                  'semantic.legal_authority',
+                  'semantic.legal_transition',
+                  'semantic.judicial_treatment'
+              )
+          )
+        GROUP BY factor.factor_ref, revision.factor_revision_ref, factor.factor_type_ref
+        ORDER BY factor.factor_ref, revision.factor_revision_ref
+        """,
+        (corpus_ref,),
+    )
+    return tuple(
+        {
+            "factor_ref": str(factor_ref),
+            "factor_revision_ref": str(revision_ref),
+            "factor_type_ref": str(factor_type),
+            "structural_signature_ref": "pnf-signature:" + str(factor_type),
+            "predicate_ref": str(factor_type),
+            "role_bindings": {},
+            "qualifier_state": {"alternative_type_refs": list(alternative_types or ())},
+            "wrapper_state": {"source_corpus_ref": corpus_ref},
+            "provenance_refs": (str(revision_ref), corpus_ref),
+            "residual_refs": ("legal_role_binding_unresolved",),
+        }
+        for factor_ref, revision_ref, factor_type, alternative_types in cursor.fetchall()
+    )
+
+
 __all__ = [
     "POSTGRES_LEGAL_ADJUNCT_PLAN_REF",
+    "load_legal_pnf_rows",
     "load_legal_source_plans",
     "load_normative_interaction_demands",
 ]

--- a/src/storage/postgres/legal_adjunct_planner.py
+++ b/src/storage/postgres/legal_adjunct_planner.py
@@ -1,0 +1,114 @@
+"""Project legal adjunct work from normalized PostgreSQL PNF demands."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.pnf.legal_adjunct import (
+    LegalSourcePlan,
+    NormativeInteractionDemand,
+    plan_legal_sources,
+    project_normative_interaction_demands,
+)
+
+POSTGRES_LEGAL_ADJUNCT_PLAN_REF = "postgres-legal-adjunct-plan:v0_1"
+
+
+def load_normative_interaction_demands(
+    cursor: Any,
+    *,
+    corpus_ref: str | None = None,
+    limit: int = 500,
+) -> tuple[NormativeInteractionDemand, ...]:
+    """Load explicit legal work from open normalized resolution demands.
+
+    The SQL reads only demand facets and immutable PNF identities. It does not
+    route from predicate lemmas, surfaces, source filenames, or document family.
+    A structural signature must be supplied as a normalized legal facet.
+    """
+
+    if limit < 1:
+        raise ValueError("legal adjunct plan limit must be positive")
+    cursor.execute(
+        """
+        SELECT
+            demand.demand_ref,
+            demand.factor_ref,
+            demand.factor_revision_ref,
+            COALESCE(
+                ARRAY_AGG(DISTINCT facet.facet_ref)
+                    FILTER (WHERE facet.facet_ref IS NOT NULL),
+                ARRAY[]::TEXT[]
+            ) AS requested_facets
+        FROM resolution.demand AS demand
+        JOIN algebra.factor AS factor
+          ON factor.factor_ref = demand.factor_ref
+        LEFT JOIN resolution.demand_facet AS facet
+          ON facet.demand_ref = demand.demand_ref
+        WHERE demand.demand_state_ref = 'open'
+          AND demand.budget_class_ref = 'bounded_external_evidence'
+          AND EXISTS (
+              SELECT 1
+              FROM resolution.demand_facet AS legal_facet
+              WHERE legal_facet.demand_ref = demand.demand_ref
+                AND left(legal_facet.facet_ref, length('legal.')) = 'legal.'
+          )
+          AND (CAST(%s AS TEXT) IS NULL OR EXISTS (
+              SELECT 1
+              FROM corpus.document_occurrence AS occurrence
+              WHERE occurrence.corpus_ref = %s
+                AND occurrence.document_ref = factor.document_ref
+          ))
+        GROUP BY
+            demand.demand_ref,
+            demand.factor_ref,
+            demand.factor_revision_ref
+        ORDER BY demand.demand_ref
+        LIMIT %s
+        """,
+        (corpus_ref, corpus_ref, limit),
+    )
+    rows = []
+    for demand_ref, factor_ref, factor_revision_ref, facets in cursor.fetchall():
+        normalized_facets = tuple(sorted(str(value) for value in facets or ()))
+        signature_values = tuple(
+            value[len("legal.interaction_signature:") :]
+            for value in normalized_facets
+            if value.startswith("legal.interaction_signature:")
+        )
+        rows.append(
+            {
+                "demand_ref": str(demand_ref),
+                "factor_ref": str(factor_ref),
+                "factor_revision_ref": str(factor_revision_ref),
+                "structural_signature_ref": signature_values[0] if signature_values else "",
+                "requested_facets": normalized_facets,
+                "provenance_refs": (
+                    str(factor_revision_ref),
+                    POSTGRES_LEGAL_ADJUNCT_PLAN_REF,
+                ),
+            }
+        )
+    return project_normative_interaction_demands(rows)
+
+
+def load_legal_source_plans(
+    cursor: Any,
+    *,
+    corpus_ref: str | None = None,
+    limit: int = 500,
+) -> tuple[LegalSourcePlan, ...]:
+    return plan_legal_sources(
+        load_normative_interaction_demands(
+            cursor,
+            corpus_ref=corpus_ref,
+            limit=limit,
+        )
+    )
+
+
+__all__ = [
+    "POSTGRES_LEGAL_ADJUNCT_PLAN_REF",
+    "load_legal_source_plans",
+    "load_normative_interaction_demands",
+]

--- a/tests/fixtures/legal_pnf_probe/minimal_legal_genres.txt
+++ b/tests/fixtures/legal_pnf_probe/minimal_legal_genres.txt
@@ -1,0 +1,17 @@
+A person must keep records.
+A person must not drive a motor vehicle on a road unless licensed.
+The Minister may grant a permit if satisfied that the criteria are met.
+This Part does not apply to ships registered overseas.
+The Court may make any order it considers appropriate.
+A person is entitled to inspect the register.
+The Minister has power to revoke the licence.
+The prosecution must prove the conduct beyond reasonable doubt.
+The accused bears an evidential burden in relation to the exception.
+It is a defence if the person acted with lawful excuse.
+The Court held that section 5 applied.
+The Court distinguished Smith v Jones.
+The appeal was allowed.
+The application was dismissed.
+Section 4 commences on 1 January 2020.
+Section 7 is repealed.
+The definition is amended by omitting “vehicle” and inserting “motor vehicle”.

--- a/tests/pnf/test_external_enrichment.py
+++ b/tests/pnf/test_external_enrichment.py
@@ -7,6 +7,11 @@ from src.ontology.external_enrichment import (
     group_lookup_demands,
 )
 from src.pnf.external_enrichment_projection import project_external_lookup_demands
+from src.pnf.legal_adjunct import project_legal_ir
+from src.pnf.legal_probe import (
+    legal_entity_lookup_demands,
+    plan_legal_entity_resolution,
+)
 
 
 def _qid_candidate() -> ExternalCandidate:
@@ -187,3 +192,76 @@ def test_projector_selects_external_named_mentions_but_not_pronouns() -> None:
     assert [row.surface for row in demands] == ["the United States"]
     assert demands[0].demand_kind == "entity_identity"
     assert demands[0].subject_ref == "factor:usa"
+
+
+def test_legal_materiality_warrants_only_blocking_entity_lookup() -> None:
+    factors = (
+        {
+            "factor_ref": "factor:minister",
+            "factor_type": "semantic.mention_identity",
+            "metadata": {
+                "mention_ref": "mention:minister",
+                "factor_revision_ref": "revision:minister",
+            },
+            "alternatives": (
+                {
+                    "type_ref": "semantic.person_candidate",
+                    "value": {"semantic_family": "entity"},
+                },
+            ),
+            "residuals": ("external_identity_unresolved",),
+        },
+        {
+            "factor_ref": "factor:brisbane",
+            "factor_type": "semantic.mention_identity",
+            "metadata": {
+                "mention_ref": "mention:brisbane",
+                "factor_revision_ref": "revision:brisbane",
+            },
+            "alternatives": (
+                {
+                    "type_ref": "semantic.location_candidate",
+                    "value": {"semantic_family": "entity"},
+                },
+            ),
+            "residuals": ("external_identity_unresolved",),
+        },
+        {
+            "factor_ref": "factor:power",
+            "factor_revision_ref": "revision:power",
+            "factor_type_ref": "semantic.normative_relation",
+            "structural_signature_ref": "signature:grant-power",
+            "predicate_ref": "normative.power",
+            "role_bindings": {
+                "bearer": "factor:minister",
+                "conduct": "factor:grant",
+            },
+            "qualifier_state": {"modality": "power"},
+            "wrapper_state": {"authority_class": "legislation"},
+            "provenance_refs": ("span:power",),
+            "residual_refs": ("bearer_identity_unresolved",),
+        },
+    )
+    artifacts = {
+        "licensing": {
+            "mentions": (
+                {
+                    "mention_ref": "mention:minister",
+                    "canonical_surface": "Minister for Health",
+                },
+                {
+                    "mention_ref": "mention:brisbane",
+                    "canonical_surface": "Brisbane",
+                },
+            )
+        },
+        "refined_pnf_graph": {"factors": factors},
+    }
+    legal_ir = project_legal_ir(factors)
+
+    decisions = plan_legal_entity_resolution(artifacts, legal_ir)
+    demands = legal_entity_lookup_demands(decisions)
+
+    assert [row.subject_ref for row in demands] == ["factor:minister"]
+    assert demands[0].surface == "Minister for Health"
+    assert all(row.to_dict()["identity_closed"] is False for row in decisions)

--- a/tests/pnf/test_legal_adjunct.py
+++ b/tests/pnf/test_legal_adjunct.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from src.pnf.legal_adjunct import (
+    LegalIRObservation,
+    plan_legal_sources,
+    project_legal_ir,
+    project_normative_interaction_demands,
+    typed_legal_meet,
+)
+
+
+def test_bare_action_does_not_schedule_legal_acquisition() -> None:
+    rows = (
+        {
+            "demand_ref": "demand:drive",
+            "factor_revision_ref": "factor-revision:drive",
+            "structural_signature_ref": "signature:operation-event",
+            "predicate_ref": "drive",
+            "requested_facets": ("local_type_unresolved",),
+        },
+    )
+
+    assert project_normative_interaction_demands(rows) == ()
+
+
+def test_explicit_legal_facets_create_ready_typed_plan() -> None:
+    rows = (
+        {
+            "demand_ref": "demand:legal-drive",
+            "factor_revision_ref": "factor-revision:drive",
+            "structural_signature_ref": "signature:operation-event",
+            "requested_facets": (
+                "legal.relevance_unresolved",
+                "legal.jurisdiction:AU",
+                "legal.source_role:primary_legislation",
+                "legal.authority_level:official",
+                "legal.request:conduct_prohibition",
+                "legal.time:2024-07-09",
+            ),
+        },
+    )
+
+    demands = project_normative_interaction_demands(rows)
+    assert len(demands) == 1
+    assert demands[0].acquisition_ready is True
+    plans = plan_legal_sources(demands)
+    assert plans[0].state == "ready"
+    assert plans[0].jurisdiction_ref == "AU"
+    assert plans[0].source_role_refs == ("primary_legislation",)
+    assert plans[0].authority_level_refs == ("official",)
+
+
+def test_missing_jurisdiction_fails_closed() -> None:
+    rows = (
+        {
+            "demand_ref": "demand:legal-drive",
+            "factor_revision_ref": "factor-revision:drive",
+            "structural_signature_ref": "signature:operation-event",
+            "requested_facets": (
+                "legal.relevance_unresolved",
+                "legal.source_role:primary_legislation",
+                "legal.authority_level:official",
+            ),
+        },
+    )
+
+    demand = project_normative_interaction_demands(rows)[0]
+    assert demand.acquisition_ready is False
+    assert demand.open_slots == ("jurisdiction_unresolved",)
+    assert plan_legal_sources((demand,))[0].state == "blocked_missing_context"
+
+
+def test_legal_ir_is_only_projected_from_legal_pnf_types() -> None:
+    ordinary = {
+        "factor_ref": "factor:drive",
+        "factor_revision_ref": "revision:drive",
+        "factor_type_ref": "semantic.eventuality",
+        "structural_signature_ref": "signature:operation-event",
+    }
+    legal = {
+        "factor_ref": "factor:norm",
+        "factor_revision_ref": "revision:norm",
+        "factor_type_ref": "semantic.normative_relation",
+        "structural_signature_ref": "signature:operation-event",
+        "predicate_ref": "normative-prohibition",
+        "role_bindings": {"bearer": "actor:person", "content": "event:operate"},
+        "qualifier_state": {"polarity": "negative", "modality": "obligation"},
+        "wrapper_state": {"authority": "statute-candidate"},
+        "provenance_refs": ("span:1",),
+        "residual_refs": ("commencement_unresolved",),
+    }
+
+    observations = project_legal_ir((ordinary, legal))
+    assert len(observations) == 1
+    assert observations[0].pnf_factor_ref == "factor:norm"
+    assert observations[0].predicate_ref == "normative-prohibition"
+    assert observations[0].projection_state == "candidate"
+
+
+def test_cross_fibre_comparison_is_no_typed_meet() -> None:
+    observation = LegalIRObservation(
+        observation_ref="legal-ir:1",
+        pnf_factor_ref="factor:norm",
+        pnf_revision_ref="revision:norm",
+        structural_signature_ref="signature:normative-operation",
+        predicate_ref="normative-prohibition",
+        role_bindings={},
+        qualifier_state={},
+        wrapper_state={},
+        provenance_refs=(),
+        residual_refs=(),
+    )
+
+    result = typed_legal_meet(
+        {
+            "factor_revision_ref": "revision:world",
+            "structural_signature_ref": "signature:publication-event",
+        },
+        observation,
+    )
+
+    assert result.structural_state == "NO_TYPED_MEET"
+    assert result.applicability_closed is False
+    assert result.residual_refs == ("cross_fibre_incommensurable",)
+
+
+def test_same_fibre_meet_remains_candidate_and_open() -> None:
+    observation = LegalIRObservation(
+        observation_ref="legal-ir:1",
+        pnf_factor_ref="factor:norm",
+        pnf_revision_ref="revision:norm",
+        structural_signature_ref="signature:operation-event",
+        predicate_ref="normative-prohibition",
+        role_bindings={},
+        qualifier_state={},
+        wrapper_state={},
+        provenance_refs=(),
+        residual_refs=(),
+    )
+
+    result = typed_legal_meet(
+        {
+            "factor_revision_ref": "revision:world",
+            "structural_signature_ref": "signature:operation-event",
+            "legal_coordinates": {
+                "jurisdiction_state": "satisfied",
+                "temporal_state": "unresolved",
+                "conduct_state": "satisfied",
+            },
+        },
+        observation,
+    )
+
+    assert result.structural_state == "same_fibre_candidate"
+    assert result.jurisdiction_state == "satisfied"
+    assert result.temporal_state == "unresolved"
+    assert result.applicability_closed is False
+    assert "legal_applicability_unresolved" in result.residual_refs

--- a/tests/pnf/test_legal_probe.py
+++ b/tests/pnf/test_legal_probe.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import hashlib
+
+from src.pnf.legal_adjunct import project_legal_ir
+from src.pnf.legal_probe import (
+    build_legal_pnf_probe,
+    legal_entity_lookup_demands,
+    plan_legal_entity_resolution,
+)
+from src.policy.corpus_compilation import compile_document, default_compiler_context
+
+
+def _compilation(text: str) -> dict[str, object]:
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    return compile_document(
+        {
+            "document_ref": "document:" + digest,
+            "source_ref": "source:" + digest,
+            "media_type": "text/plain",
+            "content_sha256": digest,
+            "canonical_text": text,
+        },
+        default_compiler_context(),
+    ).to_dict()
+
+
+def test_real_legal_text_runs_through_universal_pnf_and_emits_honest_ledger() -> None:
+    compilation = _compilation(
+        "A person must not drive a motor vehicle on a road unless licensed. "
+        "The Court held that section 5 applied."
+    )
+    legacy = (
+        {
+            "type": "prohibition",
+            "modality": "must not",
+            "actor": {"normalized": "a person"},
+            "action": {"normalized": "drive"},
+            "object": {"normalized": "a motor vehicle"},
+            "conditions": ({"type": "unless"},),
+        },
+    )
+
+    probe = build_legal_pnf_probe(compilation, legacy_rows=legacy)
+
+    assert probe["canonical_text"].startswith("A person must not drive")
+    assert probe["parser_receipt"]
+    assert probe["pnf_graph"]["factors"]
+    assert len(probe["comparison_ledger"]) == 9
+    assert probe["summary"]["identity_closure_count"] == 0
+    assert probe["summary"]["legal_conclusion_promotion_count"] == 0
+    assert any(
+        row["state"] in {"legacy_only_gap", "pnf_only", "pnf_and_legal_ir"}
+        for row in probe["comparison_ledger"]
+    )
+
+
+def test_entity_lookup_requires_legal_role_blocker_not_merely_proper_name() -> None:
+    artifacts = {
+        "licensing": {
+            "mentions": (
+                {
+                    "mention_ref": "mention:minister",
+                    "canonical_surface": "Minister for Health",
+                },
+                {
+                    "mention_ref": "mention:brisbane",
+                    "canonical_surface": "Brisbane",
+                },
+            )
+        },
+        "refined_pnf_graph": {
+            "factors": (
+                {
+                    "factor_ref": "factor:minister",
+                    "factor_type": "semantic.mention_identity",
+                    "alternatives": (
+                        {
+                            "type_ref": "semantic.person_candidate",
+                            "value": {"semantic_family": "entity"},
+                        },
+                    ),
+                    "residuals": ("external_identity_unresolved",),
+                    "metadata": {
+                        "mention_ref": "mention:minister",
+                        "factor_revision_ref": "revision:minister",
+                    },
+                },
+                {
+                    "factor_ref": "factor:brisbane",
+                    "factor_type": "semantic.mention_identity",
+                    "alternatives": (
+                        {
+                            "type_ref": "semantic.location_candidate",
+                            "value": {"semantic_family": "entity"},
+                        },
+                    ),
+                    "residuals": ("external_identity_unresolved",),
+                    "metadata": {
+                        "mention_ref": "mention:brisbane",
+                        "factor_revision_ref": "revision:brisbane",
+                    },
+                },
+                {
+                    "factor_ref": "factor:norm",
+                    "factor_revision_ref": "revision:norm",
+                    "factor_type_ref": "semantic.normative_relation",
+                    "structural_signature_ref": "signature:grant-power",
+                    "predicate_ref": "normative.power",
+                    "role_bindings": {
+                        "bearer": "factor:minister",
+                        "conduct": "factor:grant",
+                    },
+                    "qualifier_state": {"modality": "power"},
+                    "wrapper_state": {"authority_class": "legislation"},
+                    "provenance_refs": ("span:norm",),
+                    "residual_refs": ("bearer_identity_unresolved",),
+                },
+            )
+        },
+    }
+    legal_ir = project_legal_ir(artifacts["refined_pnf_graph"]["factors"])
+
+    decisions = plan_legal_entity_resolution(artifacts, legal_ir)
+    by_factor = {row.factor_ref: row for row in decisions}
+
+    assert by_factor["factor:minister"].should_lookup is True
+    assert by_factor["factor:brisbane"].should_lookup is False
+    demands = legal_entity_lookup_demands(decisions)
+    assert len(demands) == 1
+    assert demands[0].surface == "Minister for Health"
+    assert demands[0].subject_ref == "factor:minister"
+
+
+def test_explicit_legal_identity_residual_can_warrant_lookup_without_ir_role() -> None:
+    artifacts = {
+        "licensing": {
+            "mentions": (
+                {
+                    "mention_ref": "mention:court",
+                    "canonical_surface": "High Court of Australia",
+                },
+            )
+        },
+        "refined_pnf_graph": {
+            "factors": (
+                {
+                    "factor_ref": "factor:court",
+                    "factor_type": "semantic.mention_identity",
+                    "alternatives": (
+                        {
+                            "type_ref": "semantic.organization_candidate",
+                            "value": {"semantic_family": "entity"},
+                        },
+                    ),
+                    "residuals": ("legal_authority_identity_unresolved",),
+                    "metadata": {
+                        "mention_ref": "mention:court",
+                        "factor_revision_ref": "revision:court",
+                    },
+                },
+            )
+        },
+    }
+
+    decisions = plan_legal_entity_resolution(artifacts, ())
+
+    assert decisions[0].should_lookup is True
+    assert decisions[0].reasons == (
+        "entity_identity_open",
+        "legal_coordinate_blocked",
+    )

--- a/tests/runtime/test_complete_tranche_pipeline.py
+++ b/tests/runtime/test_complete_tranche_pipeline.py
@@ -154,6 +154,22 @@ def test_phase_contract_rejects_network_before_local_world() -> None:
         validate_phase_receipts(receipts)
 
 
+def test_legal_acquisition_requires_pnf_legal_demand_phase() -> None:
+    receipts = [
+        PhaseReceipt(TranchePhase.SOURCE_INVENTORY, "completed", (), (), {}),
+        PhaseReceipt(TranchePhase.SOURCE_ACQUISITION, "completed", (), (), {}),
+        PhaseReceipt(TranchePhase.CANONICAL_PROJECTION, "completed", (), (), {}),
+        PhaseReceipt(TranchePhase.LOCAL_PNF_COMPILATION, "completed", (), (), {}),
+        PhaseReceipt(TranchePhase.LOCAL_WORLD_PROJECTION, "completed", (), (), {}),
+        PhaseReceipt(TranchePhase.EXTERNAL_DEMAND_PLANNING, "completed", (), (), {}),
+        PhaseReceipt(TranchePhase.EXTERNAL_ACQUISITION, "completed", (), (), {}),
+        PhaseReceipt(TranchePhase.LEGAL_ADJUNCT_ACQUISITION, "completed", (), (), {}),
+    ]
+
+    with pytest.raises(ValueError, match="LEGAL_ADJUNCT_DEMAND_PLANNING"):
+        validate_phase_receipts(receipts)
+
+
 def test_checkpoint_preserves_authority_boundaries() -> None:
     profile = profile_for_tranche("GWB")
     receipts = [
@@ -162,10 +178,17 @@ def test_checkpoint_preserves_authority_boundaries() -> None:
     checkpoint = checkpoint_payload(profile=profile, receipts=receipts, artifacts={})
 
     assert checkpoint["authority_boundaries"] == {
+        "one_media_adapter": True,
+        "one_canonical_text_substrate": True,
+        "one_parser_spine": True,
+        "pnf_is_semantic_center": True,
+        "legal_ir_is_pnf_projection": True,
         "source_mentions_preserved": True,
         "external_candidates_are_not_identity": True,
+        "legal_relevance_is_not_applicability": True,
+        "applicability_is_not_violation": True,
         "local_compilation_network_independent": True,
         "world_entity_promotion_performed": False,
-        "review_required_for_identity_closure": True,
+        "review_required_for_identity_or_legal_closure": True,
     }
     json.dumps(checkpoint)

--- a/tests/sources/test_legal_follow.py
+++ b/tests/sources/test_legal_follow.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from io import StringIO
 
+from src.pnf.legal_adjunct import LegalSourcePlan
 from src.sources.legal_follow import (
     AU_PROFILE,
     GB_PROFILE,
     US_PROFILE,
+    follow_legal_source_plan,
     follow_legal_sources,
     profile_for,
+    select_legal_endpoints,
 )
 
 
@@ -31,6 +34,23 @@ class Session:
     def get(self, url, **_kwargs):
         self.calls.append(url)
         return self.rows[url]
+
+
+def _plan(**overrides) -> LegalSourcePlan:
+    values = {
+        "demand_ref": "demand:1",
+        "plan_key": "plan:1",
+        "jurisdiction_ref": "AU",
+        "source_role_refs": ("primary_legislation",),
+        "authority_level_refs": ("official",),
+        "provider_profile_refs": (),
+        "requested_legal_facets": ("conduct_prohibition",),
+        "temporal_refs": ("2024-07-09",),
+        "state": "ready",
+        "blocked_reasons": (),
+    }
+    values.update(overrides)
+    return LegalSourcePlan(**values)
 
 
 def test_all_jurisdictions_share_the_same_follow_capability_contract() -> None:
@@ -69,3 +89,49 @@ def test_au_follow_uses_shared_fetch_and_link_receipts() -> None:
     assert len(result.documents) == 2
     assert result.documents[0].links[0].target_url == second
     assert all(row.status == "fetched" for row in result.receipts)
+
+
+def test_typed_plan_selects_only_matching_role_and_authority() -> None:
+    endpoints = select_legal_endpoints(_plan())
+
+    assert [row.endpoint_ref for row in endpoints] == [
+        "au:federal-register-api",
+        "au:federal-register",
+    ]
+    assert all(row.source_role == "primary_legislation" for row in endpoints)
+    assert all(row.authority_level == "official" for row in endpoints)
+
+
+def test_blocked_typed_plan_performs_no_follow() -> None:
+    result = follow_legal_source_plan(
+        _plan(state="blocked_missing_context", blocked_reasons=("jurisdiction_unresolved",))
+    )
+
+    assert result is None
+
+
+def test_typed_follow_does_not_expand_to_supporting_research_index() -> None:
+    seed = "https://www.legislation.gov.au/"
+    second = "https://www.legislation.gov.au/document/Test"
+    session = Session(
+        {
+            seed: Response(
+                seed,
+                b'<main><a href="/document/Test">Test Act</a>'
+                b'<a href="https://www.austlii.edu.au/Test">Research</a></main>',
+            ),
+            second: Response(second, b"<main>Test Act text</main>"),
+        }
+    )
+
+    result = follow_legal_source_plan(
+        _plan(provider_profile_refs=("au:federal-register",)),
+        max_depth=1,
+        max_documents=2,
+        session=session,
+        progress_stream=StringIO(),
+    )
+
+    assert result is not None
+    assert session.calls == [seed, second]
+    assert all("austlii" not in url for url in session.calls)

--- a/tests/sources/test_legal_follow_pnf_plan.py
+++ b/tests/sources/test_legal_follow_pnf_plan.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from io import StringIO
+
+from src.pnf.legal_adjunct import LegalSourcePlan
+from src.sources.legal_follow import follow_legal_source_plan, select_legal_endpoints
+
+
+class Response:
+    status_code = 200
+
+    def __init__(self, url: str, content: bytes) -> None:
+        self.url = url
+        self.content = content
+        self.headers = {"Content-Type": "text/html"}
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class Session:
+    def __init__(self, rows):
+        self.rows = rows
+        self.calls = []
+
+    def get(self, url, **_kwargs):
+        self.calls.append(url)
+        return self.rows[url]
+
+
+def _plan(**overrides) -> LegalSourcePlan:
+    values = {
+        "demand_ref": "demand:1",
+        "plan_key": "plan:1",
+        "jurisdiction_ref": "AU",
+        "source_role_refs": ("primary_legislation",),
+        "authority_level_refs": ("official",),
+        "provider_profile_refs": (),
+        "requested_legal_facets": ("conduct_prohibition",),
+        "temporal_refs": ("2024-07-09",),
+        "state": "ready",
+        "blocked_reasons": (),
+    }
+    values.update(overrides)
+    return LegalSourcePlan(**values)
+
+
+def test_typed_plan_selects_only_matching_role_and_authority() -> None:
+    endpoints = select_legal_endpoints(_plan())
+
+    assert [row.endpoint_ref for row in endpoints] == [
+        "au:federal-register-api",
+        "au:federal-register",
+    ]
+    assert all(row.source_role == "primary_legislation" for row in endpoints)
+    assert all(row.authority_level == "official" for row in endpoints)
+
+
+def test_provider_ref_can_narrow_to_one_declared_endpoint() -> None:
+    endpoints = select_legal_endpoints(
+        _plan(provider_profile_refs=("au:federal-register",))
+    )
+
+    assert [row.endpoint_ref for row in endpoints] == ["au:federal-register"]
+
+
+def test_blocked_plan_performs_no_follow() -> None:
+    result = follow_legal_source_plan(
+        _plan(state="blocked_missing_context", blocked_reasons=("jurisdiction_unresolved",))
+    )
+
+    assert result is None
+
+
+def test_typed_follow_does_not_expand_to_supporting_research_index() -> None:
+    seed = "https://www.legislation.gov.au/"
+    second = "https://www.legislation.gov.au/document/Test"
+    session = Session(
+        {
+            seed: Response(
+                seed,
+                b'<main><a href="/document/Test">Test Act</a>'
+                b'<a href="https://www.austlii.edu.au/Test">Research</a></main>',
+            ),
+            second: Response(second, b"<main>Test Act text</main>"),
+        }
+    )
+
+    result = follow_legal_source_plan(
+        _plan(provider_profile_refs=("au:federal-register",)),
+        max_depth=1,
+        max_documents=2,
+        session=session,
+        progress_stream=StringIO(),
+    )
+
+    assert result is not None
+    assert session.calls == [seed, second]
+    assert all("austlii" not in url for url in session.calls)


### PR DESCRIPTION
## Summary

Corrects the complete tranche order so legal-source acquisition can be driven by explicit PNF residuals after deterministic local compilation, rather than treating each jurisdiction profile as a broad pre-PNF crawl. It now also adds a bounded empirical legal-PNF probe and a legal-materiality gate for Wikidata entity resolution.

### Parser doctrine

```text
one media adapter
  -> one canonical text substrate
  -> one parser spine
  -> PNF
```

There is no legal parser, source-family parser, normative extraction profile, or verb-to-law table. Legal IR is projected only from legal-corpus PNF.

### PNF legal adjunct algebra

Adds `src/pnf/legal_adjunct.py` with typed normative demands, legal source plans, Legal IR observations, and fibre-safe legal meets. Bare actions do not schedule legal acquisition. Explicit normalized `legal.*` facets are required, and missing context fails closed.

### Legal PNF probe

Adds `src/pnf/legal_probe.py` and `scripts/run_legal_pnf_probe.py`.

The probe runs real legal documents through the ordinary compiler and emits:

```text
canonical/source manifest
parser observations
raw and refined PNF graphs
Legal IR projection
legacy obligation oracle
comparison ledger
coverage scorecard
legal entity-resolution decisions
Wikidata lookup plan
```

The legacy RuleAtom/ObligationAtom lane is diagnostic only. Legacy-only detections become explicit PNF coverage residuals and never overwrite PNF.

A hand-auditable fixture covers obligations, prohibitions, permissions, exclusions, powers, entitlements, burdens, defences, holdings, distinguishing, dispositions, commencement, repeal, and amendment.

### Wikidata call policy

Wikidata is called only when an entity-shaped factor retains unresolved identity and materially blocks a Legal IR coordinate such as bearer, court, party, institution, jurisdiction, or authority. A proper noun alone is insufficient. Ordinary world-model identity demands remain handled by the existing pre-legal enrichment pass; the legal-materiality pass is narrower and candidate-only.

No Wikidata result closes identity, actor class, jurisdiction, applicability, violation, or liability.

### Typed legal acquisition

`src/sources/legal_follow.py` selects exact endpoints by jurisdiction, source role, authority level, and optional endpoint ref. PNF-driven follow is limited to the selected hosts. Broad jurisdiction follow remains available only for explicit or required seed-corpus formation.

### Complete tranche v0.2

1. source inventory;
2. explicit/required seed acquisition;
3. canonical projection;
4. local PNF compilation;
5. provisional local world projection;
6. ordinary registry demand planning;
7. legal adjunct demand planning;
8. bounded registry acquisition;
9. bounded typed legal acquisition;
10. adjunct recompilation through the same compiler spine;
11. Legal IR projection from legal PNF;
12. typed reconciliation;
13. review packets;
14. checkpoint.

GWB and AU no longer broad-fetch legal profiles before PNF unless `--seed-legal-follow` is supplied. Brexit may still use bounded seed acquisition when no local source family exists.

### Authority boundaries

This PR does not assert that legal relevance implies applicability, applicability implies violation, a candidate WrongType implies liability, a court-held proposition is universal truth, an empty lookup means no legal entity or no applicable law, or a legacy observation is a PNF legal fact.

### Documentation and tests

Adds:

- `docs/planning/pnf_legal_adjunct_loop_20260720.md`
- `docs/planning/legal_pnf_probe_and_entity_resolution_20260721.md`
- `tests/pnf/test_legal_adjunct.py`
- `tests/pnf/test_legal_probe.py`
- `tests/fixtures/legal_pnf_probe/minimal_legal_genres.txt`

The External enrichment workflow now tracks and executes the legal adjunct and legal probe files explicitly.