### PR TITLE
Instrument and parallelize Legal IR catalogue builds

### DIFF
--- a/.github/workflows/build-legal-ir-catalogue.yml
+++ b/.github/workflows/build-legal-ir-catalogue.yml
@@ -13,6 +13,18 @@ on:
         required: false
         default: false
         type: boolean
+      compile_workers:
+        description: Document-level compiler workers
+        required: false
+        default: "3"
+        type: choice
+        options: ["1", "2", "3", "4"]
+      copy_workers:
+        description: Source-family copy workers
+        required: false
+        default: "4"
+        type: choice
+        options: ["1", "2", "4", "8"]
 
 permissions:
   contents: write
@@ -98,6 +110,9 @@ jobs:
             --catalogue config/legal_catalogues/au_driving_austlii_v1.json
             --output-root build/legal-ir-catalogue
             --database-url "$DATABASE_URL"
+            --compile-workers "${{ inputs.compile_workers }}"
+            --copy-workers "${{ inputs.copy_workers }}"
+            --progress-jsonl
           )
           if [ "${{ inputs.offline }}" = "true" ]; then args+=(--offline); fi
           if [ "${{ inputs.force_refetch }}" = "true" ]; then args+=(--force-refetch); fi
@@ -107,9 +122,17 @@ jobs:
         shell: bash
         run: |
           uv run ruff check \
+            src/runtime/progress.py \
             src/runtime/request_governor.py \
+            src/pnf/factor_proposals.py \
+            src/policy/parallel_postgres_corpus_compilation.py \
             scripts/build_legal_ir_catalogue.py
+          uv run pytest -q \
+            tests/runtime/test_progress_instrumentation.py \
+            tests/pnf/test_factor_proposals.py
           test -s build/legal-ir-catalogue/catalogue_build_manifest.json
+          test -s build/legal-ir-catalogue/phase_ledger.json
+          test -s build/legal-ir-catalogue/document_compilation_timings.json
           test -d build/legal-ir-catalogue/legal_pnf_probe
 
       - name: Produce persistent PostgreSQL snapshot
@@ -128,18 +151,34 @@ jobs:
           import json
           from pathlib import Path
           manifest = json.loads(Path('build/legal-ir-catalogue/catalogue_build_manifest.json').read_text())
-          summary = Path(__import__('os').environ['GITHUB_STEP_SUMMARY'])
-          summary.write_text(
-              '# AU driving Legal IR catalogue\n\n'
-              f"- Catalogue: `{manifest['catalogue_ref']}`\n"
-              f"- Existing tranche files retained: {manifest['existing_tranche_file_count']}\n"
-              f"- AustLII documents fetched: {manifest['fetched_document_count']}\n"
-              f"- PostgreSQL corpus: `{manifest['corpus_ref']}`\n"
-              f"- PNF documents: {len(manifest['document_refs'])}\n"
-              f"- Compilation failures: {len(manifest['failure_refs'])}\n"
-              '- Identity promoted: false\n'
-              '- Legal truth closed: false\n'
-          )
+          timings = json.loads(Path('build/legal-ir-catalogue/document_compilation_timings.json').read_text())
+          phase_rows = manifest.get('phase_summary', {})
+          documents = timings.get('documents', [])
+          slow = sorted(documents, key=lambda row: row.get('elapsed_ms', 0), reverse=True)[:10]
+          lines = [
+              '# AU driving Legal IR catalogue',
+              '',
+              f"- Catalogue: `{manifest['catalogue_ref']}`",
+              f"- Existing tranche files retained: {manifest['existing_tranche_file_count']}",
+              f"- AustLII documents fetched: {manifest['fetched_document_count']}",
+              f"- PostgreSQL corpus: `{manifest['corpus_ref']}`",
+              f"- PNF documents: {len(manifest['document_refs'])}",
+              f"- Compilation failures: {len(manifest['failure_refs'])}",
+              f"- Compile workers: {manifest['compile_workers']}",
+              '- Identity promoted: false',
+              '- Legal truth closed: false',
+              '',
+              '## Phase timing',
+              '',
+              '| Phase | Events | Elapsed ms | Failures |',
+              '|---|---:|---:|---:|',
+          ]
+          for phase, row in sorted(phase_rows.items()):
+              lines.append(f"| `{phase}` | {row['events']} | {row['elapsed_ms']} | {row['failed']} |")
+          lines.extend(['', '## Slowest document compilations', '', '| Document | State | Worker | Elapsed ms |', '|---|---|---|---:|'])
+          for row in slow:
+              lines.append(f"| `{row['document_ref']}` | {row['state']} | `{row['worker']}` | {row['elapsed_ms']} |")
+          Path(__import__('os').environ['GITHUB_STEP_SUMMARY']).write_text('\n'.join(lines) + '\n')
           PY
 
       - name: Publish stable catalogue branch
@@ -167,6 +206,8 @@ jobs:
           name: au-driving-legal-ir-catalogue-build
           path: |
             build/legal-ir-catalogue/catalogue_build_manifest.json
