### PR TITLE
Package Legal IR semantic builds and federated lawyer review

### DIFF
--- a/database/postgres_migrations/015_legal_ir_federation.sql
+++ b/database/postgres_migrations/015_legal_ir_federation.sql
@@ -1,0 +1,224 @@
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS legal_ir;
+CREATE SCHEMA IF NOT EXISTS diagnostic;
+
+CREATE TABLE IF NOT EXISTS legal_ir.semantic_build (
+    build_ref TEXT PRIMARY KEY,
+    document_ref TEXT NOT NULL,
+    source_revision_ref TEXT NOT NULL,
+    canonical_text_ref TEXT NOT NULL,
+    parser_build_ref TEXT NOT NULL,
+    pnf_build_ref TEXT NOT NULL,
+    refined_pnf_graph_ref TEXT NOT NULL,
+    legal_ir_projection_ref TEXT NOT NULL,
+    legacy_observation_set_ref TEXT NOT NULL,
+    comparison_ledger_ref TEXT NOT NULL,
+    coverage_demand_refs TEXT[] NOT NULL DEFAULT '{}',
+    declaration_revision_refs TEXT[] NOT NULL DEFAULT '{}',
+    build_state_ref TEXT NOT NULL,
+    provenance_refs TEXT[] NOT NULL DEFAULT '{}',
+    build_sha256 BYTEA NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS legal_ir.projection (
+    projection_ref TEXT PRIMARY KEY,
+    build_ref TEXT NOT NULL REFERENCES legal_ir.semantic_build(build_ref),
+    pnf_build_ref TEXT NOT NULL,
+    projection_contract_ref TEXT NOT NULL,
+    omitted_factor_refs TEXT[] NOT NULL DEFAULT '{}',
+    projection_residuals TEXT[] NOT NULL DEFAULT '{}',
+    projection_sha256 BYTEA NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS legal_ir.observation (
+    observation_ref TEXT PRIMARY KEY,
+    projection_ref TEXT NOT NULL REFERENCES legal_ir.projection(projection_ref) ON DELETE CASCADE,
+    pnf_factor_ref TEXT NOT NULL,
+    pnf_revision_ref TEXT NOT NULL,
+    structural_signature_ref TEXT NOT NULL,
+    predicate_ref TEXT NOT NULL,
+    role_bindings JSONB NOT NULL DEFAULT '{}',
+    qualifier_state JSONB NOT NULL DEFAULT '{}',
+    wrapper_state JSONB NOT NULL DEFAULT '{}',
+    provenance_refs TEXT[] NOT NULL DEFAULT '{}',
+    residual_refs TEXT[] NOT NULL DEFAULT '{}',
+    projection_state_ref TEXT NOT NULL DEFAULT 'candidate',
+    observation_sha256 BYTEA NOT NULL UNIQUE
+);
+
+CREATE INDEX IF NOT EXISTS legal_ir_observation_signature_idx
+    ON legal_ir.observation (structural_signature_ref, predicate_ref);
+
+CREATE TABLE IF NOT EXISTS diagnostic.legacy_witness (
+    witness_ref TEXT PRIMARY KEY,
+    build_ref TEXT NOT NULL REFERENCES legal_ir.semantic_build(build_ref),
+    extractor_contract_ref TEXT NOT NULL,
+    source_span_refs TEXT[] NOT NULL DEFAULT '{}',
+    candidate_kind_ref TEXT NOT NULL,
+    candidate_payload JSONB NOT NULL,
+    match_state_ref TEXT NOT NULL,
+    provenance_refs TEXT[] NOT NULL DEFAULT '{}',
+    authority_state_ref TEXT NOT NULL CHECK (authority_state_ref = 'diagnostic_only'),
+    witness_sha256 BYTEA NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS diagnostic.semantic_comparison (
+    comparison_ref TEXT PRIMARY KEY,
+    build_ref TEXT NOT NULL REFERENCES legal_ir.semantic_build(build_ref),
+    document_ref TEXT NOT NULL,
+    comparison_kind_ref TEXT NOT NULL,
+    structural_signature_ref TEXT NOT NULL,
+    source_span_refs TEXT[] NOT NULL DEFAULT '{}',
+    pnf_factor_refs TEXT[] NOT NULL DEFAULT '{}',
+    legal_ir_observation_refs TEXT[] NOT NULL DEFAULT '{}',
+    legacy_witness_refs TEXT[] NOT NULL DEFAULT '{}',
+    comparison_state_ref TEXT NOT NULL,
+    coordinate_states JSONB NOT NULL DEFAULT '{}',
+    discrepancy_refs TEXT[] NOT NULL DEFAULT '{}',
+    proposed_actions TEXT[] NOT NULL DEFAULT '{}',
+    comparison_sha256 BYTEA NOT NULL UNIQUE
+);
+
+CREATE INDEX IF NOT EXISTS diagnostic_semantic_comparison_state_idx
+    ON diagnostic.semantic_comparison (comparison_state_ref, comparison_kind_ref);
+
+CREATE TABLE IF NOT EXISTS diagnostic.pnf_coverage_demand (
+    demand_ref TEXT PRIMARY KEY,
+    build_ref TEXT NOT NULL REFERENCES legal_ir.semantic_build(build_ref),
+    document_ref TEXT NOT NULL,
+    source_observation_refs TEXT[] NOT NULL DEFAULT '{}',
+    candidate_composition_kind_ref TEXT NOT NULL,
+    expected_role_shape TEXT[] NOT NULL DEFAULT '{}',
+    missing_factor_type_ref TEXT NOT NULL,
+    witness_refs TEXT[] NOT NULL DEFAULT '{}',
+    structural_signature_ref TEXT NOT NULL,
+    demand_state_ref TEXT NOT NULL CHECK (demand_state_ref = 'requires_pnf_reconstruction'),
+    direct_factor_creation_allowed BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (direct_factor_creation_allowed = FALSE),
+    demand_sha256 BYTEA NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS legal_ir.graph_revision (
+    revision_ref TEXT PRIMARY KEY,
+    subject_ref TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    prior_revision_refs TEXT[] NOT NULL DEFAULT '{}',
+    source_span_refs TEXT[] NOT NULL DEFAULT '{}',
+    legal_system_refs TEXT[] NOT NULL DEFAULT '{}',
+    jurisdiction_refs TEXT[] NOT NULL DEFAULT '{}',
+    temporal_refs TEXT[] NOT NULL DEFAULT '{}',
+    author_ref TEXT NOT NULL,
+    institution_ref TEXT,
+    build_ref TEXT NOT NULL REFERENCES legal_ir.semantic_build(build_ref),
+    revision_state_ref TEXT NOT NULL DEFAULT 'candidate',
+    revision_sha256 BYTEA NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS legal_ir_graph_revision_subject_idx
+    ON legal_ir.graph_revision (subject_ref, created_at);
+
+CREATE TABLE IF NOT EXISTS legal_ir.reviewer_credential (
+    credential_ref TEXT PRIMARY KEY,
+    reviewer_ref TEXT NOT NULL,
+    institution_ref TEXT,
+    jurisdiction_refs TEXT[] NOT NULL DEFAULT '{}',
+    practice_area_refs TEXT[] NOT NULL DEFAULT '{}',
+    credential_type_refs TEXT[] NOT NULL DEFAULT '{}',
+    valid_from TIMESTAMPTZ,
+    valid_until TIMESTAMPTZ,
+    evidence_refs TEXT[] NOT NULL DEFAULT '{}',
+    verification_state_ref TEXT NOT NULL,
+    credential_sha256 BYTEA NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS legal_ir.review_attestation (
+    attestation_ref TEXT PRIMARY KEY,
+    revision_ref TEXT NOT NULL REFERENCES legal_ir.graph_revision(revision_ref),
+    reviewer_ref TEXT NOT NULL,
+    credential_refs TEXT[] NOT NULL DEFAULT '{}',
+    institution_ref TEXT,
+    review_state_ref TEXT NOT NULL CHECK (
+        review_state_ref IN (
+            'endorse',
+            'approve_with_residuals',
+            'reject',
+            'contest',
+            'abstain',
+            'supersede'
+        )
+    ),
+    coordinate_states JSONB NOT NULL DEFAULT '{}',
+    reason_refs TEXT[] NOT NULL DEFAULT '{}',
+    evidence_refs TEXT[] NOT NULL DEFAULT '{}',
+    supersedes_attestation_refs TEXT[] NOT NULL DEFAULT '{}',
+    signature_ref TEXT,
+    attestation_sha256 BYTEA NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS legal_ir_review_attestation_revision_idx
+    ON legal_ir.review_attestation (revision_ref, review_state_ref, created_at);
+
+CREATE TABLE IF NOT EXISTS legal_ir.trust_projection (
+    projection_ref TEXT PRIMARY KEY,
+    revision_ref TEXT NOT NULL REFERENCES legal_ir.graph_revision(revision_ref),
+    scope_ref TEXT NOT NULL,
+    endorsement_count INTEGER NOT NULL CHECK (endorsement_count >= 0),
+    qualified_approval_count INTEGER NOT NULL CHECK (qualified_approval_count >= 0),
+    rejection_count INTEGER NOT NULL CHECK (rejection_count >= 0),
+    contest_count INTEGER NOT NULL CHECK (contest_count >= 0),
+    abstention_count INTEGER NOT NULL CHECK (abstention_count >= 0),
+    supersession_count INTEGER NOT NULL CHECK (supersession_count >= 0),
+    active_reviewer_refs TEXT[] NOT NULL DEFAULT '{}',
+    institution_refs TEXT[] NOT NULL DEFAULT '{}',
+    unresolved_coordinate_refs TEXT[] NOT NULL DEFAULT '{}',
+    state_ref TEXT NOT NULL,
+    truth_closed BOOLEAN NOT NULL DEFAULT FALSE CHECK (truth_closed = FALSE),
+    projection_sha256 BYTEA NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (revision_ref, scope_ref, projection_sha256)
+);
+
+CREATE TABLE IF NOT EXISTS legal_ir.federation_bundle (
+    bundle_ref TEXT PRIMARY KEY,
+    graph_revision_refs TEXT[] NOT NULL DEFAULT '{}',
+    credential_refs TEXT[] NOT NULL DEFAULT '{}',
+    attestation_refs TEXT[] NOT NULL DEFAULT '{}',
+    trust_projection_refs TEXT[] NOT NULL DEFAULT '{}',
+    federation_refs TEXT[] NOT NULL DEFAULT '{}',
+    checkpoint_state_ref TEXT NOT NULL,
+    anonymous_consensus BOOLEAN NOT NULL DEFAULT FALSE CHECK (anonymous_consensus = FALSE),
+    disagreement_preserved BOOLEAN NOT NULL DEFAULT TRUE CHECK (disagreement_preserved = TRUE),
+    bundle_sha256 BYTEA NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE VIEW legal_ir.v_reviewable_graph_revision AS
+SELECT
+    revision.revision_ref,
+    revision.subject_ref,
+    revision.jurisdiction_refs,
+    revision.temporal_refs,
+    revision.author_ref,
+    revision.institution_ref,
+    revision.revision_state_ref,
+    COUNT(attestation.attestation_ref) FILTER (
+        WHERE attestation.review_state_ref = 'endorse'
+    ) AS endorsement_count,
+    COUNT(attestation.attestation_ref) FILTER (
+        WHERE attestation.review_state_ref = 'reject'
+    ) AS rejection_count,
+    COUNT(attestation.attestation_ref) FILTER (
+        WHERE attestation.review_state_ref = 'contest'
+    ) AS contest_count
+FROM legal_ir.graph_revision AS revision
+LEFT JOIN legal_ir.review_attestation AS attestation
+  ON attestation.revision_ref = revision.revision_ref
+GROUP BY revision.revision_ref;
+
+COMMIT;

--- a/docs/planning/legal_ir_product_and_federation_20260721.md
+++ b/docs/planning/legal_ir_product_and_federation_20260721.md
@@ -1,0 +1,208 @@
+# Legal IR as a federated SensibLaw product
+
+## Product thesis
+
+Legal IR is not merely an internal compiler artifact. It is a public, reviewable,
+versioned legal knowledge product: a semantically typed and logically constrained
+commons whose graph revisions remain linked to exact legal source spans, PNF
+builds, jurisdictions, legal time, and attributable professional review.
+
+A useful analogy is Wikipedia's collaborative knowledge surface, but the Legal IR
+product differs in four decisive ways:
+
+1. contributions are typed graph revisions rather than prose-page edits;
+2. every legal assertion is source- and span-grounded;
+3. disagreement is represented explicitly rather than erased by a current page;
+4. trust is projected from attributable reviewer and institution scopes rather
+   than inferred from anonymous popularity.
+
+The product boundary is therefore:
+
+```text
+legal sources
+  -> canonical text
+  -> one parser spine
+  -> refined PNF
+  -> Legal IR graph revisions
+  -> lawyer/institution attestations
+  -> scoped trust projections
+  -> public, restricted, or institutional views
+```
+
+## Semantic build boundary
+
+The following artifacts are packaged in one `LegalSemanticBuild` but never
+flattened into a single authority plane:
+
+| Surface | Role | Authority |
+|---|---|---|
+| refined PNF graph | candidate semantic state | semantic candidate authority |
+| Legal IR | deterministic PNF projection | projection only |
+| legacy observations | independent extractor witness | diagnostic only |
+| comparison ledger | alignment, gaps, disagreement | audit only |
+
+Legal IR is always rebuildable from the refined PNF graph. Legacy witnesses may
+create `PNFCoverageDemand` objects, but may not create or mutate PNF factors.
+
+## Federated graph object
+
+A publishable contribution is an immutable `LegalGraphRevision`:
+
+```text
+revision_ref
+subject_ref
+payload_hash
+prior_revision_refs
+source_span_refs
+legal_system_refs
+jurisdiction_refs
+temporal_refs
+author_ref
+institution_ref
+build_ref
+revision_state
+```
+
+The payload may represent a norm, element, exception, burden, holding, treatment
+relation, transition, WrongType link, remedy relation, or another typed Legal IR
+object. A revision does not overwrite its predecessor.
+
+## Professional review acts
+
+A lawyer or institution reviews an exact graph revision by creating a
+`LegalReviewAttestation` with one of:
+
+```text
+endorse
+approve_with_residuals
+reject
+contest
+abstain
+supersede
+```
+
+Attestations are coordinate-sensitive. A reviewer may endorse the extracted
+holding while leaving precedential scope unresolved, or approve a prohibition
+while contesting its temporal validity.
+
+```text
+review_state = approve_with_residuals
+coordinate_states:
+  predicate = satisfied
+  actor = satisfied
+  jurisdiction = satisfied
+  legal_time = unresolved
+  exception = contested
+```
+
+The attestation records reviewer identity, credential evidence, institution,
+reasons, source evidence, creation time, optional signature, and superseded
+attestations.
+
+## Credentials do not confer truth
+
+`ReviewerCredential` records evidence such as admission, practice area,
+institution, jurisdiction, and validity interval. It permits consumers to define
+trust scopes. It does not grant universal truth authority.
+
+Examples of scoped views:
+
+```text
+all reviewed Australian public-law claims
+claims endorsed by this firm's administrative-law team
+claims reviewed by admitted barristers in Queensland
+claims accepted by a court-maintained federation
+claims contested by at least two independent institutions
+```
+
+## Trust projections
+
+A `FederatedClaimState` is a view over active attestations in a declared scope.
+It can report:
+
+```text
+endorsed_in_scope
+approved_with_residuals_in_scope
+rejected_in_scope
+contested
+supersession_proposed
+unreviewed_in_scope
+```
+
+No count or projection sets `truth_closed = true`. Competing endorsements and
+rejections remain visible. Superseded attestations stop contributing to active
+counts but remain immutable historical evidence.
+
+## Federation model
+
+Different operators may host compatible Legal IR shards:
+
+```text
+public SensibLaw federation
+law-firm private federation
+bar association review federation
+university doctrinal federation
+court or tribunal publication federation
+community or Indigenous legal-system federation
+```
+
+Federation exchanges content-addressed graph revisions, credentials,
+attestations, and receipts. Each receiver chooses its accepted credentials,
+institutions, legal systems, jurisdictions, and promotion policies. A remote
+endorsement is evidence of that review act, not a command to promote locally.
+
+## Product views
+
+The same underlying graph can support:
+
+- source-first provision and judgment pages;
+- visual element, exception, burden, and authority maps;
+- cross-jurisdiction WrongType comparison;
+- timelines of commencement, amendment, repeal, and judicial treatment;
+- lawyer review queues and discrepancy surfaces;
+- institution-specific trusted projections;
+- public challenge and correction surfaces;
+- machine-readable APIs for legal drafting, research, compliance, and oversight.
+
+A typical consumer card should show:
+
+```text
+Prohibition candidate
+  source span: section 4, chars 130-211
+  PNF reconstruction: present
+  Legal IR projection: present
+  legacy witness: agrees
+  reviewer state: 3 endorsements, 1 qualified approval
+  contested coordinates: commencement, exception burden
+  jurisdiction: Queensland
+  legal time: unresolved
+  promotion: candidate only
+```
+
+## Non-collapse laws
+
+```text
+review endorsement != legal truth
+review majority != universal authority
+credential != correctness
+Legal IR projection != promoted law
+court holding != globally true proposition
+Wikidata candidate != resolved legal entity
+legacy witness != PNF factor
+remote federation state != local promotion
+```
+
+## Implementation sequence
+
+1. Emit one `LegalSemanticBuild` manifest from the legal PNF probe.
+2. Normalize legacy extractor rows into `LegacySemanticWitness` objects.
+3. Generate signature-aware `SemanticComparisonRow` records.
+4. Generate `PNFCoverageDemand` objects from legacy-only gaps.
+5. Publish immutable `LegalGraphRevision` objects from approved Legal IR build
+   coordinates.
+6. Accept attributable `LegalReviewAttestation` objects.
+7. Project scoped, non-authoritative `FederatedClaimState` views.
+8. Persist and exchange federation bundles with idempotency and conflict receipts.
+9. Integrate legally material Wikidata candidates as PNF refinement evidence,
+   never as direct Legal IR writes.
+10. Add public and restricted product surfaces over the same immutable graph.

--- a/scripts/run_legal_pnf_probe.py
+++ b/scripts/run_legal_pnf_probe.py
@@ -3,8 +3,8 @@
 
 The probe preserves source/canonical coordinates, records parser observations and
 PNF graphs, projects Legal IR only from legal PNF factors, compares the legacy
-obligation lane as a diagnostic oracle, and optionally performs candidate-only
-Wikidata lookups that the legal entity-resolution policy warrants.
+obligation lane as a diagnostic oracle, emits a unified LegalSemanticBuild, and
+optionally performs candidate-only Wikidata lookups warranted by legal materiality.
 """
 
 from __future__ import annotations
@@ -22,19 +22,14 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from src.ingestion.corpus_source_projection import project_source_families  # noqa: E402
-from src.obligations import (  # noqa: E402
-    extract_obligations_from_text,
-    obligation_to_dict,
-)
+from src.obligations import extract_obligations_from_text, obligation_to_dict  # noqa: E402
 from src.ontology.wikimedia_providers import (  # noqa: E402
     WikidataProvider,
     WikimediaMicrobatchRunner,
 )
 from src.pnf.legal_probe import build_legal_pnf_probe  # noqa: E402
-from src.policy.corpus_compilation import (  # noqa: E402
-    compile_document,
-    default_compiler_context,
-)
+from src.pnf.legal_semantic_build import build_legal_semantic_build  # noqa: E402
+from src.policy.corpus_compilation import compile_document, default_compiler_context  # noqa: E402
 
 
 def _parse_args() -> argparse.Namespace:
@@ -56,7 +51,6 @@ def _parse_args() -> argparse.Namespace:
     if args.max_file_bytes < 1:
         parser.error("--max-file-bytes must be positive")
     if args.run_wikidata and not args.compare_legacy:
-        # Not semantically required, but keeps live probes deliberately explicit.
         parser.error("--run-wikidata requires --compare-legacy for an auditable probe")
     return args
 
@@ -70,7 +64,7 @@ def _write_json(path: Path, value: Mapping[str, Any] | list[Any]) -> None:
 
 
 def _document_ref(canonical_sha256: str) -> str:
-    payload = f"legal-pnf-probe|{canonical_sha256}".encode("utf-8")
+    payload = f"legal-pnf-probe|{canonical_sha256}".encode()
     return "document:" + hashlib.sha256(payload).hexdigest()
 
 
@@ -116,21 +110,38 @@ def main() -> int:
     _write_json(projection_root / "manifest.json", manifest.to_dict())
 
     probe_rows: list[dict[str, Any]] = []
-    wikidata_demands = []
+    wikidata_demands: list[dict[str, Any]] = []
     for index, row in enumerate(manifest.documents, start=1):
         compilation = _compile_projection_row(row, projection_root)
-        canonical_text = str((compilation.get("artifacts") or {}).get("canonical_text") or "")
+        artifacts = compilation.get("artifacts") or {}
+        canonical_text = str(artifacts.get("canonical_text") or "")
         legacy = _legacy_rows(canonical_text) if args.compare_legacy else []
         probe = build_legal_pnf_probe(compilation, legacy_rows=legacy)
+
+        # The probe owns discovery; the build owns the typed, versioned merge surface.
+        from src.pnf.legal_adjunct import project_legal_ir
+
+        refined_graph = artifacts.get("refined_pnf_graph") or artifacts.get("pnf_graph") or {}
+        legal_ir_objects = project_legal_ir(refined_graph.get("factors") or ())
+        semantic_build = build_legal_semantic_build(
+            compilation=compilation,
+            legal_ir=legal_ir_objects,
+            legacy_rows=legacy,
+            declaration_revision_refs=artifacts.get("semantic_reduction_refs") or (),
+        )
+
         document_dir = output_dir / "documents" / f"{index:04d}_{row.canonical_sha256[:12]}"
-        artifacts = compilation.get("artifacts") or {}
         _write_json(document_dir / "compilation.json", compilation)
         _write_json(document_dir / "parser_observations.json", probe["parser_observations"])
         _write_json(document_dir / "pnf_graph.json", probe["pnf_graph"])
         _write_json(document_dir / "refined_pnf_graph.json", probe["refined_pnf_graph"])
         _write_json(document_dir / "legal_ir.json", probe["legal_ir"])
         _write_json(document_dir / "legacy_obligations.json", probe["legacy_observations"])
-        _write_json(document_dir / "comparison_ledger.json", probe["comparison_ledger"])
+        _write_json(document_dir / "legacy_witnesses.json", semantic_build["legacy_witnesses"])
+        _write_json(document_dir / "comparison_ledger.json", semantic_build["comparison_ledger"])
+        _write_json(document_dir / "pnf_coverage_demands.json", semantic_build["coverage_demands"])
+        _write_json(document_dir / "legal_ir_projection.json", semantic_build["legal_ir_projection"])
+        _write_json(document_dir / "legal_semantic_build.json", semantic_build)
         _write_json(
             document_dir / "entity_resolution_decisions.json",
             probe["entity_resolution_decisions"],
@@ -142,7 +153,8 @@ def main() -> int:
                 "source_ref": row.source_ref,
                 "document_ref": compilation.get("document_ref"),
                 "probe_ref": probe["probe_ref"],
-                "summary": probe["summary"],
+                "legal_semantic_build_ref": semantic_build["build"]["build_ref"],
+                "summary": {**probe["summary"], **semantic_build["summary"]},
                 "document_output_dir": str(document_dir),
                 "parser_receipt": artifacts.get("parser_receipt") or {},
             }
@@ -156,7 +168,6 @@ def main() -> int:
         "results": [],
     }
     if args.run_wikidata and wikidata_demands:
-        # Reconstruct typed demand objects from each probe to avoid broad lookups.
         from src.ontology.external_enrichment import ExternalLookupDemand
 
         demands = tuple(
@@ -187,7 +198,7 @@ def main() -> int:
     _write_json(output_dir / "wikidata_results.json", wikidata_output)
 
     summary = {
-        "schema_version": "sl.legal_pnf_probe_run.v0_1",
+        "schema_version": "sl.legal_pnf_probe_run.v0_2",
         "source_projection": str(projection_root / "manifest.json"),
         "documents": probe_rows,
         "document_count": len(probe_rows),
@@ -198,11 +209,14 @@ def main() -> int:
         "coverage_gap_count": sum(
             int(row["summary"]["coverage_gap_count"]) for row in probe_rows
         ),
+        "coverage_demand_count": sum(
+            int(row["summary"]["coverage_demand_count"]) for row in probe_rows
+        ),
         "wikidata_lookup_demand_count": len(wikidata_demands),
         "wikidata_network_performed": wikidata_output["network_performed"],
         "identity_closure_count": 0,
         "legal_conclusion_promotion_count": 0,
-        "authority": "diagnostic_only",
+        "authority": "diagnostic_build_index",
     }
     _write_json(output_dir / "coverage_scorecard.json", summary)
     print(json.dumps(summary, sort_keys=True))

--- a/src/pnf/legal_ir_federation.py
+++ b/src/pnf/legal_ir_federation.py
@@ -1,0 +1,339 @@
+"""Federated review and trust algebra for the Legal IR product.
+
+The federation layer does not alter PNF or Legal IR observations. It records
+attributable review acts over immutable graph revisions and derives scoped trust
+projections without collapsing disagreement or turning popularity into truth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.ontology.external_enrichment import canonical_sha256
+
+LEGAL_IR_FEDERATION_CONTRACT = "legal-ir-federation:v0_1"
+LEGAL_IR_ATTESTATION_CONTRACT = "legal-ir-attestation:v0_1"
+LEGAL_IR_TRUST_PROJECTION_CONTRACT = "legal-ir-trust-projection:v0_1"
+
+_REVIEW_STATES = frozenset(
+    {
+        "endorse",
+        "approve_with_residuals",
+        "reject",
+        "contest",
+        "abstain",
+        "supersede",
+    }
+)
+
+
+@dataclass(frozen=True)
+class LegalGraphRevision:
+    revision_ref: str
+    subject_ref: str
+    payload_hash: str
+    prior_revision_refs: tuple[str, ...]
+    source_span_refs: tuple[str, ...]
+    legal_system_refs: tuple[str, ...]
+    jurisdiction_refs: tuple[str, ...]
+    temporal_refs: tuple[str, ...]
+    author_ref: str
+    institution_ref: str | None
+    build_ref: str
+    revision_state: str = "candidate"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "authority": "candidate_graph_revision",
+            "mutable": False,
+        }
+
+
+@dataclass(frozen=True)
+class ReviewerCredential:
+    credential_ref: str
+    reviewer_ref: str
+    institution_ref: str | None
+    jurisdiction_refs: tuple[str, ...]
+    practice_area_refs: tuple[str, ...]
+    credential_type_refs: tuple[str, ...]
+    valid_from: str | None
+    valid_until: str | None
+    evidence_refs: tuple[str, ...]
+    verification_state: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "authority": "credential_evidence_only",
+            "confers_truth_authority": False,
+        }
+
+
+@dataclass(frozen=True)
+class LegalReviewAttestation:
+    attestation_ref: str
+    revision_ref: str
+    reviewer_ref: str
+    credential_refs: tuple[str, ...]
+    institution_ref: str | None
+    review_state: str
+    coordinate_states: Mapping[str, str]
+    reason_refs: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    supersedes_attestation_refs: tuple[str, ...]
+    created_at: str
+    signature_ref: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.review_state not in _REVIEW_STATES:
+            raise ValueError(f"unsupported legal review state: {self.review_state}")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "coordinate_states": dict(self.coordinate_states),
+            "contract_ref": LEGAL_IR_ATTESTATION_CONTRACT,
+            "authority": "attributed_review_act",
+            "changes_graph_revision": False,
+        }
+
+
+@dataclass(frozen=True)
+class FederatedClaimState:
+    revision_ref: str
+    scope_ref: str
+    endorsement_count: int
+    qualified_approval_count: int
+    rejection_count: int
+    contest_count: int
+    abstention_count: int
+    supersession_count: int
+    active_reviewer_refs: tuple[str, ...]
+    institution_refs: tuple[str, ...]
+    unresolved_coordinate_refs: tuple[str, ...]
+    state: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "contract_ref": LEGAL_IR_TRUST_PROJECTION_CONTRACT,
+            "authority": "scoped_review_projection_only",
+            "truth_closed": False,
+        }
+
+
+@dataclass(frozen=True)
+class FederationBundle:
+    bundle_ref: str
+    graph_revision_refs: tuple[str, ...]
+    credential_refs: tuple[str, ...]
+    attestation_refs: tuple[str, ...]
+    trust_projection_refs: tuple[str, ...]
+    federation_refs: tuple[str, ...]
+    checkpoint_state: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "contract_ref": LEGAL_IR_FEDERATION_CONTRACT,
+            "authority": "federated_review_surface",
+            "anonymous_consensus": False,
+            "disagreement_preserved": True,
+        }
+
+
+def create_graph_revision(
+    *,
+    subject_ref: str,
+    payload: Mapping[str, Any],
+    prior_revision_refs: Iterable[str] = (),
+    source_span_refs: Iterable[str] = (),
+    legal_system_refs: Iterable[str] = (),
+    jurisdiction_refs: Iterable[str] = (),
+    temporal_refs: Iterable[str] = (),
+    author_ref: str,
+    institution_ref: str | None,
+    build_ref: str,
+) -> LegalGraphRevision:
+    payload_hash = canonical_sha256(dict(payload))
+    identity = {
+        "contract": LEGAL_IR_FEDERATION_CONTRACT,
+        "subject_ref": subject_ref,
+        "payload_hash": payload_hash,
+        "prior_revision_refs": sorted(set(prior_revision_refs)),
+        "author_ref": author_ref,
+        "institution_ref": institution_ref,
+        "build_ref": build_ref,
+    }
+    return LegalGraphRevision(
+        revision_ref="legal-graph-revision:" + canonical_sha256(identity),
+        subject_ref=subject_ref,
+        payload_hash=payload_hash,
+        prior_revision_refs=tuple(sorted(set(prior_revision_refs))),
+        source_span_refs=tuple(sorted(set(source_span_refs))),
+        legal_system_refs=tuple(sorted(set(legal_system_refs))),
+        jurisdiction_refs=tuple(sorted(set(jurisdiction_refs))),
+        temporal_refs=tuple(sorted(set(temporal_refs))),
+        author_ref=author_ref,
+        institution_ref=institution_ref,
+        build_ref=build_ref,
+    )
+
+
+def create_review_attestation(
+    *,
+    revision_ref: str,
+    reviewer_ref: str,
+    credential_refs: Iterable[str],
+    institution_ref: str | None,
+    review_state: str,
+    coordinate_states: Mapping[str, str],
+    reason_refs: Iterable[str],
+    evidence_refs: Iterable[str],
+    supersedes_attestation_refs: Iterable[str],
+    created_at: str,
+    signature_ref: str | None = None,
+) -> LegalReviewAttestation:
+    identity = {
+        "contract": LEGAL_IR_ATTESTATION_CONTRACT,
+        "revision_ref": revision_ref,
+        "reviewer_ref": reviewer_ref,
+        "credential_refs": sorted(set(credential_refs)),
+        "institution_ref": institution_ref,
+        "review_state": review_state,
+        "coordinate_states": dict(sorted(coordinate_states.items())),
+        "reason_refs": sorted(set(reason_refs)),
+        "evidence_refs": sorted(set(evidence_refs)),
+        "supersedes": sorted(set(supersedes_attestation_refs)),
+        "created_at": created_at,
+        "signature_ref": signature_ref,
+    }
+    return LegalReviewAttestation(
+        attestation_ref="legal-review-attestation:" + canonical_sha256(identity),
+        revision_ref=revision_ref,
+        reviewer_ref=reviewer_ref,
+        credential_refs=tuple(sorted(set(credential_refs))),
+        institution_ref=institution_ref,
+        review_state=review_state,
+        coordinate_states=dict(coordinate_states),
+        reason_refs=tuple(sorted(set(reason_refs))),
+        evidence_refs=tuple(sorted(set(evidence_refs))),
+        supersedes_attestation_refs=tuple(sorted(set(supersedes_attestation_refs))),
+        created_at=created_at,
+        signature_ref=signature_ref,
+    )
+
+
+def _active_attestations(
+    attestations: Sequence[LegalReviewAttestation],
+) -> tuple[LegalReviewAttestation, ...]:
+    superseded = {
+        ref
+        for row in attestations
+        for ref in row.supersedes_attestation_refs
+    }
+    return tuple(row for row in attestations if row.attestation_ref not in superseded)
+
+
+def project_federated_claim_state(
+    *,
+    revision_ref: str,
+    attestations: Sequence[LegalReviewAttestation],
+    scope_ref: str = "scope:global-unweighted",
+    accepted_credential_refs: Iterable[str] = (),
+    accepted_institution_refs: Iterable[str] = (),
+) -> FederatedClaimState:
+    accepted_credentials = set(accepted_credential_refs)
+    accepted_institutions = set(accepted_institution_refs)
+    scoped: list[LegalReviewAttestation] = []
+    for row in _active_attestations(attestations):
+        if row.revision_ref != revision_ref:
+            continue
+        if accepted_credentials and not accepted_credentials.intersection(row.credential_refs):
+            continue
+        if accepted_institutions and row.institution_ref not in accepted_institutions:
+            continue
+        scoped.append(row)
+    counts = {state: 0 for state in _REVIEW_STATES}
+    unresolved: set[str] = set()
+    for row in scoped:
+        counts[row.review_state] += 1
+        unresolved.update(
+            coordinate
+            for coordinate, state in row.coordinate_states.items()
+            if state in {"unresolved", "contested", "insufficient_evidence"}
+        )
+    if counts["supersede"]:
+        state = "supersession_proposed"
+    elif counts["reject"] and (counts["endorse"] or counts["approve_with_residuals"]):
+        state = "contested"
+    elif counts["contest"]:
+        state = "contested"
+    elif counts["reject"] and not counts["endorse"]:
+        state = "rejected_in_scope"
+    elif counts["endorse"]:
+        state = "endorsed_in_scope"
+    elif counts["approve_with_residuals"]:
+        state = "approved_with_residuals_in_scope"
+    else:
+        state = "unreviewed_in_scope"
+    return FederatedClaimState(
+        revision_ref=revision_ref,
+        scope_ref=scope_ref,
+        endorsement_count=counts["endorse"],
+        qualified_approval_count=counts["approve_with_residuals"],
+        rejection_count=counts["reject"],
+        contest_count=counts["contest"],
+        abstention_count=counts["abstain"],
+        supersession_count=counts["supersede"],
+        active_reviewer_refs=tuple(sorted({row.reviewer_ref for row in scoped})),
+        institution_refs=tuple(sorted({row.institution_ref for row in scoped if row.institution_ref})),
+        unresolved_coordinate_refs=tuple(sorted(unresolved)),
+        state=state,
+    )
+
+
+def build_federation_bundle(
+    *,
+    revisions: Sequence[LegalGraphRevision],
+    credentials: Sequence[ReviewerCredential],
+    attestations: Sequence[LegalReviewAttestation],
+    projections: Sequence[FederatedClaimState],
+    federation_refs: Iterable[str] = (),
+) -> FederationBundle:
+    identity = {
+        "contract": LEGAL_IR_FEDERATION_CONTRACT,
+        "revisions": [row.revision_ref for row in revisions],
+        "credentials": [row.credential_ref for row in credentials],
+        "attestations": [row.attestation_ref for row in attestations],
+        "projections": [canonical_sha256(row.to_dict()) for row in projections],
+        "federations": sorted(set(federation_refs)),
+    }
+    return FederationBundle(
+        bundle_ref="legal-ir-federation-bundle:" + canonical_sha256(identity),
+        graph_revision_refs=tuple(sorted(row.revision_ref for row in revisions)),
+        credential_refs=tuple(sorted(row.credential_ref for row in credentials)),
+        attestation_refs=tuple(sorted(row.attestation_ref for row in attestations)),
+        trust_projection_refs=tuple(
+            sorted("legal-trust-projection:" + canonical_sha256(row.to_dict()) for row in projections)
+        ),
+        federation_refs=tuple(sorted(set(federation_refs))),
+        checkpoint_state="reviewable_federated_graph",
+    )
+
+
+__all__ = [
+    "LEGAL_IR_FEDERATION_CONTRACT",
+    "FederatedClaimState",
+    "FederationBundle",
+    "LegalGraphRevision",
+    "LegalReviewAttestation",
+    "ReviewerCredential",
+    "build_federation_bundle",
+    "create_graph_revision",
+    "create_review_attestation",
+    "project_federated_claim_state",
+]

--- a/src/pnf/legal_semantic_build.py
+++ b/src/pnf/legal_semantic_build.py
@@ -1,0 +1,505 @@
+"""Versioned legal semantic build over PNF, Legal IR, and diagnostic witnesses.
+
+The refined PNF graph remains the candidate semantic authority. Legal IR is a
+materialized projection of that graph. Legacy extractor output is retained only
+as diagnostic witness evidence. The comparison ledger is the sole alignment
+surface and cannot promote a witness into PNF.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.ontology.external_enrichment import canonical_sha256
+from src.pnf.legal_adjunct import LegalIRObservation
+
+LEGAL_SEMANTIC_BUILD_CONTRACT = "legal-semantic-build:v0_1"
+LEGAL_IR_MATERIALIZED_VIEW_CONTRACT = "legal-ir-materialized-view:v0_1"
+LEGACY_WITNESS_CONTRACT = "legacy-semantic-witness:v0_1"
+SEMANTIC_COMPARISON_LEDGER_CONTRACT = "semantic-comparison-ledger:v0_1"
+PNF_COVERAGE_DEMAND_CONTRACT = "pnf-coverage-demand:v0_1"
+
+_COORDINATE_SIGNATURES: Mapping[str, str] = {
+    "actor": "signature:legal-actor-role:v1",
+    "modality": "signature:normative-operation:v1",
+    "conduct": "signature:regulated-conduct:v1",
+    "object": "signature:regulated-object:v1",
+    "condition": "signature:legal-condition:v1",
+    "exception": "signature:legal-exception:v1",
+    "jurisdiction": "signature:legal-jurisdiction:v1",
+    "temporal_validity": "signature:legal-transition:v1",
+    "authority_wrapper": "signature:legal-authority:v1",
+}
+
+
+@dataclass(frozen=True)
+class LegacySemanticWitness:
+    witness_ref: str
+    extractor_contract_ref: str
+    source_span_refs: tuple[str, ...]
+    candidate_kind: str
+    candidate_payload: Mapping[str, Any]
+    match_state: str
+    provenance_refs: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "candidate_payload": dict(self.candidate_payload),
+            "authority": "diagnostic_only",
+            "promotes_pnf": False,
+        }
+
+
+@dataclass(frozen=True)
+class SemanticComparisonRow:
+    row_ref: str
+    document_ref: str
+    source_span_refs: tuple[str, ...]
+    comparison_kind: str
+    structural_signature_ref: str
+    pnf_factor_refs: tuple[str, ...]
+    legal_ir_observation_refs: tuple[str, ...]
+    legacy_witness_refs: tuple[str, ...]
+    comparison_state: str
+    coordinate_states: Mapping[str, str]
+    discrepancy_refs: tuple[str, ...]
+    proposed_actions: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "coordinate_states": dict(self.coordinate_states),
+            "authority": "audit_only",
+            "promotion_authority": False,
+        }
+
+
+@dataclass(frozen=True)
+class PNFCoverageDemand:
+    demand_ref: str
+    document_ref: str
+    source_observation_refs: tuple[str, ...]
+    candidate_composition_kind: str
+    expected_role_shape: tuple[str, ...]
+    missing_factor_type: str
+    witness_refs: tuple[str, ...]
+    structural_signature_ref: str
+    state: str = "requires_pnf_reconstruction"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "contract_ref": PNF_COVERAGE_DEMAND_CONTRACT,
+            "authority": "diagnostic_demand_only",
+            "may_create_factor_directly": False,
+        }
+
+
+@dataclass(frozen=True)
+class LegalIRProjection:
+    projection_ref: str
+    pnf_build_ref: str
+    projection_contract_ref: str
+    observation_refs: tuple[str, ...]
+    omitted_factor_refs: tuple[str, ...]
+    projection_residuals: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "authority": "pnf_projection_only",
+            "rebuildable": True,
+        }
+
+
+@dataclass(frozen=True)
+class LegalSemanticBuild:
+    build_ref: str
+    document_ref: str
+    source_revision_ref: str
+    canonical_text_ref: str
+    parser_build_ref: str
+    pnf_build_ref: str
+    refined_pnf_graph_ref: str
+    legal_ir_projection_ref: str
+    legacy_observation_set_ref: str
+    comparison_ledger_ref: str
+    coverage_demand_refs: tuple[str, ...]
+    declaration_revision_refs: tuple[str, ...]
+    build_state: str
+    provenance_refs: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "contract_ref": LEGAL_SEMANTIC_BUILD_CONTRACT,
+            "surface_authority": {
+                "refined_pnf_graph": "candidate_semantic_state",
+                "legal_ir": "deterministic_pnf_projection",
+                "legacy_observations": "diagnostic_witness_only",
+                "comparison_ledger": "audit_only",
+            },
+            "flattened_union": False,
+        }
+
+
+def _span_refs(row: Mapping[str, Any]) -> tuple[str, ...]:
+    values: set[str] = set()
+    for key in ("span_refs", "source_span_refs", "provenance_refs"):
+        raw = row.get(key) or ()
+        if isinstance(raw, str):
+            values.add(raw)
+        else:
+            values.update(str(value) for value in raw if value)
+    span = row.get("span")
+    if isinstance(span, Mapping):
+        values.add("span:" + canonical_sha256(dict(span)))
+    return tuple(sorted(values))
+
+
+def normalize_legacy_witnesses(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    document_ref: str,
+    extractor_contract_ref: str = "legacy-obligation-extractor:v0_1",
+) -> tuple[LegacySemanticWitness, ...]:
+    witnesses: dict[str, LegacySemanticWitness] = {}
+    for row in rows:
+        candidate_kind = str(row.get("type") or row.get("modality") or "untyped_legal_candidate")
+        spans = _span_refs(row)
+        payload = {
+            key: value
+            for key, value in row.items()
+            if key not in {"span_refs", "source_span_refs", "provenance_refs"}
+        }
+        identity = {
+            "contract": LEGACY_WITNESS_CONTRACT,
+            "document_ref": document_ref,
+            "extractor": extractor_contract_ref,
+            "candidate_kind": candidate_kind,
+            "payload": payload,
+            "spans": spans,
+        }
+        witness_ref = "legacy-witness:" + canonical_sha256(identity)
+        witnesses[witness_ref] = LegacySemanticWitness(
+            witness_ref=witness_ref,
+            extractor_contract_ref=extractor_contract_ref,
+            source_span_refs=spans,
+            candidate_kind=candidate_kind,
+            candidate_payload=payload,
+            match_state="candidate_detected",
+            provenance_refs=tuple(sorted({document_ref, extractor_contract_ref, *spans})),
+        )
+    return tuple(sorted(witnesses.values(), key=lambda row: row.witness_ref))
+
+
+def materialize_legal_ir_projection(
+    *,
+    pnf_build_ref: str,
+    legal_ir: Sequence[LegalIRObservation],
+    all_factor_refs: Iterable[str],
+) -> LegalIRProjection:
+    projected = {row.pnf_factor_ref for row in legal_ir}
+    omitted = tuple(sorted(set(str(value) for value in all_factor_refs) - projected))
+    residuals = ("non_legal_pnf_factors_omitted",) if omitted else ()
+    identity = {
+        "contract": LEGAL_IR_MATERIALIZED_VIEW_CONTRACT,
+        "pnf_build_ref": pnf_build_ref,
+        "observations": [row.observation_ref for row in legal_ir],
+        "omitted": omitted,
+    }
+    return LegalIRProjection(
+        projection_ref="legal-ir-projection:" + canonical_sha256(identity),
+        pnf_build_ref=pnf_build_ref,
+        projection_contract_ref=LEGAL_IR_MATERIALIZED_VIEW_CONTRACT,
+        observation_refs=tuple(sorted(row.observation_ref for row in legal_ir)),
+        omitted_factor_refs=omitted,
+        projection_residuals=residuals,
+    )
+
+
+def _feature_factor_refs(
+    factors: Sequence[Mapping[str, Any]], coordinate: str
+) -> tuple[str, ...]:
+    refs: list[str] = []
+    for factor in factors:
+        factor_ref = str(factor.get("factor_ref") or "")
+        factor_type = str(factor.get("factor_type") or factor.get("factor_type_ref") or "")
+        metadata = factor.get("metadata") or {}
+        role = str(metadata.get("role") or "") if isinstance(metadata, Mapping) else ""
+        matched = (
+            coordinate == "actor" and role in {"subject", "actor", "agent", "bearer"}
+            or coordinate == "conduct" and (factor_type == "semantic.eventuality" or "conduct" in factor_type)
+            or coordinate == "object" and role in {"object", "patient", "theme"}
+            or coordinate == "modality" and factor_type == "semantic.normative_relation"
+            or coordinate == "condition" and factor_type == "semantic.legal_condition"
+            or coordinate == "exception" and factor_type == "semantic.legal_exception"
+            or coordinate == "jurisdiction" and ("jurisdiction" in factor_type or role == "jurisdiction")
+            or coordinate == "temporal_validity" and factor_type == "semantic.legal_transition"
+            or coordinate == "authority_wrapper" and factor_type in {"semantic.legal_authority", "semantic.judicial_treatment"}
+        )
+        if matched and factor_ref:
+            refs.append(factor_ref)
+    return tuple(sorted(set(refs)))
+
+
+def _feature_ir_refs(
+    legal_ir: Sequence[LegalIRObservation], coordinate: str
+) -> tuple[str, ...]:
+    refs: list[str] = []
+    for row in legal_ir:
+        roles = {key.casefold() for key in row.role_bindings}
+        matched = (
+            coordinate == "actor" and bool(roles.intersection({"actor", "bearer", "court", "party"}))
+            or coordinate == "conduct" and bool(roles.intersection({"conduct", "action", "predicate"}))
+            or coordinate == "object" and bool(roles.intersection({"object", "patient", "theme"}))
+            or coordinate == "modality" and bool(row.qualifier_state.get("modality") or "normative" in row.predicate_ref)
+            or coordinate == "condition" and bool(row.qualifier_state.get("condition_ref"))
+            or coordinate == "exception" and bool(row.qualifier_state.get("exception_ref"))
+            or coordinate == "jurisdiction" and bool(row.wrapper_state.get("jurisdiction_ref"))
+            or coordinate == "temporal_validity" and bool(row.wrapper_state.get("validity_interval"))
+            or coordinate == "authority_wrapper" and bool(row.wrapper_state.get("authority_class"))
+        )
+        if matched:
+            refs.append(row.observation_ref)
+    return tuple(sorted(set(refs)))
+
+
+def _feature_witness_refs(
+    witnesses: Sequence[LegacySemanticWitness], coordinate: str
+) -> tuple[str, ...]:
+    refs: list[str] = []
+    for witness in witnesses:
+        row = witness.candidate_payload
+        matched = (
+            coordinate == "actor" and bool(row.get("actor"))
+            or coordinate == "modality" and bool(row.get("modality") or row.get("type"))
+            or coordinate == "conduct" and bool(row.get("action"))
+            or coordinate == "object" and bool(row.get("object") or row.get("obj"))
+            or coordinate == "condition" and bool(row.get("conditions"))
+            or coordinate == "exception" and any(
+                str(item.get("type") or "") in {"unless", "except", "exception"}
+                for item in row.get("conditions") or ()
+                if isinstance(item, Mapping)
+            )
+            or coordinate == "jurisdiction" and bool(row.get("scopes"))
+            or coordinate == "temporal_validity" and bool(row.get("lifecycle"))
+            or coordinate == "authority_wrapper" and bool(row.get("references") or row.get("reference_identities"))
+        )
+        if matched:
+            refs.append(witness.witness_ref)
+    return tuple(sorted(set(refs)))
+
+
+def build_semantic_comparison_ledger(
+    *,
+    document_ref: str,
+    factors: Sequence[Mapping[str, Any]],
+    legal_ir: Sequence[LegalIRObservation],
+    witnesses: Sequence[LegacySemanticWitness],
+) -> tuple[SemanticComparisonRow, ...]:
+    rows: list[SemanticComparisonRow] = []
+    for coordinate, signature in _COORDINATE_SIGNATURES.items():
+        pnf_refs = _feature_factor_refs(factors, coordinate)
+        ir_refs = _feature_ir_refs(legal_ir, coordinate)
+        witness_refs = _feature_witness_refs(witnesses, coordinate)
+        discrepancies: list[str] = []
+        actions: list[str] = []
+        if pnf_refs and ir_refs:
+            state = "aligned"
+        elif pnf_refs and not ir_refs:
+            state = "legal_ir_projection_gap"
+            discrepancies.append(f"pnf_{coordinate}_not_projected_to_legal_ir")
+            actions.append("inspect_legal_ir_projection_contract")
+        elif witness_refs and not pnf_refs:
+            state = "legacy_only"
+            discrepancies.append(f"legacy_{coordinate}_candidate_not_reconstructed_in_pnf")
+            actions.append("request_pnf_reconstruction")
+        elif pnf_refs:
+            state = "pnf_only"
+        elif witness_refs:
+            state = "legacy_only"
+        else:
+            state = "unresolved"
+        span_refs = tuple(
+            sorted(
+                {
+                    span
+                    for witness in witnesses
+                    if witness.witness_ref in witness_refs
+                    for span in witness.source_span_refs
+                }
+            )
+        )
+        identity = {
+            "contract": SEMANTIC_COMPARISON_LEDGER_CONTRACT,
+            "document_ref": document_ref,
+            "coordinate": coordinate,
+            "signature": signature,
+            "pnf": pnf_refs,
+            "legal_ir": ir_refs,
+            "witnesses": witness_refs,
+            "state": state,
+        }
+        rows.append(
+            SemanticComparisonRow(
+                row_ref="semantic-comparison:" + canonical_sha256(identity),
+                document_ref=document_ref,
+                source_span_refs=span_refs,
+                comparison_kind=coordinate,
+                structural_signature_ref=signature,
+                pnf_factor_refs=pnf_refs,
+                legal_ir_observation_refs=ir_refs,
+                legacy_witness_refs=witness_refs,
+                comparison_state=state,
+                coordinate_states={
+                    "pnf": "present" if pnf_refs else "absent",
+                    "legal_ir": "present" if ir_refs else "absent",
+                    "legacy_witness": "present" if witness_refs else "absent",
+                },
+                discrepancy_refs=tuple(discrepancies),
+                proposed_actions=tuple(actions),
+            )
+        )
+    return tuple(rows)
+
+
+def project_pnf_coverage_demands(
+    ledger: Iterable[SemanticComparisonRow],
+) -> tuple[PNFCoverageDemand, ...]:
+    demands: list[PNFCoverageDemand] = []
+    factor_types = {
+        "modality": "semantic.normative_relation",
+        "condition": "semantic.legal_condition",
+        "exception": "semantic.legal_exception",
+        "temporal_validity": "semantic.legal_transition",
+        "authority_wrapper": "semantic.legal_authority",
+        "actor": "semantic.argument",
+        "conduct": "semantic.eventuality",
+        "object": "semantic.argument",
+        "jurisdiction": "semantic.legal.jurisdiction",
+    }
+    role_shapes = {
+        "modality": ("bearer", "content"),
+        "condition": ("condition", "consequent"),
+        "exception": ("exception", "base_norm"),
+        "temporal_validity": ("legal_object", "prior_state", "new_state", "effective_time"),
+        "authority_wrapper": ("authority", "content"),
+        "actor": ("actor",),
+        "conduct": ("conduct",),
+        "object": ("object",),
+        "jurisdiction": ("jurisdiction",),
+    }
+    for row in ledger:
+        if row.comparison_state != "legacy_only":
+            continue
+        identity = {
+            "contract": PNF_COVERAGE_DEMAND_CONTRACT,
+            "comparison_row_ref": row.row_ref,
+            "missing_factor_type": factor_types[row.comparison_kind],
+        }
+        demands.append(
+            PNFCoverageDemand(
+                demand_ref="pnf-coverage-demand:" + canonical_sha256(identity),
+                document_ref=row.document_ref,
+                source_observation_refs=row.source_span_refs,
+                candidate_composition_kind=row.comparison_kind,
+                expected_role_shape=role_shapes[row.comparison_kind],
+                missing_factor_type=factor_types[row.comparison_kind],
+                witness_refs=row.legacy_witness_refs,
+                structural_signature_ref=row.structural_signature_ref,
+            )
+        )
+    return tuple(sorted(demands, key=lambda row: row.demand_ref))
+
+
+def build_legal_semantic_build(
+    *,
+    compilation: Mapping[str, Any],
+    legal_ir: Sequence[LegalIRObservation],
+    legacy_rows: Sequence[Mapping[str, Any]],
+    declaration_revision_refs: Iterable[str] = (),
+) -> dict[str, Any]:
+    artifacts = compilation.get("artifacts") or compilation
+    document_ref = str(compilation.get("document_ref") or artifacts.get("document_ref") or "")
+    refined_graph = artifacts.get("refined_pnf_graph") or artifacts.get("pnf_graph") or {}
+    factors = tuple(row for row in refined_graph.get("factors") or () if isinstance(row, Mapping))
+    pnf_build_ref = str(refined_graph.get("graph_ref") or "pnf-build:" + canonical_sha256(refined_graph))
+    witnesses = normalize_legacy_witnesses(legacy_rows, document_ref=document_ref)
+    projection = materialize_legal_ir_projection(
+        pnf_build_ref=pnf_build_ref,
+        legal_ir=legal_ir,
+        all_factor_refs=(str(row.get("factor_ref") or "") for row in factors),
+    )
+    ledger = build_semantic_comparison_ledger(
+        document_ref=document_ref,
+        factors=factors,
+        legal_ir=legal_ir,
+        witnesses=witnesses,
+    )
+    demands = project_pnf_coverage_demands(ledger)
+    source_revision_ref = str(artifacts.get("build_key_sha256") or compilation.get("content_sha256") or "")
+    canonical_text_ref = "canonical-text:" + canonical_sha256(artifacts.get("canonical_text") or "")
+    parser_build_ref = "parser-build:" + canonical_sha256(artifacts.get("parser_receipt") or {})
+    legacy_set_ref = "legacy-witness-set:" + canonical_sha256([row.to_dict() for row in witnesses])
+    ledger_ref = "semantic-comparison-ledger:" + canonical_sha256([row.to_dict() for row in ledger])
+    declarations = tuple(sorted(set(str(value) for value in declaration_revision_refs if value)))
+    identity = {
+        "contract": LEGAL_SEMANTIC_BUILD_CONTRACT,
+        "document_ref": document_ref,
+        "source_revision_ref": source_revision_ref,
+        "canonical_text_ref": canonical_text_ref,
+        "parser_build_ref": parser_build_ref,
+        "pnf_build_ref": pnf_build_ref,
+        "legal_ir_projection_ref": projection.projection_ref,
+        "legacy_observation_set_ref": legacy_set_ref,
+        "comparison_ledger_ref": ledger_ref,
+        "declarations": declarations,
+    }
+    build = LegalSemanticBuild(
+        build_ref="legal-semantic-build:" + canonical_sha256(identity),
+        document_ref=document_ref,
+        source_revision_ref=source_revision_ref,
+        canonical_text_ref=canonical_text_ref,
+        parser_build_ref=parser_build_ref,
+        pnf_build_ref=pnf_build_ref,
+        refined_pnf_graph_ref=pnf_build_ref,
+        legal_ir_projection_ref=projection.projection_ref,
+        legacy_observation_set_ref=legacy_set_ref,
+        comparison_ledger_ref=ledger_ref,
+        coverage_demand_refs=tuple(row.demand_ref for row in demands),
+        declaration_revision_refs=declarations,
+        build_state="candidate_semantic_build",
+        provenance_refs=tuple(sorted({document_ref, source_revision_ref, pnf_build_ref})),
+    )
+    return {
+        "build": build.to_dict(),
+        "legal_ir_projection": projection.to_dict(),
+        "legacy_witnesses": [row.to_dict() for row in witnesses],
+        "comparison_ledger": [row.to_dict() for row in ledger],
+        "coverage_demands": [row.to_dict() for row in demands],
+        "summary": {
+            "legal_ir_observation_count": len(legal_ir),
+            "legacy_witness_count": len(witnesses),
+            "comparison_row_count": len(ledger),
+            "coverage_demand_count": len(demands),
+            "semantic_promotion_count": 0,
+        },
+    }
+
+
+__all__ = [
+    "LEGAL_SEMANTIC_BUILD_CONTRACT",
+    "LegacySemanticWitness",
+    "LegalIRProjection",
+    "LegalSemanticBuild",
+    "PNFCoverageDemand",
+    "SemanticComparisonRow",
+    "build_legal_semantic_build",
+    "build_semantic_comparison_ledger",
+    "materialize_legal_ir_projection",
+    "normalize_legacy_witnesses",
+    "project_pnf_coverage_demands",
+]

--- a/tests/pnf/test_legal_ir_federation.py
+++ b/tests/pnf/test_legal_ir_federation.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from src.pnf.legal_ir_federation import (
+    ReviewerCredential,
+    build_federation_bundle,
+    create_graph_revision,
+    create_review_attestation,
+    project_federated_claim_state,
+)
+
+
+def test_reviews_preserve_disagreement_and_never_close_truth() -> None:
+    revision = create_graph_revision(
+        subject_ref="legal-ir:claim:1",
+        payload={"predicate": "normative.prohibition"},
+        source_span_refs=("span:1",),
+        legal_system_refs=("AU.COMMON",),
+        jurisdiction_refs=("AU",),
+        author_ref="lawyer:alice",
+        institution_ref="firm:a",
+        build_ref="legal-semantic-build:1",
+    )
+    endorse = create_review_attestation(
+        revision_ref=revision.revision_ref,
+        reviewer_ref="lawyer:bob",
+        credential_refs=("credential:bob",),
+        institution_ref="firm:b",
+        review_state="endorse",
+        coordinate_states={"modality": "satisfied", "exception": "unresolved"},
+        reason_refs=("reason:source-aligned",),
+        evidence_refs=("span:1",),
+        supersedes_attestation_refs=(),
+        created_at="2026-07-21T00:00:00Z",
+    )
+    reject = create_review_attestation(
+        revision_ref=revision.revision_ref,
+        reviewer_ref="lawyer:carol",
+        credential_refs=("credential:carol",),
+        institution_ref="firm:c",
+        review_state="reject",
+        coordinate_states={"modality": "contested"},
+        reason_refs=("reason:scope-wrong",),
+        evidence_refs=("span:1",),
+        supersedes_attestation_refs=(),
+        created_at="2026-07-21T01:00:00Z",
+    )
+    projection = project_federated_claim_state(
+        revision_ref=revision.revision_ref,
+        attestations=(endorse, reject),
+    )
+    assert projection.state == "contested"
+    assert projection.endorsement_count == 1
+    assert projection.rejection_count == 1
+    assert projection.to_dict()["truth_closed"] is False
+    assert "exception" in projection.unresolved_coordinate_refs
+
+
+def test_superseded_reviews_stop_counting_and_scope_can_filter() -> None:
+    revision = create_graph_revision(
+        subject_ref="legal-ir:claim:2",
+        payload={"predicate": "judicial.holding"},
+        author_ref="lawyer:a",
+        institution_ref="court:registry",
+        build_ref="build:2",
+    )
+    old = create_review_attestation(
+        revision_ref=revision.revision_ref,
+        reviewer_ref="lawyer:b",
+        credential_refs=("credential:b",),
+        institution_ref="firm:b",
+        review_state="reject",
+        coordinate_states={},
+        reason_refs=(),
+        evidence_refs=(),
+        supersedes_attestation_refs=(),
+        created_at="2026-07-21T00:00:00Z",
+    )
+    replacement = create_review_attestation(
+        revision_ref=revision.revision_ref,
+        reviewer_ref="lawyer:b",
+        credential_refs=("credential:b",),
+        institution_ref="firm:b",
+        review_state="endorse",
+        coordinate_states={},
+        reason_refs=(),
+        evidence_refs=(),
+        supersedes_attestation_refs=(old.attestation_ref,),
+        created_at="2026-07-21T02:00:00Z",
+    )
+    projection = project_federated_claim_state(
+        revision_ref=revision.revision_ref,
+        attestations=(old, replacement),
+        accepted_institution_refs=("firm:b",),
+        scope_ref="scope:firm-b",
+    )
+    assert projection.endorsement_count == 1
+    assert projection.rejection_count == 0
+    assert projection.state == "endorsed_in_scope"
+
+    credential = ReviewerCredential(
+        credential_ref="credential:b",
+        reviewer_ref="lawyer:b",
+        institution_ref="firm:b",
+        jurisdiction_refs=("AU",),
+        practice_area_refs=("administrative-law",),
+        credential_type_refs=("admitted-solicitor",),
+        valid_from="2020-01-01",
+        valid_until=None,
+        evidence_refs=("registry:admissions",),
+        verification_state="verified_candidate",
+    )
+    bundle = build_federation_bundle(
+        revisions=(revision,),
+        credentials=(credential,),
+        attestations=(old, replacement),
+        projections=(projection,),
+        federation_refs=("federation:au-public-law",),
+    )
+    payload = bundle.to_dict()
+    assert payload["disagreement_preserved"] is True
+    assert payload["anonymous_consensus"] is False

--- a/tests/pnf/test_legal_semantic_build.py
+++ b/tests/pnf/test_legal_semantic_build.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from src.pnf.legal_adjunct import LegalIRObservation
+from src.pnf.legal_semantic_build import build_legal_semantic_build, normalize_legacy_witnesses
+
+
+def _compilation() -> dict:
+    return {
+        "document_ref": "document:legal-1",
+        "content_sha256": "content-1",
+        "artifacts": {
+            "canonical_text": "A person must not drive unless licensed.",
+            "build_key_sha256": "build-key-1",
+            "parser_receipt": {"parser": "shared"},
+            "semantic_reduction_refs": ["grammar:shared:v1"],
+            "refined_pnf_graph": {
+                "graph_ref": "pnf-graph:1",
+                "factors": [
+                    {"factor_ref": "factor:norm", "factor_type": "semantic.normative_relation", "metadata": {"role": "predicate"}},
+                    {"factor_ref": "factor:actor", "factor_type": "semantic.argument", "metadata": {"role": "bearer"}},
+                    {"factor_ref": "factor:drive", "factor_type": "semantic.eventuality", "metadata": {"role": "conduct"}},
+                ],
+            },
+        },
+    }
+
+
+def _legal_ir() -> tuple[LegalIRObservation, ...]:
+    return (
+        LegalIRObservation(
+            observation_ref="legal-ir:1",
+            pnf_factor_ref="factor:norm",
+            pnf_revision_ref="revision:norm",
+            structural_signature_ref="signature:normative-operation:v1",
+            predicate_ref="normative.prohibition",
+            role_bindings={"bearer": "factor:actor", "conduct": "factor:drive"},
+            qualifier_state={"modality": "obligation", "polarity": "negative"},
+            wrapper_state={},
+            provenance_refs=("span:1",),
+            residual_refs=("exception_unresolved",),
+        ),
+    )
+
+
+def test_build_unifies_surfaces_without_flattening_authority() -> None:
+    result = build_legal_semantic_build(
+        compilation=_compilation(),
+        legal_ir=_legal_ir(),
+        legacy_rows=(
+            {
+                "type": "prohibition",
+                "actor": "A person",
+                "action": "drive",
+                "conditions": [{"type": "unless", "text": "licensed"}],
+                "span_refs": ["span:1"],
+            },
+        ),
+        declaration_revision_refs=("grammar:shared:v1",),
+    )
+    build = result["build"]
+    assert build["flattened_union"] is False
+    assert build["surface_authority"]["refined_pnf_graph"] == "candidate_semantic_state"
+    assert build["surface_authority"]["legacy_observations"] == "diagnostic_witness_only"
+    assert result["summary"]["semantic_promotion_count"] == 0
+    assert result["legacy_witnesses"][0]["promotes_pnf"] is False
+    assert any(row["comparison_state"] == "aligned" for row in result["comparison_ledger"])
+    assert any(
+        demand["missing_factor_type"] == "semantic.legal_exception"
+        for demand in result["coverage_demands"]
+    )
+
+
+def test_legacy_witness_is_attributed_detection_not_legal_fact() -> None:
+    witnesses = normalize_legacy_witnesses(
+        ({"type": "permission", "actor": "Minister", "action": "grant"},),
+        document_ref="document:1",
+    )
+    payload = witnesses[0].to_dict()
+    assert payload["authority"] == "diagnostic_only"
+    assert payload["promotes_pnf"] is False
+    assert payload["candidate_kind"] == "permission"

--- a/tests/storage/test_binding_migration_chain.py
+++ b/tests/storage/test_binding_migration_chain.py
@@ -24,6 +24,9 @@ def test_binding_migrations_repair_active_document_authority_and_add_reuse() -> 
     migration_014 = (
         MIGRATIONS / "014_external_pnf_enrichment.sql"
     ).read_text(encoding="utf-8")
+    migration_015 = (
+        MIGRATIONS / "015_legal_ir_federation.sql"
+    ).read_text(encoding="utf-8")
 
     assert "REFERENCES compiler_document(document_ref)" in migration_008
     assert "DROP CONSTRAINT IF EXISTS factor_anchor_document_ref_fkey" in (
@@ -60,3 +63,16 @@ def test_binding_migrations_repair_active_document_authority_and_add_reuse() -> 
     assert "candidate_payload JSONB" not in (
         migration_010 + migration_011 + migration_012 + migration_013 + migration_014
     )
+
+    assert "CREATE SCHEMA IF NOT EXISTS legal_ir" in migration_015
+    assert "legal_ir.semantic_build" in migration_015
+    assert "diagnostic.legacy_witness" in migration_015
+    assert "diagnostic.semantic_comparison" in migration_015
+    assert "diagnostic.pnf_coverage_demand" in migration_015
+    assert "legal_ir.graph_revision" in migration_015
+    assert "legal_ir.review_attestation" in migration_015
+    assert "legal_ir.trust_projection" in migration_015
+    assert "CHECK (truth_closed = FALSE)" in migration_015
+    assert "CHECK (anonymous_consensus = FALSE)" in migration_015
+    assert "CHECK (disagreement_preserved = TRUE)" in migration_015
+    assert "direct_factor_creation_allowed = FALSE" in migration_015


### PR DESCRIPTION
## Summary

Follow-on to merged PR #442. This packages refined PNF, Legal IR, legacy diagnostic observations, and their comparison ledger into one versioned `LegalSemanticBuild` without flattening their authority, and introduces the first product/federation contract for lawyer-reviewed Legal IR graph revisions.

## Semantic build

Adds `src/pnf/legal_semantic_build.py` with:

- `LegalSemanticBuild` envelope;
- materialized `LegalIRProjection` linked to a PNF build;
- normalized `LegacySemanticWitness` objects;
- signature-aware `SemanticComparisonRow` ledger entries;
- `PNFCoverageDemand` objects for legacy-only gaps;
- explicit prohibition on direct legacy-witness-to-PNF promotion.

The refined PNF graph remains the candidate semantic authority. Legal IR remains a deterministic PNF projection. Legacy extraction remains diagnostic only. The ledger is the alignment and audit surface.

The legal PNF probe now emits:

```text
legal_semantic_build.json
legal_ir_projection.json
legacy_witnesses.json
comparison_ledger.json
pnf_coverage_demands.json
```

alongside the existing parser/PNF/entity-resolution artifacts.

## Federated Legal IR product

Adds `src/pnf/legal_ir_federation.py` with immutable:

- `LegalGraphRevision`;
- `ReviewerCredential`;
- `LegalReviewAttestation`;
- `FederatedClaimState`;
- `FederationBundle`.

Review acts are attributable and coordinate-sensitive:

```text
endorse
approve_with_residuals
reject
contest
abstain
supersede
```

Trust projections are scoped by accepted credentials and institutions. They preserve competing endorsements and rejections, ignore superseded attestations in active counts, and always retain `truth_closed = false`.

## Persistence

Adds migration `015_legal_ir_federation.sql` for:

- semantic builds and Legal IR projections;
- Legal IR observations;
- legacy witnesses and comparison rows;
- PNF coverage demands;
- graph revisions;
- reviewer credentials and attestations;
- scoped trust projections;
- federation bundles.

Database constraints enforce that diagnostic coverage demands cannot directly create PNF factors, trust projections cannot close truth, and federation bundles cannot claim anonymous consensus or discard disagreement.

## Product doctrine

Adds `docs/planning/legal_ir_product_and_federation_20260721.md` describing Legal IR as a federated SensibLaw product: a source-grounded, semantically typed legal commons where lawyers and institutions endorse, reject, contest, or supersede exact graph revisions and coordinates.

The intended product resembles collaborative public knowledge infrastructure, but with typed immutable revisions, exact legal provenance, explicit disagreement, professional attribution, and institution-scoped trust views rather than anonymous prose consensus.

## Authority boundaries

This PR does not assert that:

- endorsement equals legal truth;
- majority review creates universal authority;
- credentials guarantee correctness;
- legacy observations are PNF facts;
- remote federation state commands local promotion;
- Wikidata candidates resolve legal identity.
