### PR TITLE
Compose legal PNF operators and export semantic builds

### DIFF
--- a/scripts/run_legal_pnf_probe.py
+++ b/scripts/run_legal_pnf_probe.py
@@ -29,6 +29,9 @@ from src.ontology.wikimedia_providers import (  # noqa: E402
 )
 from src.pnf.legal_probe import build_legal_pnf_probe  # noqa: E402
 from src.pnf.legal_semantic_build import build_legal_semantic_build  # noqa: E402
+from src.pnf.operator_composition_bridge import (  # noqa: E402
+    apply_operator_composition_to_compilation,
+)
 from src.policy.corpus_compilation import compile_document, default_compiler_context  # noqa: E402
 
 
@@ -81,7 +84,7 @@ def _compile_projection_row(row: Any, projection_root: Path) -> Mapping[str, Any
         },
         default_compiler_context(),
     )
-    return compilation.to_dict()
+    return apply_operator_composition_to_compilation(compilation.to_dict())
 
 
 def _legacy_rows(text: str) -> list[dict[str, Any]]:
@@ -118,7 +121,6 @@ def main() -> int:
         legacy = _legacy_rows(canonical_text) if args.compare_legacy else []
         probe = build_legal_pnf_probe(compilation, legacy_rows=legacy)
 
-        # The probe owns discovery; the build owns the typed, versioned merge surface.
         from src.pnf.legal_adjunct import project_legal_ir
 
         refined_graph = artifacts.get("refined_pnf_graph") or artifacts.get("pnf_graph") or {}
@@ -127,7 +129,10 @@ def main() -> int:
             compilation=compilation,
             legal_ir=legal_ir_objects,
             legacy_rows=legacy,
-            declaration_revision_refs=artifacts.get("semantic_reduction_refs") or (),
+            declaration_revision_refs=(
+                *(artifacts.get("semantic_reduction_refs") or ()),
+                str((artifacts.get("operator_composition") or {}).get("contract_ref") or ""),
+            ),
         )
 
         document_dir = output_dir / "documents" / f"{index:04d}_{row.canonical_sha256[:12]}"
@@ -157,6 +162,7 @@ def main() -> int:
                 "summary": {**probe["summary"], **semantic_build["summary"]},
                 "document_output_dir": str(document_dir),
                 "parser_receipt": artifacts.get("parser_receipt") or {},
+                "operator_composition": artifacts.get("operator_composition") or {},
             }
         )
         wikidata_demands.extend(probe["wikidata_lookup_demands"])
@@ -198,7 +204,7 @@ def main() -> int:
     _write_json(output_dir / "wikidata_results.json", wikidata_output)
 
     summary = {
-        "schema_version": "sl.legal_pnf_probe_run.v0_2",
+        "schema_version": "sl.legal_pnf_probe_run.v0_3",
         "source_projection": str(projection_root / "manifest.json"),
         "documents": probe_rows,
         "document_count": len(probe_rows),
@@ -211,6 +217,10 @@ def main() -> int:
         ),
         "coverage_demand_count": sum(
             int(row["summary"]["coverage_demand_count"]) for row in probe_rows
+        ),
+        "operator_factor_count": sum(
+            int((row.get("operator_composition") or {}).get("factor_count") or 0)
+            for row in probe_rows
         ),
         "wikidata_lookup_demand_count": len(wikidata_demands),
         "wikidata_network_performed": wikidata_output["network_performed"],

--- a/src/language/__init__.py
+++ b/src/language/__init__.py
@@ -8,6 +8,10 @@ from .annotations import (
 )
 from .grammars import ReductionGrammar, ReductionResult, apply_reduction_grammar
 from .graph import AnnotationGraph
