### PR TITLE
Persist AU driving Legal IR catalogue builds

### DIFF
--- a/.github/workflows/build-legal-ir-catalogue.yml
+++ b/.github/workflows/build-legal-ir-catalogue.yml
@@ -1,0 +1,173 @@
+name: Build Legal IR catalogue
+
+on:
+  workflow_dispatch:
+    inputs:
+      offline:
+        description: Rebuild from checked-in source catalogue without network fetches
+        required: false
+        default: false
+        type: boolean
+      force_refetch:
+        description: Replace persisted AustLII source bytes even when paths already exist
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: legal-ir-catalogue-au-driving
+  cancel-in-progress: false
+
+jobs:
+  build-catalogue:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sensiblaw_legal_catalogue
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d sensiblaw_legal_catalogue"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/sensiblaw_legal_catalogue
+      PGHOST: localhost
+      PGPORT: "5432"
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: sensiblaw_legal_catalogue
+      CATALOGUE_BRANCH: catalogue/au-driving-v1
+      CATALOGUE_ROOT: .catalogue-state/au-driving-v1
+    steps:
+      - name: Checkout compiler branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout persisted catalogue state
+        shell: bash
+        run: |
+          git fetch origin "$CATALOGUE_BRANCH" || true
+          rm -rf "$CATALOGUE_ROOT"
+          mkdir -p "$CATALOGUE_ROOT"
+          if git show-ref --verify --quiet "refs/remotes/origin/$CATALOGUE_BRANCH"; then
+            git worktree add --detach "$CATALOGUE_ROOT" "origin/$CATALOGUE_BRANCH"
+          else
+            git worktree add --detach "$CATALOGUE_ROOT" HEAD
+          fi
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install environment
+        run: |
+          python -m pip install --upgrade pip uv
+          uv sync --frozen --extra test --extra dev
+
+      - name: Restore persisted PostgreSQL catalogue
+        shell: bash
+        run: |
+          if [ -f "$CATALOGUE_ROOT/catalogue/au-driving-v1/postgres.dump" ]; then
+            pg_restore --clean --if-exists --no-owner --dbname "$DATABASE_URL" \
+              "$CATALOGUE_ROOT/catalogue/au-driving-v1/postgres.dump"
+          fi
+          bash scripts/apply_pg_migrations.sh
+
+      - name: Restore persisted source and Legal IR catalogue
+        shell: bash
+        run: |
+          mkdir -p build/legal-ir-catalogue
+          if [ -d "$CATALOGUE_ROOT/catalogue/au-driving-v1/state" ]; then
+            cp -a "$CATALOGUE_ROOT/catalogue/au-driving-v1/state/." build/legal-ir-catalogue/
+          fi
+
+      - name: Build incremental AU legal catalogue
+        shell: bash
+        run: |
+          args=(
+            --catalogue config/legal_catalogues/au_driving_austlii_v1.json
+            --output-root build/legal-ir-catalogue
+            --database-url "$DATABASE_URL"
+          )
+          if [ "${{ inputs.offline }}" = "true" ]; then args+=(--offline); fi
+          if [ "${{ inputs.force_refetch }}" = "true" ]; then args+=(--force-refetch); fi
+          uv run python scripts/build_legal_ir_catalogue.py "${args[@]}"
+
+      - name: Focused validation
+        shell: bash
+        run: |
+          uv run ruff check \
+            src/runtime/request_governor.py \
+            scripts/build_legal_ir_catalogue.py
+          test -s build/legal-ir-catalogue/catalogue_build_manifest.json
+          test -d build/legal-ir-catalogue/legal_pnf_probe
+
+      - name: Produce persistent PostgreSQL snapshot
+        shell: bash
+        run: |
+          mkdir -p build/catalogue-publish/state
+          pg_dump --format=custom --no-owner --file build/catalogue-publish/postgres.dump "$DATABASE_URL"
+          cp -a build/legal-ir-catalogue/. build/catalogue-publish/state/
+          sha256sum build/catalogue-publish/postgres.dump > build/catalogue-publish/SHA256SUMS
+          find build/catalogue-publish/state -type f -print0 | sort -z | xargs -0 sha256sum >> build/catalogue-publish/SHA256SUMS
+
+      - name: Write Actions summary
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          manifest = json.loads(Path('build/legal-ir-catalogue/catalogue_build_manifest.json').read_text())
+          summary = Path(__import__('os').environ['GITHUB_STEP_SUMMARY'])
+          summary.write_text(
+              '# AU driving Legal IR catalogue\n\n'
+              f"- Catalogue: `{manifest['catalogue_ref']}`\n"
+              f"- Existing tranche files retained: {manifest['existing_tranche_file_count']}\n"
+              f"- AustLII documents fetched: {manifest['fetched_document_count']}\n"
+              f"- PostgreSQL corpus: `{manifest['corpus_ref']}`\n"
+              f"- PNF documents: {len(manifest['document_refs'])}\n"
+              f"- Compilation failures: {len(manifest['failure_refs'])}\n"
+              '- Identity promoted: false\n'
+              '- Legal truth closed: false\n'
+          )
+          PY
+
+      - name: Publish stable catalogue branch
+        shell: bash
+        run: |
+          rm -rf "$CATALOGUE_ROOT/catalogue/au-driving-v1"
+          mkdir -p "$CATALOGUE_ROOT/catalogue/au-driving-v1"
+          cp -a build/catalogue-publish/. "$CATALOGUE_ROOT/catalogue/au-driving-v1/"
+          cd "$CATALOGUE_ROOT"
+          git switch -C "$CATALOGUE_BRANCH"
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add catalogue/au-driving-v1
+          if git diff --cached --quiet; then
+            echo "Catalogue unchanged"
+          else
+            git commit -m "Refresh AU driving Legal IR catalogue"
+            git push origin "$CATALOGUE_BRANCH"
+          fi
+
+      - name: Upload build evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: au-driving-legal-ir-catalogue-build
+          path: |
+            build/legal-ir-catalogue/catalogue_build_manifest.json
+            build/legal-ir-catalogue/legal_pnf_probe/**
+            build/catalogue-publish/SHA256SUMS
+          if-no-files-found: warn
+          retention-days: 30

--- a/config/legal_catalogues/au_driving_austlii_v1.json
+++ b/config/legal_catalogues/au_driving_austlii_v1.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "sl.legal_catalogue.v0_1",
+  "catalogue_ref": "legal-catalogue:au-driving:austlii:v1",
+  "provider": {
+    "endpoint_ref": "au:austlii",
+    "base_url": "https://www.austlii.edu.au/",
+    "search_url_template": "https://www.austlii.edu.au/cgi-bin/sinosrch.cgi?query={query}&method=auto&meta=%2Fau",
+    "source_role": "research_index",
+    "authority_level": "supporting"
+  },
+  "request_policy": {
+    "allowed_hosts": ["www.austlii.edu.au", "austlii.edu.au"],
+    "minimum_interval_seconds": 1.5,
+    "maximum_attempts": 3,
+    "backoff_seconds": 2.0,
+    "request_budget": 80,
+    "max_documents": 40,
+    "max_depth": 1
+  },
+  "persisted_source_families": [
+    {
+      "family_ref": "source-family:au-legal-principles:v1",
+      "path": "demo/ingest/legal_principles_au_v1"
+    },
+    {
+      "family_ref": "source-family:hca-s942025:v1",
+      "path": "demo/ingest/hca_case_s942025"
+    }
+  ],
+  "search_terms": [
+    {"jurisdiction": "AU.QLD", "query": "Transport Operations Road Use Management Act Queensland"},
+    {"jurisdiction": "AU.QLD", "query": "Transport Operations Road Use Management Road Rules Regulation Queensland"},
+    {"jurisdiction": "AU.QLD", "query": "Transport Operations Road Use Management Driver Licensing Regulation Queensland"},
+    {"jurisdiction": "AU.QLD", "query": "Transport Operations Road Use Management Vehicle Registration Regulation Queensland"},
+    {"jurisdiction": "AU.QLD", "query": "Queensland drink driving drug driving legislation"},
+    {"jurisdiction": "AU.QLD", "query": "Queensland dangerous operation vehicle Criminal Code"},
+    {"jurisdiction": "AU", "query": "Road Vehicle Standards Act 2018"},
+    {"jurisdiction": "AU", "query": "Road Vehicle Standards Rules 2019"},
+    {"jurisdiction": "AU", "query": "Interstate Road Transport Act 1985"},
+    {"jurisdiction": "AU", "query": "Australian Design Rules motor vehicle standards legislation"}
+  ],
+  "authority": "catalogue_acquisition_coordinates_only"
+}

--- a/scripts/build_legal_ir_catalogue.py
+++ b/scripts/build_legal_ir_catalogue.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Build or refresh a checked-in legal catalogue and its persistent PNF database."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from urllib.parse import quote_plus
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.ingestion.corpus_source_projection import project_source_families  # noqa: E402
+from src.policy.corpus_compilation import default_compiler_context  # noqa: E402
+from src.policy.postgres_corpus_compilation import compile_directory_postgres  # noqa: E402
+from src.runtime.request_governor import RequestGovernor, RequestGovernorPolicy  # noqa: E402
+from src.sources.legal_follow import follow_legal_sources  # noqa: E402
+from src.storage.postgres import PostgresCompilerStore  # noqa: E402
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalogue", type=Path, required=True)
+    parser.add_argument("--output-root", type=Path, required=True)
+    parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
+    parser.add_argument("--offline", action="store_true")
+    parser.add_argument("--force-refetch", action="store_true")
+    args = parser.parse_args()
+    if not args.database_url:
+        parser.error("--database-url or DATABASE_URL is required")
+    return args
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def _safe_name(index: int, url: str, suffix: str) -> str:
+    digest = hashlib.sha256(url.encode()).hexdigest()[:16]
+    return f"{index:04d}_{digest}{suffix}"
+
+
+def _copy_source_family(source: Path, target: Path) -> int:
+    if not source.exists():
+        return 0
+    count = 0
+    for path in sorted(source.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(source)
+        destination = target / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, destination)
+        count += 1
+    return count
+
+
+def main() -> int:
+    args = _args()
+    catalogue = json.loads(args.catalogue.read_text(encoding="utf-8"))
+    output_root = args.output_root.resolve()
+    source_root = output_root / "source_catalogue"
+    existing_root = source_root / "existing_au_tranche"
+    driving_root = source_root / "austlii_driving"
+    raw_root = driving_root / "raw"
+    canonical_root = driving_root / "canonical"
+    raw_root.mkdir(parents=True, exist_ok=True)
+    canonical_root.mkdir(parents=True, exist_ok=True)
+
+    copied = 0
+    for family in catalogue.get("persisted_source_families", []):
+        copied += _copy_source_family(ROOT / family["path"], existing_root / family["family_ref"].replace(":", "_"))
+
+    policy_data = catalogue["request_policy"]
+    governor = RequestGovernor(
+        RequestGovernorPolicy(
+            minimum_interval_seconds=float(policy_data["minimum_interval_seconds"]),
+            maximum_attempts=int(policy_data["maximum_attempts"]),
+            backoff_seconds=float(policy_data["backoff_seconds"]),
+            request_budget=int(policy_data["request_budget"]),
+        )
+    )
+    provider = catalogue["provider"]
+    fetched_documents: list[dict[str, object]] = []
+    if not args.offline:
+        for term_index, term in enumerate(catalogue.get("search_terms", []), start=1):
+            search_url = provider["search_url_template"].format(query=quote_plus(term["query"]))
+            result = governor.call(
+                search_url,
+                lambda url=search_url: follow_legal_sources(
+                    "AU",
+                    seed_urls=(url,),
+                    max_depth=int(policy_data["max_depth"]),
+                    max_documents=max(1, int(policy_data["max_documents"]) // max(1, len(catalogue["search_terms"]))),
+                ),
+            )
+            for followed in result.documents:
+                document = followed.document
+                final_url = document.final_url or document.requested_url
+                suffix = ".html" if document.media_type in {"text/html", "application/xhtml+xml"} else ".txt"
+                name = _safe_name(len(fetched_documents) + 1, final_url, suffix)
+                raw_path = raw_root / name
+                canonical_path = canonical_root / (Path(name).stem + ".txt")
+                if args.force_refetch or not raw_path.exists():
+                    raw_path.write_bytes(document.raw_bytes)
+                    canonical_path.write_text(document.canonical_text, encoding="utf-8")
+                fetched_documents.append(
+                    {
+                        "jurisdiction": term["jurisdiction"],
+                        "search_term": term["query"],
+                        "search_url": search_url,
+                        "requested_url": document.requested_url,
+                        "final_url": document.final_url,
+                        "raw_path": str(raw_path.relative_to(output_root)),
+                        "canonical_path": str(canonical_path.relative_to(output_root)),
+                        "receipt": document.receipt.to_dict(),
+                    }
+                )
+
+    projection = project_source_families(
+        [existing_root, raw_root],
+        output_dir=output_root / "source_projection",
+        max_files=500,
+        max_file_bytes=10_000_000,
+    )
+    _write_json(output_root / "source_projection" / "manifest.json", projection.to_dict())
+
+    store = PostgresCompilerStore.connect(args.database_url)
+    try:
+        compilation = compile_directory_postgres(
+            output_root / "source_projection" / "canonical",
+            context=default_compiler_context(),
+            store=store,
+            execution_phase="legal_catalogue_build",
+        )
+    finally:
+        store.close()
+
+    probe_dir = output_root / "legal_pnf_probe"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "run_legal_pnf_probe.py"),
+            "--input-directory",
+            str(source_root),
+            "--output-dir",
+            str(probe_dir),
+            "--compare-legacy",
+            "--max-files",
+            "500",
+        ],
+        check=True,
+    )
+
+    manifest = {
+        "schema_version": "sl.persisted_legal_catalogue_build.v0_1",
+        "catalogue_ref": catalogue["catalogue_ref"],
+        "provider": provider,
+        "existing_tranche_file_count": copied,
+        "fetched_document_count": len(fetched_documents),
+        "fetched_documents": fetched_documents,
+        "request_governor": governor.summary(),
+        "corpus_ref": compilation.corpus_ref,
+        "document_refs": list(compilation.document_refs),
+        "demand_refs": list(compilation.demand_refs),
+        "failure_refs": list(compilation.failure_refs),
+        "legal_pnf_probe_root": str(probe_dir.relative_to(output_root)),
+        "identity_promoted": False,
+        "legal_truth_closed": False,
+        "authority": "candidate_catalogue_build_only",
+    }
+    _write_json(output_root / "catalogue_build_manifest.json", manifest)
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/runtime/request_governor.py
+++ b/src/runtime/request_governor.py
@@ -1,0 +1,160 @@
+"""Reusable host-aware request pacing for bounded acquisition workers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import random
+import time
+from typing import Any, Callable, Mapping, Protocol
+from urllib.parse import urlparse
+
+
+REQUEST_GOVERNOR_CONTRACT = "request-governor:v0_1"
+
+
+class Clock(Protocol):
+    def __call__(self) -> float: ...
+
+
+class Sleeper(Protocol):
+    def __call__(self, seconds: float) -> None: ...
+
+
+@dataclass(frozen=True)
+class RequestGovernorPolicy:
+    minimum_interval_seconds: float = 1.0
+    maximum_attempts: int = 3
+    backoff_seconds: float = 2.0
+    jitter_seconds: float = 0.25
+    request_budget: int = 64
+
+    def __post_init__(self) -> None:
+        if self.minimum_interval_seconds < 0:
+            raise ValueError("minimum_interval_seconds must be nonnegative")
+        if self.maximum_attempts < 1:
+            raise ValueError("maximum_attempts must be positive")
+        if self.backoff_seconds < 0 or self.jitter_seconds < 0:
+            raise ValueError("backoff and jitter must be nonnegative")
+        if self.request_budget < 1:
+            raise ValueError("request_budget must be positive")
+
+
+@dataclass(frozen=True)
+class RequestAttemptReceipt:
+    url: str
+    host: str
+    attempt: int
+    state: str
+    elapsed_seconds: float
+    error_type: str | None = None
+    error_detail: str | None = None
+    contract_ref: str = REQUEST_GOVERNOR_CONTRACT
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in asdict(self).items()
+            if value not in (None, "")
+        }
+
+
+class RequestGovernor:
+    """Pace requests per host, enforce a total budget, and retain attempt receipts."""
+
+    def __init__(
+        self,
+        policy: RequestGovernorPolicy | None = None,
+        *,
+        clock: Clock = time.monotonic,
+        sleeper: Sleeper = time.sleep,
+        random_value: Callable[[], float] = random.random,
+    ) -> None:
+        self.policy = policy or RequestGovernorPolicy()
+        self._clock = clock
+        self._sleep = sleeper
+        self._random = random_value
+        self._last_started_by_host: dict[str, float] = {}
+        self._request_count = 0
+        self._receipts: list[RequestAttemptReceipt] = []
+
+    @property
+    def receipts(self) -> tuple[RequestAttemptReceipt, ...]:
+        return tuple(self._receipts)
+
+    @property
+    def request_count(self) -> int:
+        return self._request_count
+
+    def _host(self, url: str) -> str:
+        return str(urlparse(url).hostname or "").casefold()
+
+    def _wait_for_host(self, host: str) -> None:
+        previous = self._last_started_by_host.get(host)
+        if previous is None:
+            return
+        remaining = self.policy.minimum_interval_seconds - (self._clock() - previous)
+        if remaining > 0:
+            self._sleep(remaining)
+
+    def call(self, url: str, operation: Callable[[], Any]) -> Any:
+        host = self._host(url)
+        last_error: Exception | None = None
+        for attempt in range(1, self.policy.maximum_attempts + 1):
+            if self._request_count >= self.policy.request_budget:
+                raise RuntimeError("request governor budget exhausted")
+            self._wait_for_host(host)
+            started = self._clock()
+            self._last_started_by_host[host] = started
+            self._request_count += 1
+            try:
+                result = operation()
+            except Exception as error:  # noqa: BLE001 - receipt must preserve worker failure
+                last_error = error
+                elapsed = self._clock() - started
+                self._receipts.append(
+                    RequestAttemptReceipt(
+                        url=url,
+                        host=host,
+                        attempt=attempt,
+                        state="failed",
+                        elapsed_seconds=elapsed,
+                        error_type=type(error).__name__,
+                        error_detail=str(error),
+                    )
+                )
+                if attempt == self.policy.maximum_attempts:
+                    raise
+                delay = self.policy.backoff_seconds * (2 ** (attempt - 1))
+                delay += self.policy.jitter_seconds * self._random()
+                self._sleep(delay)
+                continue
+            elapsed = self._clock() - started
+            self._receipts.append(
+                RequestAttemptReceipt(
+                    url=url,
+                    host=host,
+                    attempt=attempt,
+                    state="completed",
+                    elapsed_seconds=elapsed,
+                )
+            )
+            return result
+        assert last_error is not None
+        raise last_error
+
+    def summary(self) -> Mapping[str, Any]:
+        return {
+            "contract_ref": REQUEST_GOVERNOR_CONTRACT,
+            "request_count": self.request_count,
+            "request_budget": self.policy.request_budget,
+            "attempts": [row.to_dict() for row in self.receipts],
+            "authority": "request_execution_receipt_only",
+        }
+
+
+__all__ = [
+    "REQUEST_GOVERNOR_CONTRACT",
+    "RequestAttemptReceipt",
+    "RequestGovernor",
+    "RequestGovernorPolicy",
+]

--- a/tests/runtime/test_request_governor_and_legal_catalogue.py
+++ b/tests/runtime/test_request_governor_and_legal_catalogue.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.runtime.request_governor import RequestGovernor, RequestGovernorPolicy
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_request_governor_enforces_budget_and_records_attempts() -> None:
+    now = [0.0]
+    sleeps: list[float] = []
+
+    def clock() -> float:
+        return now[0]
+
+    def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        now[0] += seconds
+
+    governor = RequestGovernor(
+        RequestGovernorPolicy(
+            minimum_interval_seconds=2.0,
+            maximum_attempts=1,
+            backoff_seconds=0,
+            jitter_seconds=0,
+            request_budget=2,
+        ),
+        clock=clock,
+        sleeper=sleep,
+        random_value=lambda: 0.0,
+    )
+
+    assert governor.call("https://www.austlii.edu.au/a", lambda: "a") == "a"
+    assert governor.call("https://www.austlii.edu.au/b", lambda: "b") == "b"
+    assert sleeps == [2.0]
+    assert governor.request_count == 2
+    assert [row.state for row in governor.receipts] == ["completed", "completed"]
+
+    with pytest.raises(RuntimeError, match="budget exhausted"):
+        governor.call("https://www.austlii.edu.au/c", lambda: "c")
+
+
+def test_au_driving_catalogue_is_bounded_and_preserves_existing_tranche() -> None:
+    path = ROOT / "config/legal_catalogues/au_driving_austlii_v1.json"
+    catalogue = json.loads(path.read_text(encoding="utf-8"))
+
+    assert catalogue["provider"]["endpoint_ref"] == "au:austlii"
+    assert catalogue["provider"]["authority_level"] == "supporting"
+    assert set(catalogue["request_policy"]["allowed_hosts"]) == {
+        "www.austlii.edu.au",
+        "austlii.edu.au",
+    }
+    assert 0 < catalogue["request_policy"]["request_budget"] <= 100
+    assert {row["jurisdiction"] for row in catalogue["search_terms"]} == {
+        "AU",
+        "AU.QLD",
+    }
+    assert {
+        row["path"] for row in catalogue["persisted_source_families"]
+    } == {
+        "demo/ingest/legal_principles_au_v1",
+        "demo/ingest/hca_case_s942025",
+    }


### PR DESCRIPTION
## Summary

Adds a manually triggered, persistent Legal IR catalogue build for the existing Australian legal tranche plus Queensland and Commonwealth driving legislation discovered through the existing AustLII acquisition lane.

## Catalogue

Adds `config/legal_catalogues/au_driving_austlii_v1.json` with bounded, predeclared search terms for:

- Queensland road-use, road-rules, licensing, registration, drink/drug-driving and dangerous-operation legislation;
- Commonwealth road-vehicle standards, rules, interstate transport and Australian Design Rules material.

AustLII remains correctly declared as a supporting research index, not an official source.

The catalogue also retains the existing AU tranche source families:

- `demo/ingest/legal_principles_au_v1`;
- `demo/ingest/hca_case_s942025`.

## Reusable request governor

Adds `src/runtime/request_governor.py` with host-aware pacing, bounded attempts, exponential backoff, jitter, a total request budget and immutable attempt receipts. This is provider-neutral and reusable by AustLII, Wikimedia and later source adapters.

## Persistent build

Adds `scripts/build_legal_ir_catalogue.py` to:

1. restore the existing AU tranche;
2. execute bounded AustLII search seeds through the existing legal follow/fetch machinery;
3. retain raw and canonical source artifacts;
4. project the combined source catalogue;
5. compile the catalogue into PostgreSQL PNF state;
6. run the ordinary legal-PNF probe and Legal IR projection;
7. emit a catalogue build manifest with explicit non-promotion boundaries.

## GitHub Actions

Adds manual workflow `Build Legal IR catalogue`.

The workflow:

- never connects to a private home/Tailscale PostgreSQL server;
- restores a PostgreSQL dump and source/Legal IR state from `catalogue/au-driving-v1`;
- applies current immutable migrations;
- incrementally builds or refreshes the catalogue;
- produces a new PostgreSQL custom dump and checksummed source/PNF/Legal IR state;
- commits changed persistent state back to the dedicated catalogue branch;
- uploads the current build evidence and writes a visible Actions summary.

The workflow runs only through `workflow_dispatch`; ordinary CI does not refetch or rebuild the catalogue.

## Validation

Adds focused tests proving request-budget/pacing behaviour and the bounded AU/QLD catalogue contract.

## Authority boundaries

Catalogue acquisition, successful fetching, PostgreSQL persistence and Legal IR projection do not promote identity, applicability, violation, liability or legal truth.