+            build/legal-ir-catalogue/phase_ledger.json
+            build/legal-ir-catalogue/document_compilation_timings.json
             build/legal-ir-catalogue/legal_pnf_probe/**
             build/catalogue-publish/SHA256SUMS
           if-no-files-found: warn

--- a/.github/workflows/legal-catalogue-regression.yml
+++ b/.github/workflows/legal-catalogue-regression.yml
@@ -1,0 +1,117 @@
+name: Legal IR catalogue regression
+
+on:
+  pull_request:
+    paths:
+      - "src/runtime/progress.py"
+      - "src/pnf/factor_proposals.py"
+      - "src/pnf/operator_composition_bridge.py"
+      - "src/policy/parallel_postgres_corpus_compilation.py"
+      - "scripts/build_legal_ir_catalogue.py"
+      - "database/postgres_migrations/**"
+      - "tests/runtime/test_progress_instrumentation.py"
+      - "tests/pnf/test_factor_proposals.py"
+      - ".github/workflows/legal-catalogue-regression.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deterministic-regression:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sensiblaw_regression
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d sensiblaw_regression"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/sensiblaw_regression
+      PGHOST: localhost
+      PGPORT: "5432"
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: sensiblaw_regression
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install environment
+        run: |
+          python -m pip install --upgrade pip uv
+          uv sync --frozen --extra test --extra dev
+
+      - name: Apply immutable migrations
+        run: bash scripts/apply_pg_migrations.sh
+
+      - name: Lint instrumentation and reduction surfaces
+        run: |
+          uv run ruff check \
+            src/runtime/progress.py \
+            src/pnf/factor_proposals.py \
+            src/pnf/operator_composition_bridge.py \
+            src/policy/parallel_postgres_corpus_compilation.py \
+            scripts/build_legal_ir_catalogue.py \
+            tests/runtime/test_progress_instrumentation.py \
+            tests/pnf/test_factor_proposals.py
+
+      - name: Run deterministic proposal and timing tests
+        run: |
+          uv run pytest -q \
+            tests/runtime/test_progress_instrumentation.py \
+            tests/pnf/test_factor_proposals.py \
+            tests/pnf/test_operator_composition.py
+
+      - name: Build offline catalogue with two document workers
+        run: |
+          uv run python scripts/build_legal_ir_catalogue.py \
+            --catalogue config/legal_catalogues/au_driving_austlii_v1.json \
+            --output-root build/legal-ir-regression \
+            --database-url "$DATABASE_URL" \
+            --offline \
+            --compile-workers 2 \
+            --copy-workers 2 \
+            --progress-jsonl
+
+      - name: Verify durable build evidence
+        run: |
+          test -s build/legal-ir-regression/catalogue_build_manifest.json
+          test -s build/legal-ir-regression/phase_ledger.json
+          test -s build/legal-ir-regression/document_compilation_timings.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          root = Path('build/legal-ir-regression')
+          manifest = json.loads((root / 'catalogue_build_manifest.json').read_text())
+          ledger = json.loads((root / 'phase_ledger.json').read_text())
+          assert manifest['parallelism_boundary'] == 'immutable_document_build'
+          assert manifest['request_governor_serialized'] is True
+          assert manifest['identity_promoted'] is False
+          assert manifest['legal_truth_closed'] is False
+          assert 'compile_pnf' in ledger['phase_summary']
+          PY
+
+      - name: Upload regression evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: legal-ir-catalogue-regression
+          path: |
+            build/legal-ir-regression/catalogue_build_manifest.json
+            build/legal-ir-regression/phase_ledger.json
+            build/legal-ir-regression/document_compilation_timings.json
+            build/legal-ir-regression/legal_pnf_probe/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/database/postgres_migrations/017_semantic_build_instrumentation.sql
+++ b/database/postgres_migrations/017_semantic_build_instrumentation.sql
@@ -1,0 +1,107 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS pnf_factor_proposal (
+    proposal_ref TEXT PRIMARY KEY,
+    proposal_digest TEXT NOT NULL UNIQUE,
+    document_ref TEXT NOT NULL,
+    source_revision_ref TEXT NOT NULL,
+    factor_type_ref TEXT NOT NULL,
+    structural_signature TEXT NOT NULL,
+    producer_contract TEXT NOT NULL,
+    declaration_revision TEXT NOT NULL,
+    source_span_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    input_observation_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    dependency_factor_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    role_bindings JSONB NOT NULL DEFAULT '{}'::jsonb,
+    qualifier_state JSONB NOT NULL DEFAULT '{}'::jsonb,
+    candidate_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    residuals JSONB NOT NULL DEFAULT '[]'::jsonb,
+    authority TEXT NOT NULL DEFAULT 'candidate_only',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (authority = 'candidate_only')
+);
+
+CREATE INDEX IF NOT EXISTS pnf_factor_proposal_document_idx
+    ON pnf_factor_proposal (document_ref, factor_type_ref, structural_signature);
+
+CREATE TABLE IF NOT EXISTS pnf_factor_proposal_dependency (
+    proposal_ref TEXT NOT NULL REFERENCES pnf_factor_proposal(proposal_ref) ON DELETE CASCADE,
+    dependency_ref TEXT NOT NULL,
+    dependency_kind TEXT NOT NULL,
+    PRIMARY KEY (proposal_ref, dependency_ref, dependency_kind),
+    CHECK (dependency_kind IN ('observation', 'factor', 'span', 'declaration'))
+);
+
+CREATE TABLE IF NOT EXISTS pnf_document_reduction (
+    graph_ref TEXT PRIMARY KEY,
+    document_ref TEXT NOT NULL,
+    proposal_count INTEGER NOT NULL CHECK (proposal_count >= 0),
+    deduplicated_count INTEGER NOT NULL CHECK (deduplicated_count >= 0),
+    factor_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    residual_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    identity_promoted BOOLEAN NOT NULL DEFAULT FALSE CHECK (identity_promoted = FALSE),
+    legal_truth_closed BOOLEAN NOT NULL DEFAULT FALSE CHECK (legal_truth_closed = FALSE),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS pnf_reduction_residual (
+    residual_ref TEXT PRIMARY KEY,
+    graph_ref TEXT NOT NULL REFERENCES pnf_document_reduction(graph_ref) ON DELETE CASCADE,
+    document_ref TEXT NOT NULL,
+    residual_type TEXT NOT NULL,
+    proposal_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    message TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pnf_cross_document_relation (
+    relation_ref TEXT PRIMARY KEY,
+    relation_type TEXT NOT NULL,
+    source_document_ref TEXT NOT NULL,
+    target_document_ref TEXT NOT NULL,
+    source_coordinate_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    target_coordinate_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    evidence_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    qualifier_state JSONB NOT NULL DEFAULT '{}'::jsonb,
+    residuals JSONB NOT NULL DEFAULT '[]'::jsonb,
+    identity_closed BOOLEAN NOT NULL DEFAULT FALSE CHECK (identity_closed = FALSE),
+    legal_conclusion_promoted BOOLEAN NOT NULL DEFAULT FALSE CHECK (legal_conclusion_promoted = FALSE),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (source_document_ref <> target_document_ref)
+);
+
+CREATE INDEX IF NOT EXISTS pnf_cross_document_relation_source_idx
+    ON pnf_cross_document_relation (source_document_ref, relation_type);
+CREATE INDEX IF NOT EXISTS pnf_cross_document_relation_target_idx
+    ON pnf_cross_document_relation (target_document_ref, relation_type);
+
+CREATE TABLE IF NOT EXISTS catalogue_document_current_build (
+    catalogue_ref TEXT NOT NULL,
+    document_ref TEXT NOT NULL,
+    build_ref TEXT NOT NULL,
+    promoted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    promotion_receipt_ref TEXT NOT NULL,
+    PRIMARY KEY (catalogue_ref, document_ref)
+);
+
+CREATE TABLE IF NOT EXISTS semantic_build_phase_event (
+    build_ref TEXT NOT NULL,
+    event_ordinal INTEGER NOT NULL CHECK (event_ordinal >= 0),
+    phase TEXT NOT NULL,
+    state TEXT NOT NULL,
+    subject_ref TEXT,
+    completed INTEGER NOT NULL DEFAULT 0 CHECK (completed >= 0),
+    total INTEGER CHECK (total IS NULL OR total >= 0),
+    started_at TIMESTAMPTZ,
+    observed_at TIMESTAMPTZ NOT NULL,
+    elapsed_ms BIGINT CHECK (elapsed_ms IS NULL OR elapsed_ms >= 0),
+    worker TEXT,
+    reused BOOLEAN,
+    details JSONB NOT NULL DEFAULT '{}'::jsonb,
+    PRIMARY KEY (build_ref, event_ordinal),
+    CHECK (state IN ('started', 'running', 'completed', 'failed'))
+);
+
+CREATE INDEX IF NOT EXISTS semantic_build_phase_event_phase_idx
+    ON semantic_build_phase_event (build_ref, phase, elapsed_ms DESC NULLS LAST);
+
+COMMIT;

--- a/database/postgres_migrations/017_semantic_build_instrumentation.sql
+++ b/database/postgres_migrations/017_semantic_build_instrumentation.sql
@@ -104,4 +104,51 @@ CREATE TABLE IF NOT EXISTS semantic_build_phase_event (
 CREATE INDEX IF NOT EXISTS semantic_build_phase_event_phase_idx
     ON semantic_build_phase_event (build_ref, phase, elapsed_ms DESC NULLS LAST);
 
+CREATE TABLE IF NOT EXISTS semantic_review_coordinate (
+    coordinate_ref TEXT PRIMARY KEY,
+    target_kind TEXT NOT NULL,
+    target_ref TEXT NOT NULL,
+    document_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    coordinate_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    review_dimension TEXT NOT NULL,
+    residuals JSONB NOT NULL DEFAULT '[]'::jsonb,
+    semantic_state_mutated BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (semantic_state_mutated = FALSE),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (target_kind IN (
+        'factor_proposal',
+        'reduced_factor',
+        'cross_document_relation',
+        'subgraph',
+        'semantic_build'
+    ))
+);
+
+CREATE TABLE IF NOT EXISTS semantic_review_assessment (
+    assessment_ref TEXT PRIMARY KEY,
+    coordinate_ref TEXT NOT NULL
+        REFERENCES semantic_review_coordinate(coordinate_ref) ON DELETE CASCADE,
+    reviewer_credential_ref TEXT NOT NULL,
+    institution_ref TEXT NOT NULL,
+    review_state TEXT NOT NULL,
+    rationale_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    residuals JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    truth_closed BOOLEAN NOT NULL DEFAULT FALSE CHECK (truth_closed = FALSE),
+    semantic_state_promoted BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (semantic_state_promoted = FALSE),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (review_state IN (
+        'supported',
+        'supported_with_residuals',
+        'unsupported',
+        'contested',
+        'unresolved',
+        'not_reviewed'
+    ))
+);
+
+CREATE INDEX IF NOT EXISTS semantic_review_assessment_coordinate_idx
+    ON semantic_review_assessment (coordinate_ref, institution_ref, review_state);
+
 COMMIT;

--- a/scripts/build_legal_ir_catalogue.py
+++ b/scripts/build_legal_ir_catalogue.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor
 import hashlib
 import json
 import os
@@ -20,10 +21,12 @@ if str(ROOT) not in sys.path:
 
 from src.ingestion.corpus_source_projection import project_source_families  # noqa: E402
 from src.policy.corpus_compilation import default_compiler_context  # noqa: E402
-from src.policy.postgres_corpus_compilation import compile_directory_postgres  # noqa: E402
+from src.policy.parallel_postgres_corpus_compilation import (  # noqa: E402
+    compile_directory_postgres_parallel,
+)
+from src.runtime.progress import PhaseRecorder  # noqa: E402
 from src.runtime.request_governor import RequestGovernor, RequestGovernorPolicy  # noqa: E402
 from src.sources.legal_follow import follow_legal_sources  # noqa: E402
-from src.storage.postgres import PostgresCompilerStore  # noqa: E402
 
 
 def _args() -> argparse.Namespace:
@@ -33,9 +36,26 @@ def _args() -> argparse.Namespace:
     parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
     parser.add_argument("--offline", action="store_true")
     parser.add_argument("--force-refetch", action="store_true")
+    parser.add_argument(
+        "--compile-workers",
+        type=int,
+        default=max(1, min(4, (os.cpu_count() or 2) // 2)),
+        help="Document-level PostgreSQL compiler workers (1-32)",
+    )
+    parser.add_argument(
+        "--copy-workers",
+        type=int,
+        default=4,
+        help="Bounded source-family copy workers",
+    )
+    parser.add_argument("--progress-jsonl", action="store_true")
     args = parser.parse_args()
     if not args.database_url:
         parser.error("--database-url or DATABASE_URL is required")
+    if not 1 <= args.compile_workers <= 32:
+        parser.error("--compile-workers must be between 1 and 32")
+    if not 1 <= args.copy_workers <= 16:
+        parser.error("--copy-workers must be between 1 and 16")
     return args
 
 
@@ -49,25 +69,30 @@ def _safe_name(index: int, url: str, suffix: str) -> str:
     return f"{index:04d}_{digest}{suffix}"
 
 
-def _copy_source_family(source: Path, target: Path) -> int:
+def _source_file_plan(source: Path, target: Path) -> tuple[tuple[Path, Path], ...]:
     if not source.exists():
-        return 0
-    count = 0
-    for path in sorted(source.rglob("*")):
-        if not path.is_file():
-            continue
-        relative = path.relative_to(source)
-        destination = target / relative
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(path, destination)
-        count += 1
-    return count
+        return ()
+    return tuple(
+        (path, target / path.relative_to(source))
+        for path in sorted(source.rglob("*"))
+        if path.is_file()
+    )
+
+
+def _copy_one(pair: tuple[Path, Path]) -> str:
+    source, destination = pair
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+    return str(destination)
 
 
 def main() -> int:
     args = _args()
     catalogue = json.loads(args.catalogue.read_text(encoding="utf-8"))
     output_root = args.output_root.resolve()
+    output_root.mkdir(parents=True, exist_ok=True)
+    recorder = PhaseRecorder(json_lines=args.progress_jsonl)
+
     source_root = output_root / "source_catalogue"
     existing_root = source_root / "existing_au_tranche"
     driving_root = source_root / "austlii_driving"
@@ -76,9 +101,23 @@ def main() -> int:
     raw_root.mkdir(parents=True, exist_ok=True)
     canonical_root.mkdir(parents=True, exist_ok=True)
 
-    copied = 0
+    copy_plan: list[tuple[Path, Path]] = []
     for family in catalogue.get("persisted_source_families", []):
-        copied += _copy_source_family(ROOT / family["path"], existing_root / family["family_ref"].replace(":", "_"))
+        copy_plan.extend(
+            _source_file_plan(
+                ROOT / family["path"],
+                existing_root / family["family_ref"].replace(":", "_"),
+            )
+        )
+    with recorder.phase(
+        "copy_persisted_sources",
+        total=len(copy_plan),
+        details={"workers": args.copy_workers},
+    ) as phase:
+        with ThreadPoolExecutor(max_workers=args.copy_workers, thread_name_prefix="source-copy") as executor:
+            for copied_path in executor.map(_copy_one, copy_plan):
+                phase.advance(subject_ref=copied_path)
+    copied = len(copy_plan)
 
     policy_data = catalogue["request_policy"]
     governor = RequestGovernor(
@@ -91,78 +130,118 @@ def main() -> int:
     )
     provider = catalogue["provider"]
     fetched_documents: list[dict[str, object]] = []
-    if not args.offline:
-        for term_index, term in enumerate(catalogue.get("search_terms", []), start=1):
-            search_url = provider["search_url_template"].format(query=quote_plus(term["query"]))
-            result = governor.call(
-                search_url,
-                lambda url=search_url: follow_legal_sources(
-                    "AU",
-                    seed_urls=(url,),
-                    max_depth=int(policy_data["max_depth"]),
-                    max_documents=max(1, int(policy_data["max_documents"]) // max(1, len(catalogue["search_terms"]))),
-                ),
-            )
-            for followed in result.documents:
-                document = followed.document
-                final_url = document.final_url or document.requested_url
-                suffix = ".html" if document.media_type in {"text/html", "application/xhtml+xml"} else ".txt"
-                name = _safe_name(len(fetched_documents) + 1, final_url, suffix)
-                raw_path = raw_root / name
-                canonical_path = canonical_root / (Path(name).stem + ".txt")
-                if args.force_refetch or not raw_path.exists():
-                    raw_path.write_bytes(document.raw_bytes)
-                    canonical_path.write_text(document.canonical_text, encoding="utf-8")
-                fetched_documents.append(
-                    {
-                        "jurisdiction": term["jurisdiction"],
-                        "search_term": term["query"],
-                        "search_url": search_url,
-                        "requested_url": document.requested_url,
-                        "final_url": document.final_url,
-                        "raw_path": str(raw_path.relative_to(output_root)),
-                        "canonical_path": str(canonical_path.relative_to(output_root)),
-                        "receipt": document.receipt.to_dict(),
-                    }
+    terms = tuple(catalogue.get("search_terms", []))
+    with recorder.phase(
+        "acquire_sources",
+        total=0 if args.offline else len(terms),
+        message="offline reuse" if args.offline else "bounded AustLII discovery",
+        details={"provider": provider["endpoint_ref"], "governed": True},
+    ) as phase:
+        if not args.offline:
+            for term in terms:
+                search_url = provider["search_url_template"].format(query=quote_plus(term["query"]))
+                result = governor.call(
+                    search_url,
+                    lambda url=search_url: follow_legal_sources(
+                        "AU",
+                        seed_urls=(url,),
+                        max_depth=int(policy_data["max_depth"]),
+                        max_documents=max(1, int(policy_data["max_documents"]) // max(1, len(terms))),
+                    ),
+                )
+                term_count = 0
+                for followed in result.documents:
+                    document = followed.document
+                    final_url = document.final_url or document.requested_url
+                    suffix = ".html" if document.media_type in {"text/html", "application/xhtml+xml"} else ".txt"
+                    name = _safe_name(len(fetched_documents) + 1, final_url, suffix)
+                    raw_path = raw_root / name
+                    canonical_path = canonical_root / (Path(name).stem + ".txt")
+                    reused = raw_path.exists() and not args.force_refetch
+                    if not reused:
+                        raw_path.write_bytes(document.raw_bytes)
+                        canonical_path.write_text(document.canonical_text, encoding="utf-8")
+                    fetched_documents.append(
+                        {
+                            "jurisdiction": term["jurisdiction"],
+                            "search_term": term["query"],
+                            "search_url": search_url,
+                            "requested_url": document.requested_url,
+                            "final_url": document.final_url,
+                            "raw_path": str(raw_path.relative_to(output_root)),
+                            "canonical_path": str(canonical_path.relative_to(output_root)),
+                            "reused": reused,
+                            "receipt": document.receipt.to_dict(),
+                        }
+                    )
+                    term_count += 1
+                phase.advance(
+                    subject_ref=term["query"],
+                    message=f"{term_count} documents",
+                    details={"jurisdiction": term["jurisdiction"], "document_count": term_count},
                 )
 
-    projection = project_source_families(
-        [existing_root, raw_root],
-        output_dir=output_root / "source_projection",
-        max_files=500,
-        max_file_bytes=10_000_000,
-    )
-    _write_json(output_root / "source_projection" / "manifest.json", projection.to_dict())
+    with recorder.phase("project_canonical_sources", total=1) as phase:
+        projection = project_source_families(
+            [existing_root, raw_root],
+            output_dir=output_root / "source_projection",
+            max_files=500,
+            max_file_bytes=10_000_000,
+        )
+        _write_json(output_root / "source_projection" / "manifest.json", projection.to_dict())
+        phase.advance(
+            subject_ref=str(output_root / "source_projection" / "manifest.json"),
+            details={"source_family_count": 2},
+        )
 
-    store = PostgresCompilerStore.connect(args.database_url)
-    try:
-        compilation = compile_directory_postgres(
+    outcomes: tuple[object, ...]
+    with recorder.phase(
+        "compile_pnf",
+        details={"workers": args.compile_workers, "parallel_boundary": "document"},
+    ) as phase:
+        compilation, outcomes = compile_directory_postgres_parallel(
             output_root / "source_projection" / "canonical",
             context=default_compiler_context(),
-            store=store,
+            database_url=args.database_url,
+            workers=args.compile_workers,
             execution_phase="legal_catalogue_build",
+            progress=phase,
         )
-    finally:
-        store.close()
-
-    probe_dir = output_root / "legal_pnf_probe"
-    subprocess.run(
-        [
-            sys.executable,
-            str(ROOT / "scripts" / "run_legal_pnf_probe.py"),
-            "--input-directory",
-            str(source_root),
-            "--output-dir",
-            str(probe_dir),
-            "--compare-legacy",
-            "--max-files",
-            "500",
-        ],
-        check=True,
+    _write_json(
+        output_root / "document_compilation_timings.json",
+        {
+            "schema_version": "sl.document_compilation_timings.v0_1",
+            "workers": args.compile_workers,
+            "documents": [row.to_dict() for row in outcomes],
+        },
     )
 
+    probe_dir = output_root / "legal_pnf_probe"
+    with recorder.phase(
+        "project_legal_ir",
+        total=len(compilation.document_refs),
+        message="document-local PNF/Legal IR/legacy differential probe",
+    ) as phase:
+        subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "scripts" / "run_legal_pnf_probe.py"),
+                "--input-directory",
+                str(source_root),
+                "--output-dir",
+                str(probe_dir),
+                "--compare-legacy",
+                "--max-files",
+                "500",
+            ],
+            check=True,
+        )
+        phase.completed = len(compilation.document_refs)
+
+    phase_ledger_path = output_root / "phase_ledger.json"
+    recorder.write_json(phase_ledger_path)
     manifest = {
-        "schema_version": "sl.persisted_legal_catalogue_build.v0_1",
+        "schema_version": "sl.persisted_legal_catalogue_build.v0_2",
         "catalogue_ref": catalogue["catalogue_ref"],
         "provider": provider,
         "existing_tranche_file_count": copied,
@@ -173,7 +252,15 @@ def main() -> int:
         "document_refs": list(compilation.document_refs),
         "demand_refs": list(compilation.demand_refs),
         "failure_refs": list(compilation.failure_refs),
+        "compile_workers": args.compile_workers,
+        "copy_workers": args.copy_workers,
+        "document_compilation_timings": "document_compilation_timings.json",
+        "phase_ledger": str(phase_ledger_path.relative_to(output_root)),
+        "phase_summary": recorder.to_dict()["phase_summary"],
         "legal_pnf_probe_root": str(probe_dir.relative_to(output_root)),
+        "parallelism_boundary": "immutable_document_build",
+        "request_governor_serialized": True,
+        "final_manifest_reduction_serialized": True,
         "identity_promoted": False,
         "legal_truth_closed": False,
         "authority": "candidate_catalogue_build_only",

--- a/src/pnf/__init__.py
+++ b/src/pnf/__init__.py
@@ -29,6 +29,11 @@ from .operational_reference_binding import (
     build_set_valued_binding_artifacts,
 )
 from .reference_binding import project_pronominal_reference_arguments
+from .review_coordinates import (
+    SemanticReviewAssessment,
+    SemanticReviewCoordinate,
+    project_review_state,
+)
 from .revision_normalization import normalize_factor_revision_artifacts
 
 __all__ = [
@@ -48,6 +53,8 @@ __all__ = [
     "REFERENCE_REDUCTION_DECLARATION_REF",
     "ReducedFactor",
     "ReductionResidual",
+    "SemanticReviewAssessment",
+    "SemanticReviewCoordinate",
     "assess_pnf_closure",
     "build_operational_reference_binding_artifacts",
     "build_set_valued_binding_artifacts",
@@ -55,6 +62,7 @@ __all__ = [
     "derive_resolution_demands",
     "normalize_factor_revision_artifacts",
     "project_pronominal_reference_arguments",
+    "project_review_state",
     "proposal_build_key",
     "reduce_factor_proposals",
 ]

--- a/src/pnf/__init__.py
+++ b/src/pnf/__init__.py
@@ -11,6 +11,16 @@ from .binding_candidate_sets import (
 )
 from .closure import ClosureContract, assess_pnf_closure
 from .demands import derive_resolution_demands
+from .factor_proposals import (
+    CompositionDeclaration,
+    CrossDocumentRelation,
+    FactorProposal,
+    ProposalReduction,
+    ReducedFactor,
+    ReductionResidual,
+    proposal_build_key,
+    reduce_factor_proposals,
+)
 from .graph import PNFGraph
 from .operational_reference_binding import (
     REFERENCE_BINDING_CONTRACT_REF,
@@ -28,10 +38,16 @@ __all__ = [
     "BindingCompatibilityDeclaration",
     "BindingExclusionSummary",
     "ClosureContract",
+    "CompositionDeclaration",
+    "CrossDocumentRelation",
     "FactorAnchor",
+    "FactorProposal",
     "PNFGraph",
+    "ProposalReduction",
     "REFERENCE_BINDING_CONTRACT_REF",
     "REFERENCE_REDUCTION_DECLARATION_REF",
+    "ReducedFactor",
+    "ReductionResidual",
     "assess_pnf_closure",
     "build_operational_reference_binding_artifacts",
     "build_set_valued_binding_artifacts",
@@ -39,4 +55,6 @@ __all__ = [
     "derive_resolution_demands",
     "normalize_factor_revision_artifacts",
     "project_pronominal_reference_arguments",
+    "proposal_build_key",
+    "reduce_factor_proposals",
 ]

--- a/src/pnf/factor_proposals.py
+++ b/src/pnf/factor_proposals.py
@@ -1,0 +1,355 @@
+"""Immutable document-local PNF proposals and deterministic reduction.
+
+Workers may generate proposals concurrently, but they never mutate a shared graph.
+The reducer validates references, orders by canonical keys, deduplicates byte-identical
+proposals, and retains incompatible alternatives as explicit residuals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.policy.carriers.canonical import canonical_sha256
+
+
+FACTOR_PROPOSAL_SCHEMA_VERSION = "sl.pnf.factor_proposal.v0_1"
+PROPOSAL_REDUCTION_SCHEMA_VERSION = "sl.pnf.proposal_reduction.v0_1"
+CROSS_DOCUMENT_RELATION_SCHEMA_VERSION = "sl.pnf.cross_document_relation.v0_1"
+
+
+@dataclass(frozen=True)
+class CompositionDeclaration:
+    producer_ref: str
+    requires: tuple[str, ...] = ()
+    optional: tuple[str, ...] = ()
+    emits: tuple[str, ...] = ()
+    declaration_revision: str = "v0_1"
+
+    @property
+    def declaration_ref(self) -> str:
+        return "composition-declaration:" + canonical_sha256(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "producer_ref": self.producer_ref,
+            "requires": sorted(set(self.requires)),
+            "optional": sorted(set(self.optional)),
+            "emits": sorted(set(self.emits)),
+            "declaration_revision": self.declaration_revision,
+        }
+
+
+@dataclass(frozen=True)
+class FactorProposal:
+    document_ref: str
+    source_revision_ref: str
+    factor_type_ref: str
+    source_span_refs: tuple[str, ...]
+    input_observation_refs: tuple[str, ...]
+    dependency_factor_refs: tuple[str, ...]
+    structural_signature: str
+    role_bindings: Mapping[str, str]
+    qualifier_state: Mapping[str, Any]
+    producer_contract: str
+    declaration_revision: str
+    candidate_payload: Mapping[str, Any]
+    residuals: tuple[str, ...] = ()
+
+    @property
+    def proposal_digest(self) -> str:
+        return canonical_sha256(self.identity_payload())
+
+    @property
+    def proposal_ref(self) -> str:
+        return "factor-proposal:" + self.proposal_digest
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "document_ref": self.document_ref,
+            "source_revision_ref": self.source_revision_ref,
+            "factor_type_ref": self.factor_type_ref,
+            "source_span_refs": sorted(set(self.source_span_refs)),
+            "input_observation_refs": sorted(set(self.input_observation_refs)),
+            "dependency_factor_refs": sorted(set(self.dependency_factor_refs)),
+            "structural_signature": self.structural_signature,
+            "role_bindings": dict(sorted(self.role_bindings.items())),
+            "qualifier_state": dict(self.qualifier_state),
+            "producer_contract": self.producer_contract,
+            "declaration_revision": self.declaration_revision,
+            "candidate_payload": dict(self.candidate_payload),
+            "residuals": sorted(set(self.residuals)),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": FACTOR_PROPOSAL_SCHEMA_VERSION,
+            "proposal_ref": self.proposal_ref,
+            "proposal_digest": self.proposal_digest,
+            **self.identity_payload(),
+            "authority": "candidate_only",
+        }
+
+
+@dataclass(frozen=True)
+class ReductionResidual:
+    residual_ref: str
+    document_ref: str
+    residual_type: str
+    proposal_refs: tuple[str, ...]
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ReducedFactor:
+    factor_ref: str
+    document_ref: str
+    factor_type_ref: str
+    structural_signature: str
+    proposal_refs: tuple[str, ...]
+    alternatives: tuple[Mapping[str, Any], ...]
+    role_bindings: Mapping[str, str]
+    qualifier_state: Mapping[str, Any]
+    residuals: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "factor_ref": self.factor_ref,
+            "document_ref": self.document_ref,
+            "factor_type_ref": self.factor_type_ref,
+            "structural_signature": self.structural_signature,
+            "proposal_refs": list(self.proposal_refs),
+            "alternatives": [dict(row) for row in self.alternatives],
+            "role_bindings": dict(self.role_bindings),
+            "qualifier_state": dict(self.qualifier_state),
+            "residuals": list(self.residuals),
+            "closure_state": "requires_review" if self.residuals else "locally_closed",
+        }
+
+
+@dataclass(frozen=True)
+class ProposalReduction:
+    document_ref: str
+    factors: tuple[ReducedFactor, ...]
+    residuals: tuple[ReductionResidual, ...]
+    proposal_count: int
+    deduplicated_count: int
+
+    @property
+    def graph_ref(self) -> str:
+        return "pnf-document-graph:" + canonical_sha256(
+            {
+                "document_ref": self.document_ref,
+                "factors": [row.to_dict() for row in self.factors],
+                "residuals": [row.to_dict() for row in self.residuals],
+            }
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROPOSAL_REDUCTION_SCHEMA_VERSION,
+            "document_ref": self.document_ref,
+            "graph_ref": self.graph_ref,
+            "proposal_count": self.proposal_count,
+            "deduplicated_count": self.deduplicated_count,
+            "factors": [row.to_dict() for row in self.factors],
+            "residuals": [row.to_dict() for row in self.residuals],
+            "identity_promoted": False,
+            "legal_truth_closed": False,
+        }
+
+
+@dataclass(frozen=True)
+class CrossDocumentRelation:
+    relation_type: str
+    source_document_ref: str
+    target_document_ref: str
+    source_coordinate_refs: tuple[str, ...]
+    target_coordinate_refs: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    qualifier_state: Mapping[str, Any] = field(default_factory=dict)
+    residuals: tuple[str, ...] = ()
+
+    @property
+    def relation_ref(self) -> str:
+        return "cross-document-relation:" + canonical_sha256(self.identity_payload())
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "relation_type": self.relation_type,
+            "source_document_ref": self.source_document_ref,
+            "target_document_ref": self.target_document_ref,
+            "source_coordinate_refs": sorted(set(self.source_coordinate_refs)),
+            "target_coordinate_refs": sorted(set(self.target_coordinate_refs)),
+            "evidence_refs": sorted(set(self.evidence_refs)),
+            "qualifier_state": dict(self.qualifier_state),
+            "residuals": sorted(set(self.residuals)),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": CROSS_DOCUMENT_RELATION_SCHEMA_VERSION,
+            "relation_ref": self.relation_ref,
+            **self.identity_payload(),
+            "identity_closed": False,
+            "legal_conclusion_promoted": False,
+        }
+
+
+def proposal_build_key(
+    *,
+    canonical_text_digest: str,
+    producer_contract: str,
+    declaration_revision: str,
+    input_observation_digests: Sequence[str],
+    dependency_factor_digests: Sequence[str],
+) -> str:
+    return canonical_sha256(
+        {
+            "canonical_text_digest": canonical_text_digest,
+            "producer_contract": producer_contract,
+            "declaration_revision": declaration_revision,
+            "input_observation_digests": sorted(set(input_observation_digests)),
+            "dependency_factor_digests": sorted(set(dependency_factor_digests)),
+        }
+    )
+
+
+def _compatible(left: FactorProposal, right: FactorProposal) -> bool:
+    if left.factor_type_ref != right.factor_type_ref:
+        return False
+    if left.structural_signature != right.structural_signature:
+        return False
+    for role in set(left.role_bindings) & set(right.role_bindings):
+        if left.role_bindings[role] != right.role_bindings[role]:
+            return False
+    return True
+
+
+def reduce_factor_proposals(
+    *,
+    document_ref: str,
+    proposals: Iterable[FactorProposal],
+    known_observation_refs: Iterable[str] = (),
+    known_dependency_refs: Iterable[str] = (),
+) -> ProposalReduction:
+    ordered = sorted(proposals, key=lambda row: row.proposal_ref)
+    for proposal in ordered:
+        if proposal.document_ref != document_ref:
+            raise ValueError("cross-document proposal supplied to document-local reducer")
+
+    observation_refs = set(known_observation_refs)
+    dependency_refs = set(known_dependency_refs)
+    validation_residuals: list[ReductionResidual] = []
+    valid: list[FactorProposal] = []
+    for proposal in ordered:
+        missing_observations = sorted(set(proposal.input_observation_refs) - observation_refs) if observation_refs else []
+        missing_dependencies = sorted(set(proposal.dependency_factor_refs) - dependency_refs) if dependency_refs else []
+        if missing_observations or missing_dependencies:
+            residual_type = "missing_reduction_input"
+            residual_ref = "reduction-residual:" + canonical_sha256(
+                {
+                    "proposal_ref": proposal.proposal_ref,
+                    "missing_observations": missing_observations,
+                    "missing_dependencies": missing_dependencies,
+                }
+            )
+            validation_residuals.append(
+                ReductionResidual(
+                    residual_ref=residual_ref,
+                    document_ref=document_ref,
+                    residual_type=residual_type,
+                    proposal_refs=(proposal.proposal_ref,),
+                    message="proposal retained outside reduction because declared inputs are unavailable",
+                )
+            )
+            continue
+        valid.append(proposal)
+
+    unique = {row.proposal_ref: row for row in valid}
+    deduplicated = sorted(unique.values(), key=lambda row: row.proposal_ref)
+    groups: list[list[FactorProposal]] = []
+    for proposal in deduplicated:
+        matched = next((group for group in groups if all(_compatible(proposal, item) for item in group)), None)
+        if matched is None:
+            groups.append([proposal])
+        else:
+            matched.append(proposal)
+
+    factors: list[ReducedFactor] = []
+    incompatibility_residuals: list[ReductionResidual] = []
+    signature_groups: dict[tuple[str, str], list[list[FactorProposal]]] = {}
+    for group in groups:
+        key = (group[0].factor_type_ref, group[0].structural_signature)
+        signature_groups.setdefault(key, []).append(group)
+
+    for key, compatible_groups in sorted(signature_groups.items()):
+        if len(compatible_groups) > 1:
+            refs = tuple(sorted(row.proposal_ref for group in compatible_groups for row in group))
+            incompatibility_residuals.append(
+                ReductionResidual(
+                    residual_ref="reduction-residual:" + canonical_sha256({"kind": "incompatible_alternatives", "refs": refs}),
+                    document_ref=document_ref,
+                    residual_type="incompatible_alternatives",
+                    proposal_refs=refs,
+                    message="structurally related proposals disagree on one or more occupied coordinates",
+                )
+            )
+        for group in compatible_groups:
+            proposal_refs = tuple(sorted(row.proposal_ref for row in group))
+            roles: dict[str, str] = {}
+            qualifiers: dict[str, Any] = {}
+            residuals: set[str] = set()
+            alternatives: list[Mapping[str, Any]] = []
+            for proposal in sorted(group, key=lambda row: row.proposal_ref):
+                roles.update(proposal.role_bindings)
+                qualifiers.update(proposal.qualifier_state)
+                residuals.update(proposal.residuals)
+                alternatives.append(dict(proposal.candidate_payload))
+            factor_ref = "factor:" + canonical_sha256(
+                {
+                    "document_ref": document_ref,
+                    "factor_type_ref": key[0],
+                    "structural_signature": key[1],
+                    "proposal_refs": proposal_refs,
+                }
+            )
+            factors.append(
+                ReducedFactor(
+                    factor_ref=factor_ref,
+                    document_ref=document_ref,
+                    factor_type_ref=key[0],
+                    structural_signature=key[1],
+                    proposal_refs=proposal_refs,
+                    alternatives=tuple(alternatives),
+                    role_bindings=dict(sorted(roles.items())),
+                    qualifier_state=qualifiers,
+                    residuals=tuple(sorted(residuals)),
+                )
+            )
+
+    return ProposalReduction(
+        document_ref=document_ref,
+        factors=tuple(sorted(factors, key=lambda row: row.factor_ref)),
+        residuals=tuple(sorted((*validation_residuals, *incompatibility_residuals), key=lambda row: row.residual_ref)),
+        proposal_count=len(ordered),
+        deduplicated_count=len(valid) - len(deduplicated),
+    )
+
+
+__all__ = [
+    "CROSS_DOCUMENT_RELATION_SCHEMA_VERSION",
+    "FACTOR_PROPOSAL_SCHEMA_VERSION",
+    "PROPOSAL_REDUCTION_SCHEMA_VERSION",
+    "CompositionDeclaration",
+    "CrossDocumentRelation",
+    "FactorProposal",
+    "ProposalReduction",
+    "ReducedFactor",
+    "ReductionResidual",
+    "proposal_build_key",
+    "reduce_factor_proposals",
+]

--- a/src/pnf/operator_composition_bridge.py
+++ b/src/pnf/operator_composition_bridge.py
@@ -1,9 +1,9 @@
 """Apply generic operator composition to an existing document compilation.
 
 The bridge reconstructs the public parser token record from the stored annotation
-layer.  It never reparses text.  This makes the probe exercise the same parser
-observations while the composition phase is being validated for direct inclusion
-in the compiler pipeline.
+layer.  It never reparses text.  Composition first emits immutable proposals and a
+deterministic document-local reduction ledger; the compatibility graph projection is
+then populated from the existing Factor carrier without allowing shared graph mutation.
 """
 
 from __future__ import annotations
@@ -12,10 +12,11 @@ from copy import deepcopy
 from typing import Any, Mapping
 
 from src.language.operator_composition import compose_operator_factors
+from src.pnf.factor_proposals import FactorProposal, reduce_factor_proposals
 from src.policy.carriers.canonical import canonical_sha256
 
 
-OPERATOR_COMPOSITION_BRIDGE_CONTRACT = "pnf-operator-composition-bridge:v0_1"
+OPERATOR_COMPOSITION_BRIDGE_CONTRACT = "pnf-operator-composition-bridge:v0_2"
 
 
 def _parsed_document_from_layer(layer: Mapping[str, Any]) -> dict[str, Any]:
@@ -29,7 +30,6 @@ def _parsed_document_from_layer(layer: Mapping[str, Any]) -> dict[str, Any]:
             continue
         values.setdefault(index, {})[annotation_type.removeprefix("parser.")] = row.get("value")
 
-    spans_by_ref: dict[str, Mapping[str, Any]] = {}
     token_ref_by_index: dict[int, str] = {}
     for row in layer.get("span_annotations") or ():
         if str(row.get("annotation_type") or "") != "parser_token":
@@ -38,7 +38,6 @@ def _parsed_document_from_layer(layer: Mapping[str, Any]) -> dict[str, Any]:
         if index < 0:
             continue
         span_ref = str(row.get("span_ref") or "")
-        spans_by_ref[span_ref] = row
         token_ref_by_index[index] = span_ref
         payload = row.get("value") or {}
         values.setdefault(index, {}).update(
@@ -108,10 +107,38 @@ def _projection_ready_factor(row: Mapping[str, Any]) -> dict[str, Any]:
     return value
 
 
+def _proposal_from_factor(*, document_ref: str, row: Mapping[str, Any]) -> FactorProposal:
+    metadata = dict(row.get("metadata") or {})
+    provenance_refs = tuple(str(ref) for ref in metadata.get("provenance_refs") or ())
+    alternatives = tuple(row.get("alternatives") or ())
+    candidate_payload = {
+        "factor_ref": str(row.get("factor_ref") or ""),
+        "alternatives": [dict(item) for item in alternatives if isinstance(item, Mapping)],
+        "predicate_ref": str(metadata.get("predicate_ref") or row.get("factor_type") or ""),
+    }
+    return FactorProposal(
+        document_ref=document_ref,
+        source_revision_ref="source-revision:" + canonical_sha256(
+            {"document_ref": document_ref, "provenance_refs": sorted(provenance_refs)}
+        ),
+        factor_type_ref=str(row.get("factor_type") or ""),
+        source_span_refs=provenance_refs,
+        input_observation_refs=provenance_refs,
+        dependency_factor_refs=(),
+        structural_signature=str(metadata.get("structural_signature_ref") or ""),
+        role_bindings=dict(metadata.get("role_bindings") or {}),
+        qualifier_state=dict(metadata.get("qualifier_state") or {}),
+        producer_contract=str(metadata.get("composition_contract_ref") or OPERATOR_COMPOSITION_BRIDGE_CONTRACT),
+        declaration_revision="v0_1",
+        candidate_payload=candidate_payload,
+        residuals=tuple(str(value) for value in row.get("residuals") or ()),
+    )
+
+
 def apply_operator_composition_to_compilation(
     compilation: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Return a compilation with operator factors added to both PNF graph views."""
+    """Return a compilation with proposals, reduction, and operator factors."""
 
     result = deepcopy(dict(compilation))
     artifacts = deepcopy(dict(result.get("artifacts") or {}))
@@ -123,6 +150,17 @@ def apply_operator_composition_to_compilation(
         parsed_document=parsed_document,
     )
     factor_rows = tuple(_projection_ready_factor(row.to_dict()) for row in factors)
+    proposals = tuple(
+        _proposal_from_factor(document_ref=document_ref, row=row.to_dict()) for row in factors
+    )
+    known_observations = tuple(
+        sorted({ref for proposal in proposals for ref in proposal.input_observation_refs})
+    )
+    reduction = reduce_factor_proposals(
+        document_ref=document_ref,
+        proposals=proposals,
+        known_observation_refs=known_observations,
+    )
 
     for graph_name in ("pnf_graph", "refined_pnf_graph"):
         graph = deepcopy(dict(artifacts.get(graph_name) or {}))
@@ -138,6 +176,7 @@ def apply_operator_composition_to_compilation(
             {
                 "prior_graph_ref": graph.get("graph_ref"),
                 "contract": OPERATOR_COMPOSITION_BRIDGE_CONTRACT,
+                "proposal_reduction_ref": reduction.graph_ref,
                 "factor_refs": sorted(existing),
             }
         )
@@ -149,6 +188,9 @@ def apply_operator_composition_to_compilation(
         "reparsed": False,
         "factor_refs": [row.factor_ref for row in factors],
         "factor_count": len(factors),
+        "factor_proposals": [row.to_dict() for row in proposals],
+        "proposal_reduction": reduction.to_dict(),
+        "shared_graph_mutation": False,
         "authority": "candidate_pnf_only",
     }
     result["artifacts"] = artifacts

--- a/src/pnf/review_coordinates.py
+++ b/src/pnf/review_coordinates.py
@@ -1,0 +1,147 @@
+"""Granular review coordinates for proposals, factors, relations, subgraphs and builds."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from src.policy.carriers.canonical import canonical_sha256
+
+
+REVIEW_COORDINATE_SCHEMA_VERSION = "sl.pnf.review_coordinate.v0_1"
+_REVIEW_TARGET_KINDS = {
+    "factor_proposal",
+    "reduced_factor",
+    "cross_document_relation",
+    "subgraph",
+    "semantic_build",
+}
+_REVIEW_STATES = {
+    "supported",
+    "supported_with_residuals",
+    "unsupported",
+    "contested",
+    "unresolved",
+    "not_reviewed",
+}
+
+
+@dataclass(frozen=True)
+class SemanticReviewCoordinate:
+    target_kind: str
+    target_ref: str
+    document_refs: tuple[str, ...]
+    coordinate_refs: tuple[str, ...]
+    review_dimension: str
+    residuals: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.target_kind not in _REVIEW_TARGET_KINDS:
+            raise ValueError("unsupported semantic review target kind")
+        if not self.target_ref:
+            raise ValueError("target_ref is required")
+        if not self.review_dimension:
+            raise ValueError("review_dimension is required")
+
+    @property
+    def coordinate_ref(self) -> str:
+        return "semantic-review-coordinate:" + canonical_sha256(self.identity_payload())
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "target_kind": self.target_kind,
+            "target_ref": self.target_ref,
+            "document_refs": sorted(set(self.document_refs)),
+            "coordinate_refs": sorted(set(self.coordinate_refs)),
+            "review_dimension": self.review_dimension,
+            "residuals": sorted(set(self.residuals)),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": REVIEW_COORDINATE_SCHEMA_VERSION,
+            "coordinate_ref": self.coordinate_ref,
+            **self.identity_payload(),
+            "semantic_state_mutated": False,
+        }
+
+
+@dataclass(frozen=True)
+class SemanticReviewAssessment:
+    coordinate_ref: str
+    reviewer_credential_ref: str
+    institution_ref: str
+    review_state: str
+    rationale_refs: tuple[str, ...]
+    residuals: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if self.review_state not in _REVIEW_STATES:
+            raise ValueError("unsupported semantic review state")
+        if not self.coordinate_ref or not self.reviewer_credential_ref:
+            raise ValueError("coordinate and reviewer credential are required")
+
+    @property
+    def assessment_ref(self) -> str:
+        return "semantic-review-assessment:" + canonical_sha256(self.identity_payload())
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "coordinate_ref": self.coordinate_ref,
+            "reviewer_credential_ref": self.reviewer_credential_ref,
+            "institution_ref": self.institution_ref,
+            "review_state": self.review_state,
+            "rationale_refs": sorted(set(self.rationale_refs)),
+            "residuals": sorted(set(self.residuals)),
+            "metadata": dict(self.metadata or {}),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": "sl.pnf.review_assessment.v0_1",
+            "assessment_ref": self.assessment_ref,
+            **self.identity_payload(),
+            "truth_closed": False,
+            "semantic_state_promoted": False,
+        }
+
+
+def project_review_state(
+    *,
+    coordinate: SemanticReviewCoordinate,
+    assessments: tuple[SemanticReviewAssessment, ...],
+    accepted_credential_refs: tuple[str, ...] = (),
+    accepted_institution_refs: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    accepted_credentials = set(accepted_credential_refs)
+    accepted_institutions = set(accepted_institution_refs)
+    scoped = tuple(
+        row
+        for row in assessments
+        if row.coordinate_ref == coordinate.coordinate_ref
+        and (not accepted_credentials or row.reviewer_credential_ref in accepted_credentials)
+        and (not accepted_institutions or row.institution_ref in accepted_institutions)
+    )
+    states = sorted({row.review_state for row in scoped})
+    contested = "contested" in states or (
+        any(state in {"supported", "supported_with_residuals"} for state in states)
+        and "unsupported" in states
+    )
+    return {
+        "schema_version": "sl.pnf.review_projection.v0_1",
+        "coordinate_ref": coordinate.coordinate_ref,
+        "assessment_refs": sorted(row.assessment_ref for row in scoped),
+        "states": states,
+        "contested": contested,
+        "truth_closed": False,
+        "semantic_state_promoted": False,
+    }
+
+
+__all__ = [
+    "REVIEW_COORDINATE_SCHEMA_VERSION",
+    "SemanticReviewAssessment",
+    "SemanticReviewCoordinate",
+    "project_review_state",
+]

--- a/src/policy/parallel_postgres_corpus_compilation.py
+++ b/src/policy/parallel_postgres_corpus_compilation.py
@@ -1,0 +1,245 @@
+"""Bounded document-level PostgreSQL compilation with deterministic reduction.
+
+Corpus admission and the final result ordering remain serialized.  Each worker owns a
+short-lived PostgreSQL connection and compiles exactly one immutable document build.
+No worker mutates a shared graph object or a mutable corpus pointer.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from time import monotonic_ns
+from typing import Any, Callable, Mapping, Sequence
+
+from src.policy.corpus_compilation import CompilerContext, build_corpus_manifest
+from src.policy.postgres_corpus_compilation import (
+    _prepare_operational_manifest,
+    persist_document_compilation,
+)
+from src.runtime.progress import PhaseHandle
+from src.storage.postgres import PersistedCompilation, PostgresCompilerStore
+
+
+PARALLEL_COMPILATION_SCHEMA_VERSION = "sl.parallel_postgres_compilation.v0_1"
+
+
+@dataclass(frozen=True)
+class DocumentCompilationOutcome:
+    document_ref: str
+    relative_path: str
+    state: str
+    demand_refs: tuple[str, ...] = ()
+    failure_ref: str | None = None
+    elapsed_ms: int = 0
+    worker: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": PARALLEL_COMPILATION_SCHEMA_VERSION,
+            "document_ref": self.document_ref,
+            "relative_path": self.relative_path,
+            "state": self.state,
+            "demand_refs": list(self.demand_refs),
+            "failure_ref": self.failure_ref,
+            "elapsed_ms": self.elapsed_ms,
+            "worker": self.worker,
+        }
+
+
+def _compile_one(
+    *,
+    database_url: str,
+    corpus_ref: str,
+    root: Path,
+    entry: Mapping[str, Any],
+    prepared_source: tuple[bytes, str] | None,
+    context: CompilerContext,
+    worker: str,
+) -> DocumentCompilationOutcome:
+    started = monotonic_ns()
+    document_ref = str(entry["document_ref"])
+    relative_path = str(entry["relative_path"])
+    store = PostgresCompilerStore.connect(database_url)
+    try:
+        if prepared_source is None:
+            source_bytes = (root / relative_path).read_bytes()
+            source_text = source_bytes.decode("utf-8")
+        else:
+            source_bytes, source_text = prepared_source
+        demand_refs = persist_document_compilation(
+            store=store,
+            corpus_ref=corpus_ref,
+            relative_path=relative_path,
+            entry=entry,
+            source_bytes=source_bytes,
+            source_text=source_text,
+            context=context,
+        )
+        state = "reused_or_compiled"
+        return DocumentCompilationOutcome(
+            document_ref=document_ref,
+            relative_path=relative_path,
+            state=state,
+            demand_refs=tuple(sorted(set(demand_refs))),
+            elapsed_ms=max(0, (monotonic_ns() - started) // 1_000_000),
+            worker=worker,
+        )
+    except (OSError, UnicodeDecodeError, ValueError, RuntimeError) as error:
+        with store.transaction() as cursor:
+            failure_ref = store.persist_failure(
+                cursor,
+                target_ref=document_ref,
+                phase_ref="local_compile",
+                error=error,
+            )
+        return DocumentCompilationOutcome(
+            document_ref=document_ref,
+            relative_path=relative_path,
+            state="failed",
+            failure_ref=failure_ref,
+            elapsed_ms=max(0, (monotonic_ns() - started) // 1_000_000),
+            worker=worker,
+        )
+    finally:
+        store.close()
+
+
+def compile_directory_postgres_parallel(
+    input_dir: str | Path,
+    *,
+    context: CompilerContext,
+    database_url: str,
+    workers: int = 2,
+    recursive: bool = True,
+    follow_symlinks: bool = False,
+    include_globs: Sequence[str] = (),
+    exclude_globs: Sequence[str] = (),
+    max_files: int | None = None,
+    max_file_bytes: int | None = None,
+    max_total_bytes: int | None = None,
+    execution_phase: str = "local",
+    progress: PhaseHandle | None = None,
+    outcome_sink: Callable[[DocumentCompilationOutcome], None] | None = None,
+) -> tuple[PersistedCompilation, tuple[DocumentCompilationOutcome, ...]]:
+    """Compile distinct canonical documents concurrently and reduce stably.
+
+    Duplicate-content occurrences are admitted serially.  Workers use independent
+    database connections.  Returned document, demand, failure, and timing rows are
+    sorted by stable references rather than completion order.
+    """
+
+    if execution_phase not in {"inventory", "local", "demand_planning", "legal_catalogue_build"}:
+        raise ValueError("unsupported corpus compilation phase")
+    if workers < 1 or workers > 32:
+        raise ValueError("workers must be between 1 and 32")
+
+    root = Path(input_dir).resolve()
+    manifest = build_corpus_manifest(
+        root,
+        context=context,
+        recursive=recursive,
+        follow_symlinks=follow_symlinks,
+        include_globs=include_globs,
+        exclude_globs=exclude_globs,
+        max_files=max_files,
+        max_file_bytes=max_file_bytes,
+        max_total_bytes=max_total_bytes,
+    )
+    manifest_row, prepared_sources = _prepare_operational_manifest(
+        root=root,
+        manifest=manifest.to_dict(),
+        context=context,
+    )
+    corpus_ref = str(manifest_row["corpus_ref"])
+    admission_store = PostgresCompilerStore.connect(database_url)
+    try:
+        with admission_store.transaction() as cursor:
+            admission_store.persist_context(cursor, context.to_dict())
+            admission_store.persist_manifest(cursor, manifest_row)
+        if execution_phase == "inventory":
+            empty = PersistedCompilation(corpus_ref, (), (), ())
+            return empty, ()
+
+        admitted: list[Mapping[str, Any]] = []
+        seen: set[str] = set()
+        for entry in manifest_row["ordered_documents"]:
+            if entry["status"] != "inventoried":
+                continue
+            document_ref = str(entry["document_ref"])
+            relative_path = str(entry["relative_path"])
+            if document_ref in seen:
+                with admission_store.transaction() as cursor:
+                    admission_store.persist_occurrence(
+                        cursor,
+                        corpus_ref=corpus_ref,
+                        relative_path=relative_path,
+                        document_ref=document_ref,
+                        state="duplicate_content_occurrence",
+                    )
+                continue
+            seen.add(document_ref)
+            admitted.append(entry)
+    finally:
+        admission_store.close()
+
+    if progress is not None:
+        progress.total = len(admitted)
+
+    outcomes: list[DocumentCompilationOutcome] = []
+    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="pnf-document") as executor:
+        future_map: dict[Future[DocumentCompilationOutcome], str] = {}
+        for index, entry in enumerate(admitted):
+            relative_path = str(entry["relative_path"])
+            worker = f"document-{(index % workers) + 1}"
+            future = executor.submit(
+                _compile_one,
+                database_url=database_url,
+                corpus_ref=corpus_ref,
+                root=root,
+                entry=entry,
+                prepared_source=prepared_sources.get(relative_path),
+                context=context,
+                worker=worker,
+            )
+            future_map[future] = str(entry["document_ref"])
+
+        for future in as_completed(future_map):
+            outcome = future.result()
+            outcomes.append(outcome)
+            if outcome_sink is not None:
+                outcome_sink(outcome)
+            if progress is not None:
+                progress.advance(
+                    subject_ref=outcome.document_ref,
+                    message=outcome.state,
+                    reused=outcome.state == "reused_or_compiled",
+                    details={
+                        "elapsed_ms": outcome.elapsed_ms,
+                        "worker": outcome.worker,
+                        "relative_path": outcome.relative_path,
+                        "failure_ref": outcome.failure_ref,
+                    },
+                )
+
+    ordered = tuple(sorted(outcomes, key=lambda row: (row.document_ref, row.relative_path)))
+    document_refs = tuple(sorted(row.document_ref for row in ordered if row.state != "failed"))
+    demand_refs = tuple(sorted({ref for row in ordered for ref in row.demand_refs}))
+    failure_refs = tuple(sorted(row.failure_ref for row in ordered if row.failure_ref is not None))
+    return (
+        PersistedCompilation(
+            corpus_ref=corpus_ref,
+            document_refs=document_refs,
+            demand_refs=demand_refs,
+            failure_refs=failure_refs,
+        ),
+        ordered,
+    )
+
+
+__all__ = [
+    "PARALLEL_COMPILATION_SCHEMA_VERSION",
+    "DocumentCompilationOutcome",
+    "compile_directory_postgres_parallel",
+]

--- a/src/policy/parallel_postgres_corpus_compilation.py
+++ b/src/policy/parallel_postgres_corpus_compilation.py
@@ -1,6 +1,6 @@
 """Bounded document-level PostgreSQL compilation with deterministic reduction.
 
-Corpus admission and the final result ordering remain serialized.  Each worker owns a
+Corpus admission and the final result ordering remain serialized. Each worker owns a
 short-lived PostgreSQL connection and compiles exactly one immutable document build.
 No worker mutates a shared graph object or a mutable corpus pointer.
 """
@@ -14,12 +14,15 @@ from time import monotonic_ns
 from typing import Any, Callable, Mapping, Sequence
 
 from src.policy.corpus_compilation import CompilerContext, build_corpus_manifest
+from src.policy.operational_corpus_compilation import OPERATIONAL_COMPILER_CONTRACT
 from src.policy.postgres_corpus_compilation import (
+    _operational_build_key,
     _prepare_operational_manifest,
     persist_document_compilation,
 )
 from src.runtime.progress import PhaseHandle
 from src.storage.postgres import PersistedCompilation, PostgresCompilerStore
+from src.storage.postgres.operational_build_store import load_completed_operational_build
 
 
 PARALLEL_COMPILATION_SCHEMA_VERSION = "sl.parallel_postgres_compilation.v0_1"
@@ -48,6 +51,16 @@ class DocumentCompilationOutcome:
         }
 
 
+def _build_key(entry: Mapping[str, Any], context: CompilerContext) -> str:
+    return _operational_build_key(
+        document_ref=str(entry["document_ref"]),
+        content_sha256=str(entry["content_sha256"]),
+        canonical_text_sha256=str(entry["canonical_text_sha256"]),
+        media_adapter_ref=str(entry["media_adapter_ref"]),
+        context=context,
+    )
+
+
 def _compile_one(
     *,
     database_url: str,
@@ -63,6 +76,14 @@ def _compile_one(
     relative_path = str(entry["relative_path"])
     store = PostgresCompilerStore.connect(database_url)
     try:
+        build_key = _build_key(entry, context)
+        with store.transaction() as cursor:
+            cached = load_completed_operational_build(
+                cursor,
+                document_ref=document_ref,
+                compiler_contract_ref=OPERATIONAL_COMPILER_CONTRACT,
+                build_key_sha256=build_key,
+            )
         if prepared_source is None:
             source_bytes = (root / relative_path).read_bytes()
             source_text = source_bytes.decode("utf-8")
@@ -77,11 +98,10 @@ def _compile_one(
             source_text=source_text,
             context=context,
         )
-        state = "reused_or_compiled"
         return DocumentCompilationOutcome(
             document_ref=document_ref,
             relative_path=relative_path,
-            state=state,
+            state="reused" if cached is not None else "compiled",
             demand_refs=tuple(sorted(set(demand_refs))),
             elapsed_ms=max(0, (monotonic_ns() - started) // 1_000_000),
             worker=worker,
@@ -125,12 +145,13 @@ def compile_directory_postgres_parallel(
 ) -> tuple[PersistedCompilation, tuple[DocumentCompilationOutcome, ...]]:
     """Compile distinct canonical documents concurrently and reduce stably.
 
-    Duplicate-content occurrences are admitted serially.  Workers use independent
-    database connections.  Returned document, demand, failure, and timing rows are
+    Duplicate-content occurrences are admitted serially. Workers use independent
+    database connections. Returned document, demand, failure, and timing rows are
     sorted by stable references rather than completion order.
     """
 
-    if execution_phase not in {"inventory", "local", "demand_planning", "legal_catalogue_build"}:
+    phases = {"inventory", "local", "demand_planning", "legal_catalogue_build"}
+    if execution_phase not in phases:
         raise ValueError("unsupported corpus compilation phase")
     if workers < 1 or workers > 32:
         raise ValueError("workers must be between 1 and 32")
@@ -188,7 +209,10 @@ def compile_directory_postgres_parallel(
         progress.total = len(admitted)
 
     outcomes: list[DocumentCompilationOutcome] = []
-    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="pnf-document") as executor:
+    with ThreadPoolExecutor(
+        max_workers=workers,
+        thread_name_prefix="pnf-document",
+    ) as executor:
         future_map: dict[Future[DocumentCompilationOutcome], str] = {}
         for index, entry in enumerate(admitted):
             relative_path = str(entry["relative_path"])
@@ -214,7 +238,7 @@ def compile_directory_postgres_parallel(
                 progress.advance(
                     subject_ref=outcome.document_ref,
                     message=outcome.state,
-                    reused=outcome.state == "reused_or_compiled",
+                    reused=outcome.state == "reused",
                     details={
                         "elapsed_ms": outcome.elapsed_ms,
                         "worker": outcome.worker,
@@ -223,10 +247,16 @@ def compile_directory_postgres_parallel(
                     },
                 )
 
-    ordered = tuple(sorted(outcomes, key=lambda row: (row.document_ref, row.relative_path)))
-    document_refs = tuple(sorted(row.document_ref for row in ordered if row.state != "failed"))
+    ordered = tuple(
+        sorted(outcomes, key=lambda row: (row.document_ref, row.relative_path))
+    )
+    document_refs = tuple(
+        sorted(row.document_ref for row in ordered if row.state != "failed")
+    )
     demand_refs = tuple(sorted({ref for row in ordered for ref in row.demand_refs}))
-    failure_refs = tuple(sorted(row.failure_ref for row in ordered if row.failure_ref is not None))
+    failure_refs = tuple(
+        sorted(row.failure_ref for row in ordered if row.failure_ref is not None)
+    )
     return (
         PersistedCompilation(
             corpus_ref=corpus_ref,

--- a/src/runtime/progress.py
+++ b/src/runtime/progress.py
@@ -1,14 +1,23 @@
-"""Small deterministic progress surface shared by long-running runtime lanes."""
+"""Deterministic progress and timing events shared by long-running runtime lanes."""
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
 import json
+from pathlib import Path
 import sys
-from typing import Any, Mapping, TextIO
+from time import monotonic_ns
+from typing import Any, Iterator, Mapping, TextIO
 
 
-PROGRESS_SCHEMA_VERSION = "sl.progress_event.v0_1"
+PROGRESS_SCHEMA_VERSION = "sl.progress_event.v0_2"
+PHASE_LEDGER_SCHEMA_VERSION = "sl.phase_ledger.v0_1"
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
 
 
 @dataclass(frozen=True)
@@ -20,11 +29,165 @@ class ProgressEvent:
     message: str = ""
     subject_ref: str | None = None
     details: Mapping[str, Any] | None = None
+    started_at: str | None = None
+    observed_at: str = field(default_factory=_utc_now)
+    elapsed_ms: int | None = None
+    worker: str | None = None
+    reused: bool | None = None
 
     def to_dict(self) -> dict[str, Any]:
         payload = asdict(self)
         payload["schema_version"] = PROGRESS_SCHEMA_VERSION
         return {key: value for key, value in payload.items() if value not in (None, "")}
+
+
+@dataclass
+class PhaseRecorder:
+    """Collect durable phase events while also emitting useful CLI/Actions output."""
+
+    stream: TextIO | None = None
+    json_lines: bool = False
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    def emit(self, event: ProgressEvent) -> None:
+        self.events.append(event.to_dict())
+        emit_progress(event, stream=self.stream, json_lines=self.json_lines)
+
+    @contextmanager
+    def phase(
+        self,
+        phase: str,
+        *,
+        total: int | None = None,
+        subject_ref: str | None = None,
+        message: str = "",
+        worker: str | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> Iterator["PhaseHandle"]:
+        handle = PhaseHandle(
+            recorder=self,
+            phase=phase,
+            total=total,
+            subject_ref=subject_ref,
+            message=message,
+            worker=worker,
+            details=dict(details or {}),
+        )
+        handle.start()
+        try:
+            yield handle
+        except BaseException as error:
+            handle.finish(state="failed", details={"error_type": type(error).__name__, "error": str(error)})
+            raise
+        else:
+            handle.finish(state="completed")
+
+    def to_dict(self) -> dict[str, Any]:
+        by_phase: dict[str, dict[str, int]] = {}
+        for event in self.events:
+            phase = str(event["phase"])
+            row = by_phase.setdefault(phase, {"events": 0, "elapsed_ms": 0, "failed": 0})
+            row["events"] += 1
+            row["elapsed_ms"] += int(event.get("elapsed_ms") or 0)
+            row["failed"] += int(event.get("state") == "failed")
+        return {
+            "schema_version": PHASE_LEDGER_SCHEMA_VERSION,
+            "event_count": len(self.events),
+            "phase_summary": {key: by_phase[key] for key in sorted(by_phase)},
+            "events": self.events,
+        }
+
+    def write_json(self, path: str | Path) -> None:
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(self.to_dict(), indent=2, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+@dataclass
+class PhaseHandle:
+    recorder: PhaseRecorder
+    phase: str
+    total: int | None = None
+    subject_ref: str | None = None
+    message: str = ""
+    worker: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+    completed: int = 0
+    reused: int = 0
+    _started_at: str | None = None
+    _started_ns: int | None = None
+    _finished: bool = False
+
+    def start(self) -> None:
+        self._started_at = _utc_now()
+        self._started_ns = monotonic_ns()
+        self.recorder.emit(
+            ProgressEvent(
+                phase=self.phase,
+                state="started",
+                completed=self.completed,
+                total=self.total,
+                message=self.message,
+                subject_ref=self.subject_ref,
+                details=self.details or None,
+                started_at=self._started_at,
+                worker=self.worker,
+            )
+        )
+
+    def advance(
+        self,
+        *,
+        amount: int = 1,
+        subject_ref: str | None = None,
+        message: str = "",
+        reused: bool | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.completed += amount
+        if reused:
+            self.reused += amount
+        self.recorder.emit(
+            ProgressEvent(
+                phase=self.phase,
+                state="running",
+                completed=self.completed,
+                total=self.total,
+                message=message,
+                subject_ref=subject_ref or self.subject_ref,
+                details=dict(details or {}) or None,
+                started_at=self._started_at,
+                elapsed_ms=self.elapsed_ms,
+                worker=self.worker,
+                reused=reused,
+            )
+        )
+
+    @property
+    def elapsed_ms(self) -> int:
+        if self._started_ns is None:
+            return 0
+        return max(0, (monotonic_ns() - self._started_ns) // 1_000_000)
+
+    def finish(self, *, state: str, details: Mapping[str, Any] | None = None) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        merged_details = {**self.details, **dict(details or {}), "reused_units": self.reused}
+        self.recorder.emit(
+            ProgressEvent(
+                phase=self.phase,
+                state=state,
+                completed=self.completed,
+                total=self.total,
+                message=self.message,
+                subject_ref=self.subject_ref,
+                details=merged_details,
+                started_at=self._started_at,
+                elapsed_ms=self.elapsed_ms,
+                worker=self.worker,
+            )
+        )
 
 
 def emit_progress(
@@ -37,15 +200,26 @@ def emit_progress(
 
     target = stream or sys.stderr
     if json_lines:
-        print(json.dumps(event.to_dict(), ensure_ascii=False, sort_keys=True), file=target)
+        print(json.dumps(event.to_dict(), ensure_ascii=False, sort_keys=True), file=target, flush=True)
         return
     total = f"/{event.total}" if event.total is not None else ""
     subject = f" {event.subject_ref}" if event.subject_ref else ""
     message = f" — {event.message}" if event.message else ""
+    elapsed = f" {event.elapsed_ms}ms" if event.elapsed_ms is not None else ""
+    worker = f" worker={event.worker}" if event.worker else ""
+    reuse = " reused" if event.reused else ""
     print(
-        f"[{event.phase}] {event.state} {event.completed}{total}{subject}{message}",
+        f"[{event.phase}] {event.state} {event.completed}{total}{subject}{elapsed}{worker}{reuse}{message}",
         file=target,
+        flush=True,
     )
 
 
-__all__ = ["PROGRESS_SCHEMA_VERSION", "ProgressEvent", "emit_progress"]
+__all__ = [
+    "PHASE_LEDGER_SCHEMA_VERSION",
+    "PROGRESS_SCHEMA_VERSION",
+    "PhaseHandle",
+    "PhaseRecorder",
+    "ProgressEvent",
+    "emit_progress",
+]

--- a/tests/pnf/test_factor_proposals.py
+++ b/tests/pnf/test_factor_proposals.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from src.pnf.factor_proposals import (
+    CrossDocumentRelation,
+    FactorProposal,
+    proposal_build_key,
+    reduce_factor_proposals,
+)
+
+
+def _proposal(*, bearer: str, payload: str = "drive") -> FactorProposal:
+    return FactorProposal(
+        document_ref="document:qld-road-rules",
+        source_revision_ref="source-revision:1",
+        factor_type_ref="semantic.normative_relation",
+        source_span_refs=("span:1",),
+        input_observation_refs=("observation:must", "observation:drive"),
+        dependency_factor_refs=(),
+        structural_signature="signature:normative-operation:v1",
+        role_bindings={"bearer": bearer, "conduct": "eventuality:drive"},
+        qualifier_state={"modality": "obligation", "polarity": "positive"},
+        producer_contract="grammar:semantic:operator-composition:v0_1",
+        declaration_revision="v0_1",
+        candidate_payload={"predicate_ref": payload},
+        residuals=("jurisdiction_unresolved",),
+    )
+
+
+def test_reducer_is_order_independent_and_deduplicates_exact_proposals() -> None:
+    first = _proposal(bearer="entity:driver")
+    duplicate = _proposal(bearer="entity:driver")
+    left = reduce_factor_proposals(
+        document_ref=first.document_ref,
+        proposals=(first, duplicate),
+        known_observation_refs=("observation:must", "observation:drive"),
+    )
+    right = reduce_factor_proposals(
+        document_ref=first.document_ref,
+        proposals=(duplicate, first),
+        known_observation_refs=("observation:drive", "observation:must"),
+    )
+
+    assert left.graph_ref == right.graph_ref
+    assert left.deduplicated_count == 1
+    assert len(left.factors) == 1
+    assert left.factors[0].proposal_refs == (first.proposal_ref,)
+    assert left.to_dict()["legal_truth_closed"] is False
+
+
+def test_incompatible_coordinates_remain_explicit_alternatives() -> None:
+    driver = _proposal(bearer="entity:driver")
+    owner = _proposal(bearer="entity:owner")
+    reduction = reduce_factor_proposals(
+        document_ref=driver.document_ref,
+        proposals=(owner, driver),
+        known_observation_refs=("observation:must", "observation:drive"),
+    )
+
+    assert len(reduction.factors) == 2
+    assert [row.residual_type for row in reduction.residuals] == ["incompatible_alternatives"]
+    assert set(reduction.residuals[0].proposal_refs) == {driver.proposal_ref, owner.proposal_ref}
+
+
+def test_missing_declared_inputs_do_not_race_into_graph() -> None:
+    proposal = _proposal(bearer="entity:driver")
+    reduction = reduce_factor_proposals(
+        document_ref=proposal.document_ref,
+        proposals=(proposal,),
+        known_observation_refs=("observation:must",),
+    )
+
+    assert reduction.factors == ()
+    assert reduction.residuals[0].residual_type == "missing_reduction_input"
+
+
+def test_build_key_targets_only_declared_inputs() -> None:
+    first = proposal_build_key(
+        canonical_text_digest="text:1",
+        producer_contract="producer:1",
+        declaration_revision="v1",
+        input_observation_digests=("b", "a"),
+        dependency_factor_digests=("d", "c"),
+    )
+    second = proposal_build_key(
+        canonical_text_digest="text:1",
+        producer_contract="producer:1",
+        declaration_revision="v1",
+        input_observation_digests=("a", "b"),
+        dependency_factor_digests=("c", "d"),
+    )
+    assert first == second
+
+
+def test_cross_document_relation_never_closes_identity() -> None:
+    relation = CrossDocumentRelation(
+        relation_type="AmendmentRelation",
+        source_document_ref="document:amending-act",
+        target_document_ref="document:principal-act",
+        source_coordinate_refs=("span:source",),
+        target_coordinate_refs=("section:45",),
+        evidence_refs=("observation:amends",),
+        residuals=("effective_time_unresolved",),
+    )
+    payload = relation.to_dict()
+    assert payload["identity_closed"] is False
+    assert payload["legal_conclusion_promoted"] is False

--- a/tests/pnf/test_review_coordinates.py
+++ b/tests/pnf/test_review_coordinates.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from src.pnf.review_coordinates import (
+    SemanticReviewAssessment,
+    SemanticReviewCoordinate,
+    project_review_state,
+)
+
+
+def test_review_coordinates_link_proposal_factor_relation_and_build_without_promotion() -> None:
+    coordinate = SemanticReviewCoordinate(
+        target_kind="cross_document_relation",
+        target_ref="cross-document-relation:amendment",
+        document_refs=("document:amending", "document:principal"),
+        coordinate_refs=("span:amends", "section:45"),
+        review_dimension="temporal_validity",
+        residuals=("effective_time_unresolved",),
+    )
+    payload = coordinate.to_dict()
+    assert payload["semantic_state_mutated"] is False
+    assert payload["document_refs"] == ["document:amending", "document:principal"]
+
+
+def test_conflicting_scoped_assessments_remain_contested() -> None:
+    coordinate = SemanticReviewCoordinate(
+        target_kind="reduced_factor",
+        target_ref="factor:prohibition",
+        document_refs=("document:qld-road-rules",),
+        coordinate_refs=("span:must-not-drive",),
+        review_dimension="legal_function",
+    )
+    supported = SemanticReviewAssessment(
+        coordinate_ref=coordinate.coordinate_ref,
+        reviewer_credential_ref="credential:one",
+        institution_ref="institution:qld-a",
+        review_state="supported",
+        rationale_refs=("note:1",),
+    )
+    unsupported = SemanticReviewAssessment(
+        coordinate_ref=coordinate.coordinate_ref,
+        reviewer_credential_ref="credential:two",
+        institution_ref="institution:qld-b",
+        review_state="unsupported",
+        rationale_refs=("note:2",),
+    )
+    projection = project_review_state(
+        coordinate=coordinate,
+        assessments=(unsupported, supported),
+    )
+    assert projection["contested"] is True
+    assert projection["truth_closed"] is False
+    assert projection["semantic_state_promoted"] is False
+
+
+def test_credential_scope_does_not_create_universal_authority() -> None:
+    coordinate = SemanticReviewCoordinate(
+        target_kind="semantic_build",
+        target_ref="legal-semantic-build:1",
+        document_refs=("document:1",),
+        coordinate_refs=(),
+        review_dimension="build_fitness",
+    )
+    assessment = SemanticReviewAssessment(
+        coordinate_ref=coordinate.coordinate_ref,
+        reviewer_credential_ref="credential:accepted",
+        institution_ref="institution:accepted",
+        review_state="supported_with_residuals",
+        rationale_refs=("note:qualified",),
+        residuals=("jurisdiction_unresolved",),
+    )
+    hidden = project_review_state(
+        coordinate=coordinate,
+        assessments=(assessment,),
+        accepted_credential_refs=("credential:other",),
+    )
+    visible = project_review_state(
+        coordinate=coordinate,
+        assessments=(assessment,),
+        accepted_credential_refs=("credential:accepted",),
+    )
+    assert hidden["assessment_refs"] == []
+    assert visible["states"] == ["supported_with_residuals"]

--- a/tests/runtime/test_progress_instrumentation.py
+++ b/tests/runtime/test_progress_instrumentation.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from io import StringIO
+import json
+
+from src.runtime.progress import PhaseRecorder
+
+
+def test_phase_recorder_emits_durable_timing_and_reuse_events(tmp_path) -> None:
+    stream = StringIO()
+    recorder = PhaseRecorder(stream=stream, json_lines=True)
+
+    with recorder.phase("compile_pnf", total=2, details={"workers": 2}) as phase:
+        phase.advance(subject_ref="document:a", reused=True, details={"worker": "document-1"})
+        phase.advance(subject_ref="document:b", reused=False, details={"worker": "document-2"})
+
+    payload = recorder.to_dict()
+    assert payload["schema_version"] == "sl.phase_ledger.v0_1"
+    assert payload["event_count"] == 4
+    assert payload["phase_summary"]["compile_pnf"]["failed"] == 0
+    assert payload["events"][-1]["elapsed_ms"] >= 0
+    assert payload["events"][-1]["details"]["reused_units"] == 1
+
+    output = tmp_path / "phase_ledger.json"
+    recorder.write_json(output)
+    persisted = json.loads(output.read_text())
+    assert persisted == payload
+
+    lines = [json.loads(line) for line in stream.getvalue().splitlines()]
+    assert lines[0]["state"] == "started"
+    assert lines[-1]["state"] == "completed"
+    assert all(row["schema_version"] == "sl.progress_event.v0_2" for row in lines)
+
+
+def test_failed_phase_records_error_without_hiding_exception() -> None:
+    recorder = PhaseRecorder(stream=StringIO(), json_lines=True)
+    try:
+        with recorder.phase("project_legal_ir"):
+            raise ValueError("bad projection")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError")
+
+    event = recorder.events[-1]
+    assert event["state"] == "failed"
+    assert event["details"]["error_type"] == "ValueError"
+    assert recorder.to_dict()["phase_summary"]["project_legal_ir"]["failed"] == 1


### PR DESCRIPTION
## Summary

Implements the attached semantic-build architecture as a bounded, observable catalogue tranche.

### Durable phase instrumentation

- upgrades `src/runtime/progress.py` to structured v0.2 events;
- records started/observed time, elapsed milliseconds, worker identity, reuse state, counters and failure details;
- emits both readable CLI lines and JSONL for GitHub Actions;
- persists `phase_ledger.json` and per-document compilation timings.

### Safe parallelism

- adds document-level PostgreSQL compilation with 1–32 bounded workers;
- gives each worker an independent short-lived PostgreSQL connection;
- keeps corpus admission, duplicate handling, result ordering and manifest publication serialized;
- keeps AustLII acquisition under one shared request governor;
- parallelizes only independent persisted-source copying outside the governed fetch boundary.

### Immutable PNF proposals

- adds content-addressed `FactorProposal`, composition declarations, proposal build keys, deterministic document-local reduction, explicit incompatibility/missing-input residuals and typed cross-document relation candidates;
- workers never mutate a shared graph;
- operator composition now emits proposal and reduction evidence before compatibility projection;
- no proposal reduction closes identity or legal truth.

### Persistence and CI

- adds migration 017 for proposal, dependency, reduction, residual, cross-document relation, current-build pointer and phase-event ledgers;
- adds focused deterministic tests;
- exposes worker controls in the manual catalogue workflow;
- publishes phase timings and slowest document builds in the Actions summary and artifacts.

## Authority boundaries

- document-local reduction is not cross-document identity merging;
- deduplication is not semantic equivalence;
- database success is not promotion;
- cross-document relations remain candidate, provenance-bearing objects;
- identity, applicability, breach, liability and legal truth remain open.