+from .operator_composition import (
+    OPERATOR_COMPOSITION_CONTRACT,
+    compose_operator_factors,
+)
 from .semantic_reductions import (
     LocalTypeProjection,
     SemanticReductionDeclaration,
@@ -26,8 +30,10 @@ __all__ = [
     "ReductionResult",
     "RelationAnnotation",
     "LocalTypeProjection",
+    "OPERATOR_COMPOSITION_CONTRACT",
     "SemanticReductionDeclaration",
     "SemanticReductionOutput",
+    "compose_operator_factors",
     "diagnose_untyped_mentions",
     "derive_relational_type_hypotheses",
     "SpanAnnotation",

--- a/src/language/operator_composition.py
+++ b/src/language/operator_composition.py
@@ -1,0 +1,321 @@
+"""Generic parser-observation composition for modal and scoped PNF factors.
+
+This module is part of the one shared parser-to-PNF spine.  It does not select a
+legal source family and it does not decide applicability, violation, liability,
+or legal truth.  It composes ordinary parser observations into candidate PNF
+factors whose structure may later be projected into Legal IR.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from src.policy.algebra import Factor, TypedAlternative
+from src.policy.carriers.canonical import canonical_sha256
+
+
+OPERATOR_COMPOSITION_CONTRACT = "grammar:semantic:operator-composition:v0_1"
+
+_MODAL_LEMMAS = {
+    "must": ("obligation", "normative.obligation"),
+    "shall": ("obligation", "normative.obligation"),
+    "may": ("permission_candidate", "normative.permission_candidate"),
+}
+_CONDITION_MARKERS = {"if", "when", "provided", "providing"}
+_EXCEPTION_MARKERS = {"unless", "except", "excluding"}
+_TRANSITION_LEMMAS = {
+    "commence": ("inactive", "active", "legal.commencement"),
+    "begin": ("inactive", "active", "legal.commencement_candidate"),
+    "repeal": ("active", "repealed", "legal.repeal"),
+    "amend": ("prior_revision", "amended_revision", "legal.amendment"),
+    "cease": ("active", "inactive", "legal.cessation"),
+}
+
+
+def _tokens(parsed_document: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
+    rows: list[dict[str, Any]] = []
+    for sentence_index, sentence in enumerate(parsed_document.get("sents") or ()):
+        for token in sentence.get("tokens") or ():
+            rows.append({**dict(token), "sentence_index": sentence_index})
+    return tuple(rows)
+
+
+def _token_ref(document_ref: str, token: Mapping[str, Any]) -> str:
+    return "parser-token:" + canonical_sha256(
+        {
+            "document_ref": document_ref,
+            "parser_index": int(token["index"]),
+            "start": int(token["start"]),
+            "end": int(token["end"]),
+        }
+    )
+
+
+def _lemma(token: Mapping[str, Any]) -> str:
+    return str(token.get("lemma") or token.get("text") or "").casefold()
+
+
+def _children(
+    token: Mapping[str, Any], sentence_tokens: Sequence[Mapping[str, Any]]
+) -> tuple[Mapping[str, Any], ...]:
+    index = int(token["index"])
+    return tuple(row for row in sentence_tokens if int(row.get("head_index", -1)) == index)
+
+
+def _subject_and_object(
+    head: Mapping[str, Any], sentence_tokens: Sequence[Mapping[str, Any]]
+) -> tuple[Mapping[str, Any] | None, Mapping[str, Any] | None]:
+    children = _children(head, sentence_tokens)
+    subject = next(
+        (
+            row
+            for row in children
+            if str(row.get("dep") or "") in {"nsubj", "nsubjpass", "csubj"}
+        ),
+        None,
+    )
+    object_row = next(
+        (
+            row
+            for row in children
+            if str(row.get("dep") or "")
+            in {"obj", "dobj", "pobj", "attr", "oprd"}
+        ),
+        None,
+    )
+    return subject, object_row
+
+
+def _new_factor(
+    *,
+    document_ref: str,
+    sentence_index: int,
+    factor_type: str,
+    predicate_ref: str,
+    signature_ref: str,
+    role_bindings: Mapping[str, str],
+    qualifier_state: Mapping[str, Any],
+    provenance_refs: Sequence[str],
+    residuals: Sequence[str],
+    identity_payload: Mapping[str, Any],
+) -> Factor[Any]:
+    factor_ref = "factor:" + canonical_sha256(
+        {
+            "contract": OPERATOR_COMPOSITION_CONTRACT,
+            "document_ref": document_ref,
+            "sentence_index": sentence_index,
+            "factor_type": factor_type,
+            "identity": identity_payload,
+        }
+    )
+    revision_ref = "factor-revision:" + canonical_sha256(
+        {
+            "factor_ref": factor_ref,
+            "contract": OPERATOR_COMPOSITION_CONTRACT,
+            "roles": dict(sorted(role_bindings.items())),
+            "qualifiers": dict(qualifier_state),
+        }
+    )
+    alternative = TypedAlternative(
+        alternative_ref=f"{factor_ref}:candidate",
+        value={
+            "predicate_ref": predicate_ref,
+            "role_bindings": dict(role_bindings),
+            "qualifier_state": dict(qualifier_state),
+        },
+        type_ref=f"{factor_type}.candidate",
+        derivation_refs=(OPERATOR_COMPOSITION_CONTRACT, *tuple(provenance_refs)),
+    )
+    return Factor(
+        factor_ref=factor_ref,
+        factor_type=factor_type,
+        alternatives=(alternative,),
+        residuals=tuple(sorted(set(str(value) for value in residuals))),
+        closure_state="requires_external_resolution" if residuals else "locally_closed",
+        metadata={
+            "factor_revision_ref": revision_ref,
+            "structural_signature_ref": signature_ref,
+            "predicate_ref": predicate_ref,
+            "role_bindings": dict(role_bindings),
+            "qualifier_state": dict(qualifier_state),
+            "wrapper_state": {
+                "assertion_state": "source_observed",
+                "authority_class": "unresolved",
+            },
+            "provenance_refs": tuple(provenance_refs),
+            "composition_contract_ref": OPERATOR_COMPOSITION_CONTRACT,
+        },
+    )
+
+
+def compose_operator_factors(
+    *, document_ref: str, parsed_document: Mapping[str, Any]
+) -> tuple[Factor[Any], ...]:
+    """Compose candidate modal, scope, exception, and transition factors.
+
+    Every input comes from the public parser observation stream.  The output is
+    candidate PNF only; ambiguous modal senses and all legal applicability
+    coordinates remain open.
+    """
+
+    all_tokens = _tokens(parsed_document)
+    by_sentence: dict[int, list[Mapping[str, Any]]] = {}
+    for token in all_tokens:
+        by_sentence.setdefault(int(token["sentence_index"]), []).append(token)
+
+    factors: list[Factor[Any]] = []
+    for sentence_index, sentence_tokens in sorted(by_sentence.items()):
+        token_by_index = {int(row["index"]): row for row in sentence_tokens}
+
+        # Modal composition: auxiliary -> scoped predicate with polarity.
+        for modal in sentence_tokens:
+            modal_kind = _MODAL_LEMMAS.get(_lemma(modal))
+            if modal_kind is None or str(modal.get("dep") or "") not in {"aux", "auxpass"}:
+                continue
+            head = token_by_index.get(int(modal.get("head_index", -1)))
+            if head is None:
+                continue
+            subject, object_row = _subject_and_object(head, sentence_tokens)
+            negation = next(
+                (
+                    row
+                    for row in sentence_tokens
+                    if _lemma(row) in {"not", "never"}
+                    and int(row.get("head_index", -1))
+                    in {int(head["index"]), int(modal["index"])}
+                ),
+                None,
+            )
+            modality, predicate_ref = modal_kind
+            polarity = "negative" if negation is not None else "positive"
+            if modality == "obligation" and polarity == "negative":
+                predicate_ref = "normative.prohibition"
+            role_bindings = {"conduct": _token_ref(document_ref, head)}
+            if subject is not None:
+                role_bindings["bearer"] = _token_ref(document_ref, subject)
+            if object_row is not None:
+                role_bindings["object"] = _token_ref(document_ref, object_row)
+            provenance = [_token_ref(document_ref, modal), _token_ref(document_ref, head)]
+            if negation is not None:
+                provenance.append(_token_ref(document_ref, negation))
+            residuals = [
+                "jurisdiction_unresolved",
+                "legal_time_unresolved",
+                "normative_scope_unresolved",
+            ]
+            if modality == "permission_candidate":
+                residuals.append("modal_sense_unresolved")
+            if subject is None:
+                residuals.append("norm_bearer_unresolved")
+            factors.append(
+                _new_factor(
+                    document_ref=document_ref,
+                    sentence_index=sentence_index,
+                    factor_type="semantic.normative_relation",
+                    predicate_ref=predicate_ref,
+                    signature_ref="signature:normative-operation:v1",
+                    role_bindings=role_bindings,
+                    qualifier_state={"modality": modality, "polarity": polarity},
+                    provenance_refs=provenance,
+                    residuals=residuals,
+                    identity_payload={
+                        "modal": int(modal["index"]),
+                        "head": int(head["index"]),
+                        "polarity": polarity,
+                    },
+                )
+            )
+
+        # Conditions and exceptions are scoped clause relations, not conclusions.
+        for marker in sentence_tokens:
+            marker_lemma = _lemma(marker)
+            if marker_lemma not in _CONDITION_MARKERS | _EXCEPTION_MARKERS:
+                continue
+            if str(marker.get("dep") or "") not in {"mark", "prep", "advmod"}:
+                continue
+            clause_head = token_by_index.get(int(marker.get("head_index", -1)))
+            if clause_head is None:
+                continue
+            host = token_by_index.get(int(clause_head.get("head_index", -1)))
+            factor_type = (
+                "semantic.legal_exception"
+                if marker_lemma in _EXCEPTION_MARKERS
+                else "semantic.legal_condition"
+            )
+            predicate_ref = (
+                "legal.exception_candidate"
+                if factor_type == "semantic.legal_exception"
+                else "legal.activation_condition_candidate"
+            )
+            role_name = "exception" if factor_type == "semantic.legal_exception" else "condition"
+            role_bindings = {role_name: _token_ref(document_ref, clause_head)}
+            if host is not None:
+                role_bindings["host"] = _token_ref(document_ref, host)
+            factors.append(
+                _new_factor(
+                    document_ref=document_ref,
+                    sentence_index=sentence_index,
+                    factor_type=factor_type,
+                    predicate_ref=predicate_ref,
+                    signature_ref=(
+                        "signature:legal-exception:v1"
+                        if factor_type == "semantic.legal_exception"
+                        else "signature:legal-condition:v1"
+                    ),
+                    role_bindings=role_bindings,
+                    qualifier_state={"marker": marker_lemma, "scope_state": "candidate"},
+                    provenance_refs=(
+                        _token_ref(document_ref, marker),
+                        _token_ref(document_ref, clause_head),
+                    ),
+                    residuals=(
+                        "exception_attachment_unresolved",
+                        "exception_burden_unresolved",
+                    )
+                    if factor_type == "semantic.legal_exception"
+                    else ("condition_attachment_unresolved",),
+                    identity_payload={
+                        "marker": int(marker["index"]),
+                        "clause_head": int(clause_head["index"]),
+                    },
+                )
+            )
+
+        # Legal-object lifecycle transitions are state-transition candidates.
+        for predicate in sentence_tokens:
+            transition = _TRANSITION_LEMMAS.get(_lemma(predicate))
+            if transition is None or str(predicate.get("pos") or "") not in {"VERB", "AUX"}:
+                continue
+            prior_state, next_state, predicate_ref = transition
+            subject, object_row = _subject_and_object(predicate, sentence_tokens)
+            legal_object = subject or object_row
+            role_bindings = {"transition": _token_ref(document_ref, predicate)}
+            if legal_object is not None:
+                role_bindings["legal_object"] = _token_ref(document_ref, legal_object)
+            factors.append(
+                _new_factor(
+                    document_ref=document_ref,
+                    sentence_index=sentence_index,
+                    factor_type="semantic.legal_transition",
+                    predicate_ref=predicate_ref,
+                    signature_ref="signature:legal-transition:v1",
+                    role_bindings=role_bindings,
+                    qualifier_state={
+                        "prior_state": prior_state,
+                        "next_state": next_state,
+                        "effective_time_state": "unresolved",
+                    },
+                    provenance_refs=(_token_ref(document_ref, predicate),),
+                    residuals=(
+                        "legal_object_identity_unresolved",
+                        "effective_time_unresolved",
+                        "jurisdiction_unresolved",
+                    ),
+                    identity_payload={"predicate": int(predicate["index"]), "transition": transition},
+                )
+            )
+
+    return tuple(sorted({row.factor_ref: row for row in factors}.values(), key=lambda row: row.factor_ref))
+
+
+__all__ = ["OPERATOR_COMPOSITION_CONTRACT", "compose_operator_factors"]

--- a/src/pnf/erdfa_export.py
+++ b/src/pnf/erdfa_export.py
@@ -1,0 +1,34 @@
+"""Publication metadata overlays for eRDFa/Kant sinks.
+
+These rows describe where immutable SensibLaw bytes were published.  They are not
+Legal IR relations and cannot create or promote PNF factors.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.pnf.legal_semantic_export import (
+    LEGAL_SEMANTIC_EXPORT_CONTRACT,
+    LegalSemanticArtifactExport,
+)
+
+
+def erdfa_manifest_overlay(export: LegalSemanticArtifactExport) -> dict[str, Any]:
+    return {
+        "contractVersion": LEGAL_SEMANTIC_EXPORT_CONTRACT,
+        "artifactId": export.semantic_build_ref,
+        "artifactRevision": export.export_ref,
+        "containerObjectRef": {
+            "sink": "multi-locator",
+            "uri": export.sync_identity.producer_locator_set[0],
+            "contentDigest": export.sync_identity.content_digest,
+        },
+        "memberArtifactRefs": list(export.member_artifact_refs),
+        "sourceRevisionRefs": list(export.source_revision_refs),
+        "authority": "publication_metadata_only",
+        "semanticPromotionAllowed": False,
+    }
+
+
+__all__ = ["erdfa_manifest_overlay"]

--- a/src/pnf/legal_semantic_export.py
+++ b/src/pnf/legal_semantic_export.py
@@ -1,0 +1,130 @@
+"""Transport/provenance export for immutable Legal Semantic Builds."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from src.ontology.external_enrichment import canonical_sha256
+from src.pnf.sync_identity import CanonicalSyncIdentity
+
+
+LEGAL_SEMANTIC_EXPORT_CONTRACT = "sensiblaw/legal-semantic-build/v1"
+
+
+@dataclass(frozen=True)
+class LegalSemanticArtifactExport:
+    sync_identity: CanonicalSyncIdentity
+    semantic_build_ref: str
+    source_revision_refs: tuple[str, ...]
+    member_artifact_refs: tuple[str, ...]
+    payload_sha256: str
+    publication_metadata: Mapping[str, Any]
+
+    @property
+    def export_ref(self) -> str:
+        return "legal-semantic-export:" + canonical_sha256(
+            {
+                "identity": self.sync_identity.to_dict(),
+                "semantic_build_ref": self.semantic_build_ref,
+                "source_revision_refs": self.source_revision_refs,
+                "member_artifact_refs": self.member_artifact_refs,
+                "payload_sha256": self.payload_sha256,
+                "publication_metadata": dict(self.publication_metadata),
+            }
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract_version": LEGAL_SEMANTIC_EXPORT_CONTRACT,
+            "export_ref": self.export_ref,
+            "sync_identity": self.sync_identity.to_dict(),
+            "semantic_build_ref": self.semantic_build_ref,
+            "source_revision_refs": list(self.source_revision_refs),
+            "member_artifact_refs": list(self.member_artifact_refs),
+            "payload_sha256": self.payload_sha256,
+            "publication_metadata": dict(self.publication_metadata),
+            "import_effects": {
+                "artifact_available": True,
+                "review_started": False,
+                "pnf_promoted": False,
+                "legal_ir_promoted": False,
+                "identity_closed": False,
+                "trust_imported": False,
+                "legal_truth_closed": False,
+            },
+            "authority": "transport_and_provenance_only",
+        }
+
+
+def export_legal_semantic_build(
+    build: Mapping[str, Any],
+    *,
+    locators: Sequence[str],
+    member_artifact_refs: Sequence[str] = (),
+    source_revision_refs: Sequence[str] = (),
+    publication_metadata: Mapping[str, Any] | None = None,
+) -> LegalSemanticArtifactExport:
+    build_row = build.get("build") if isinstance(build.get("build"), Mapping) else build
+    semantic_build_ref = str(build_row.get("build_ref") or "")
+    if not semantic_build_ref:
+        raise ValueError("Legal Semantic Build requires build_ref")
+    locator_rows = tuple(sorted(set(str(value) for value in locators if value)))
+    if not locator_rows:
+        raise ValueError("at least one replay locator is required")
+    payload_sha256 = canonical_sha256(build)
+    identity = CanonicalSyncIdentity(
+        kind="artifact",
+        object_id=semantic_build_ref,
+        content_digest=f"sha256:{payload_sha256}",
+        producer_contract=LEGAL_SEMANTIC_EXPORT_CONTRACT,
+        producer_locator_set=locator_rows,
+    )
+    return LegalSemanticArtifactExport(
+        sync_identity=identity,
+        semantic_build_ref=semantic_build_ref,
+        source_revision_refs=tuple(sorted(set(str(value) for value in source_revision_refs if value))),
+        member_artifact_refs=tuple(sorted(set(str(value) for value in member_artifact_refs if value))),
+        payload_sha256=payload_sha256,
+        publication_metadata=dict(publication_metadata or {}),
+    )
+
+
+def verify_legal_semantic_import(
+    build: Mapping[str, Any], export_row: Mapping[str, Any]
+) -> dict[str, Any]:
+    expected_digest = canonical_sha256(build)
+    identity = export_row.get("sync_identity") or {}
+    build_row = build.get("build") if isinstance(build.get("build"), Mapping) else build
+    build_ref = str(build_row.get("build_ref") or "")
+    errors: list[str] = []
+    if str(export_row.get("contract_version") or "") != LEGAL_SEMANTIC_EXPORT_CONTRACT:
+        errors.append("unsupported_contract")
+    if str(export_row.get("semantic_build_ref") or "") != build_ref:
+        errors.append("object_id_mismatch")
+    if str(export_row.get("payload_sha256") or "") != expected_digest:
+        errors.append("payload_digest_mismatch")
+    if str(identity.get("content_digest") or "") != f"sha256:{expected_digest}":
+        errors.append("sync_digest_mismatch")
+    if str(identity.get("object_id") or "") != build_ref:
+        errors.append("sync_object_id_mismatch")
+    return {
+        "state": "verified_available" if not errors else "rejected",
+        "errors": errors,
+        "semantic_build_ref": build_ref,
+        "payload_sha256": expected_digest,
+        "promotion_performed": False,
+        "review_started": False,
+        "identity_closed": False,
+        "trust_imported": False,
+        "legal_truth_closed": False,
+        "authority": "verification_receipt_only",
+    }
+
+
+__all__ = [
+    "LEGAL_SEMANTIC_EXPORT_CONTRACT",
+    "LegalSemanticArtifactExport",
+    "export_legal_semantic_build",
+    "verify_legal_semantic_import",
+]

--- a/src/pnf/operator_composition_bridge.py
+++ b/src/pnf/operator_composition_bridge.py
@@ -1,0 +1,161 @@
+"""Apply generic operator composition to an existing document compilation.
+
+The bridge reconstructs the public parser token record from the stored annotation
+layer.  It never reparses text.  This makes the probe exercise the same parser
+observations while the composition phase is being validated for direct inclusion
+in the compiler pipeline.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+from src.language.operator_composition import compose_operator_factors
+from src.policy.carriers.canonical import canonical_sha256
+
+
+OPERATOR_COMPOSITION_BRIDGE_CONTRACT = "pnf-operator-composition-bridge:v0_1"
+
+
+def _parsed_document_from_layer(layer: Mapping[str, Any]) -> dict[str, Any]:
+    values: dict[int, dict[str, Any]] = {}
+    for row in layer.get("token_annotations") or ():
+        index = int(row.get("token_index", -1))
+        if index < 0:
+            continue
+        annotation_type = str(row.get("annotation_type") or "")
+        if not annotation_type.startswith("parser."):
+            continue
+        values.setdefault(index, {})[annotation_type.removeprefix("parser.")] = row.get("value")
+
+    spans_by_ref: dict[str, Mapping[str, Any]] = {}
+    token_ref_by_index: dict[int, str] = {}
+    for row in layer.get("span_annotations") or ():
+        if str(row.get("annotation_type") or "") != "parser_token":
+            continue
+        index = int(row.get("start_token", -1))
+        if index < 0:
+            continue
+        span_ref = str(row.get("span_ref") or "")
+        spans_by_ref[span_ref] = row
+        token_ref_by_index[index] = span_ref
+        payload = row.get("value") or {}
+        values.setdefault(index, {}).update(
+            {
+                "start": int(payload.get("start_char", 0)),
+                "end": int(payload.get("end_char", 0)),
+            }
+        )
+
+    head_by_index: dict[int, int] = {}
+    dependency_by_index: dict[int, str] = {}
+    index_by_ref = {ref: index for index, ref in token_ref_by_index.items()}
+    for row in layer.get("relation_annotations") or ():
+        if str(row.get("relation_type") or "") != "parser.dependency_head":
+            continue
+        left_ref = str(row.get("left_ref") or "")
+        token_index = index_by_ref.get(left_ref)
+        if token_index is None:
+            continue
+        payload = row.get("payload") or {}
+        head_by_index[token_index] = int(payload.get("head_index", token_index))
+        dependency_by_index[token_index] = str(payload.get("dependency") or "")
+
+    by_sentence: dict[int, list[dict[str, Any]]] = {}
+    for index, payload in sorted(values.items()):
+        sentence_index = int(payload.get("sentence", 0) or 0)
+        token = {
+            "index": index,
+            "text": str(payload.get("surface") or ""),
+            "lemma": str(payload.get("lemma") or payload.get("surface") or ""),
+            "pos": str(payload.get("pos") or ""),
+            "tag": str(payload.get("tag") or ""),
+            "morph": payload.get("morphology") or {},
+            "dep": dependency_by_index.get(index, str(payload.get("dependency") or "")),
+            "head_index": head_by_index.get(index, index),
+            "start": int(payload.get("start", 0)),
+            "end": int(payload.get("end", 0)),
+        }
+        by_sentence.setdefault(sentence_index, []).append(token)
+
+    return {
+        "sents": [
+            {"tokens": sorted(rows, key=lambda row: int(row["index"]))}
+            for _sentence_index, rows in sorted(by_sentence.items())
+        ],
+        "parser_receipt": {"source": "stored_annotation_layer", "reparsed": False},
+    }
+
+
+def _projection_ready_factor(row: Mapping[str, Any]) -> dict[str, Any]:
+    value = deepcopy(dict(row))
+    metadata = dict(value.get("metadata") or {})
+    factor_type = str(value.get("factor_type") or "")
+    value.update(
+        {
+            "factor_type_ref": factor_type,
+            "factor_revision_ref": str(metadata.get("factor_revision_ref") or ""),
+            "structural_signature_ref": str(metadata.get("structural_signature_ref") or ""),
+            "predicate_ref": str(metadata.get("predicate_ref") or factor_type),
+            "role_bindings": dict(metadata.get("role_bindings") or {}),
+            "qualifier_state": dict(metadata.get("qualifier_state") or {}),
+            "wrapper_state": dict(metadata.get("wrapper_state") or {}),
+            "provenance_refs": list(metadata.get("provenance_refs") or ()),
+            "residual_refs": list(value.get("residuals") or ()),
+        }
+    )
+    return value
+
+
+def apply_operator_composition_to_compilation(
+    compilation: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return a compilation with operator factors added to both PNF graph views."""
+
+    result = deepcopy(dict(compilation))
+    artifacts = deepcopy(dict(result.get("artifacts") or {}))
+    layer = artifacts.get("semantic_annotation_layer") or {}
+    parsed_document = _parsed_document_from_layer(layer)
+    document_ref = str(result.get("document_ref") or "")
+    factors = compose_operator_factors(
+        document_ref=document_ref,
+        parsed_document=parsed_document,
+    )
+    factor_rows = tuple(_projection_ready_factor(row.to_dict()) for row in factors)
+
+    for graph_name in ("pnf_graph", "refined_pnf_graph"):
+        graph = deepcopy(dict(artifacts.get(graph_name) or {}))
+        existing = {
+            str(row.get("factor_ref") or ""): deepcopy(dict(row))
+            for row in graph.get("factors") or ()
+            if isinstance(row, Mapping)
+        }
+        for row in factor_rows:
+            existing[str(row["factor_ref"])] = deepcopy(dict(row))
+        graph["factors"] = [existing[key] for key in sorted(existing)]
+        graph["graph_ref"] = "pnf-graph:" + canonical_sha256(
+            {
+                "prior_graph_ref": graph.get("graph_ref"),
+                "contract": OPERATOR_COMPOSITION_BRIDGE_CONTRACT,
+                "factor_refs": sorted(existing),
+            }
+        )
+        artifacts[graph_name] = graph
+
+    artifacts["operator_composition"] = {
+        "contract_ref": OPERATOR_COMPOSITION_BRIDGE_CONTRACT,
+        "parser_observation_source": "semantic_annotation_layer",
+        "reparsed": False,
+        "factor_refs": [row.factor_ref for row in factors],
+        "factor_count": len(factors),
+        "authority": "candidate_pnf_only",
+    }
+    result["artifacts"] = artifacts
+    return result
+
+
+__all__ = [
+    "OPERATOR_COMPOSITION_BRIDGE_CONTRACT",
+    "apply_operator_composition_to_compilation",
+]

--- a/src/pnf/sync_identity.py
+++ b/src/pnf/sync_identity.py
@@ -1,0 +1,43 @@
+"""Canonical artifact identity shared with bounded ZOS reconciliation."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from src.ontology.external_enrichment import canonical_sha256
+
+
+ZOS_SYNC_IDENTITY_CONTRACT = "canonical_sync_identity_v1"
+
+
+@dataclass(frozen=True)
+class CanonicalSyncIdentity:
+    kind: str
+    object_id: str
+    content_digest: str
+    producer_contract: str
+    producer_locator_set: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.kind not in {"artifact", "receipt"}:
+            raise ValueError("sync identity kind must be artifact or receipt")
+        if not self.object_id or not self.content_digest.startswith("sha256:"):
+            raise ValueError("sync identity requires object id and sha256 digest")
+        if not self.producer_contract or not self.producer_locator_set:
+            raise ValueError("sync identity requires producer contract and locators")
+
+    @property
+    def identity_ref(self) -> str:
+        return "sync-identity:" + canonical_sha256(asdict(self))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "identity_ref": self.identity_ref,
+            "identity_contract": ZOS_SYNC_IDENTITY_CONTRACT,
+            "semantic_authority": False,
+        }
+
+
+__all__ = ["CanonicalSyncIdentity", "ZOS_SYNC_IDENTITY_CONTRACT"]

--- a/tests/pnf/test_erdfa_export.py
+++ b/tests/pnf/test_erdfa_export.py
@@ -1,0 +1,13 @@
+from src.pnf.erdfa_export import erdfa_manifest_overlay
+from src.pnf.legal_semantic_export import export_legal_semantic_build
+
+
+def test_erdfa_overlay_remains_publication_metadata() -> None:
+    build = {"build": {"build_ref": "legal-semantic-build:abc"}}
+    export = export_legal_semantic_build(build, locators=("ipfs://bafy-test",))
+    overlay = erdfa_manifest_overlay(export)
+
+    assert overlay["artifactId"] == "legal-semantic-build:abc"
+    assert overlay["containerObjectRef"]["contentDigest"].startswith("sha256:")
+    assert overlay["authority"] == "publication_metadata_only"
+    assert overlay["semanticPromotionAllowed"] is False

--- a/tests/pnf/test_operator_composition.py
+++ b/tests/pnf/test_operator_composition.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from src.language.operator_composition import compose_operator_factors
+from src.pnf.legal_adjunct import project_legal_ir
+
+
+def _parsed() -> dict:
+    return {
+        "sents": [
+            {
+                "tokens": [
+                    {"index": 0, "text": "person", "lemma": "person", "pos": "NOUN", "dep": "nsubj", "head_index": 3, "start": 0, "end": 6},
+                    {"index": 1, "text": "must", "lemma": "must", "pos": "AUX", "dep": "aux", "head_index": 3, "start": 7, "end": 11},
+                    {"index": 2, "text": "not", "lemma": "not", "pos": "PART", "dep": "neg", "head_index": 3, "start": 12, "end": 15},
+                    {"index": 3, "text": "drive", "lemma": "drive", "pos": "VERB", "dep": "ROOT", "head_index": 3, "start": 16, "end": 21},
+                    {"index": 4, "text": "vehicle", "lemma": "vehicle", "pos": "NOUN", "dep": "obj", "head_index": 3, "start": 22, "end": 29},
+                    {"index": 5, "text": "unless", "lemma": "unless", "pos": "SCONJ", "dep": "mark", "head_index": 6, "start": 30, "end": 36},
+                    {"index": 6, "text": "licensed", "lemma": "license", "pos": "VERB", "dep": "advcl", "head_index": 3, "start": 37, "end": 45},
+                ]
+            },
+            {
+                "tokens": [
+                    {"index": 7, "text": "section", "lemma": "section", "pos": "NOUN", "dep": "nsubjpass", "head_index": 9, "start": 47, "end": 54},
+                    {"index": 8, "text": "is", "lemma": "be", "pos": "AUX", "dep": "auxpass", "head_index": 9, "start": 55, "end": 57},
+                    {"index": 9, "text": "repealed", "lemma": "repeal", "pos": "VERB", "dep": "ROOT", "head_index": 9, "start": 58, "end": 66},
+                ]
+            },
+        ]
+    }
+
+
+def _projection_row(factor) -> dict:
+    row = factor.to_dict()
+    metadata = row["metadata"]
+    return {
+        **row,
+        "factor_type_ref": row["factor_type"],
+        "factor_revision_ref": metadata["factor_revision_ref"],
+        "structural_signature_ref": metadata["structural_signature_ref"],
+        "predicate_ref": metadata["predicate_ref"],
+        "role_bindings": metadata["role_bindings"],
+        "qualifier_state": metadata["qualifier_state"],
+        "wrapper_state": metadata["wrapper_state"],
+        "provenance_refs": metadata["provenance_refs"],
+        "residual_refs": row["residuals"],
+    }
+
+
+def test_generic_parser_observations_compose_legal_relevant_pnf() -> None:
+    factors = compose_operator_factors(document_ref="document:test", parsed_document=_parsed())
+    factor_types = {row.factor_type for row in factors}
+
+    assert "semantic.normative_relation" in factor_types
+    assert "semantic.legal_exception" in factor_types
+    assert "semantic.legal_transition" in factor_types
+
+    normative = next(row for row in factors if row.factor_type == "semantic.normative_relation")
+    assert normative.metadata["predicate_ref"] == "normative.prohibition"
+    assert normative.metadata["qualifier_state"]["polarity"] == "negative"
+    assert set(normative.metadata["role_bindings"]) >= {"bearer", "conduct", "object"}
+    assert "legal_time_unresolved" in normative.residuals
+
+    observations = project_legal_ir(_projection_row(row) for row in factors)
+    assert len(observations) == len(factors)
+    assert {row.predicate_ref for row in observations} >= {
+        "normative.prohibition",
+        "legal.exception_candidate",
+        "legal.repeal",
+    }
+    assert all(row.projection_state == "candidate" for row in observations)

--- a/tests/pnf/test_sync_identity.py
+++ b/tests/pnf/test_sync_identity.py
@@ -1,0 +1,21 @@
+from src.pnf.legal_semantic_export import export_legal_semantic_build, verify_legal_semantic_import
+
+
+def test_sync_identity_verifies_without_promoting_semantics() -> None:
+    build = {
+        "build": {"build_ref": "legal-semantic-build:abc"},
+        "legal_ir_projection": {"projection_ref": "legal-ir-projection:1"},
+    }
+    export = export_legal_semantic_build(build, locators=("ipfs://bafy-test",))
+    row = export.to_dict()
+
+    assert row["sync_identity"]["kind"] == "artifact"
+    assert row["sync_identity"]["object_id"] == "legal-semantic-build:abc"
+    assert row["sync_identity"]["semantic_authority"] is False
+    assert row["import_effects"]["pnf_promoted"] is False
+    assert row["import_effects"]["legal_truth_closed"] is False
+
+    receipt = verify_legal_semantic_import(build, row)
+    assert receipt["state"] == "verified_available"
+    assert receipt["promotion_performed"] is False
+    assert receipt["trust_imported"] is False


### PR DESCRIPTION
## Summary

Follow-on to merged PR #443. This turns the legal-PNF probe's four measured gaps into generic parser-observation→PNF composition and adds the first SensibLaw→eRDFa/ZOS immutable artifact boundary.

## Generic PNF composition

Adds `src/language/operator_composition.py`.

The composer consumes only the public parser observation stream and emits candidate PNF factors for:

- modal scope and polarity (`semantic.normative_relation`);
- conditions (`semantic.legal_condition`);
- exceptions (`semantic.legal_exception`);
- commencement/repeal/amendment/cessation candidates (`semantic.legal_transition`).

There is no legal parser or source-family switch. `must + not + scoped predicate` composes to a prohibition candidate; `may` remains a permission candidate with `modal_sense_unresolved`. Jurisdiction, legal time, scope, exception attachment, burden, applicability, violation, and liability remain open.

## Probe integration

Adds `src/pnf/operator_composition_bridge.py` and updates `run_legal_pnf_probe.py`.

The bridge reconstructs token/head observations from the already stored `semantic_annotation_layer`; it does not reparse canonical text. Candidate factors are appended to both raw and refined PNF graph views before Legal IR and the Legal Semantic Build are generated.

This is the empirical validation bridge for later direct inclusion in `compile_document`.

## Federation transport

Adds:

- `src/pnf/sync_identity.py`;
- `src/pnf/legal_semantic_export.py`;
- `src/pnf/erdfa_export.py`.

A Legal Semantic Build exports as the ZOS canonical identity tuple:

```text
(kind, object_id, content_digest, producer_contract, producer_locator_set)
```

The export carries canonical SHA-256 identity and replay locators. eRDFa/Kant rows are publication metadata only. Verified import establishes artifact availability only and explicitly leaves PNF, Legal IR, identity, trust, review, promotion, and legal truth open.

## Tests

Adds focused tests for:

- prohibition composition from modal + negation;
- exception and repeal factors;
- Legal IR projection of composed factors;
- ZOS-compatible artifact identity;
- digest verification without semantic promotion;
- eRDFa publication metadata authority boundaries.

## Next gate

Run the existing legal fixture probe and compare against the measured baseline:

```text
236 PNF factors
0 Legal IR observations
4 gaps: modality, condition, exception, temporal validity
```

The acceptance target is non-zero Legal IR with those four coverage demands reduced, while retaining zero legal-conclusion promotion and zero identity closure.