### PR TITLE
Make PNF reduction explicitly fibred and producer-integrated

### DIFF
--- a/.github/workflows/fibred-semantic-producer.yml
+++ b/.github/workflows/fibred-semantic-producer.yml
@@ -9,15 +9,21 @@ on:
       - "src/pnf/factor_proposals.py"
       - "src/pnf/semantic_fibres.py"
       - "src/pnf/integrated_semantic_producer.py"
+      - "src/pnf/fibred_build_projection.py"
+      - "src/pnf/constraint_worklist.py"
       - "src/pnf/streaming_operator_executor.py"
       - "src/pnf/streaming_reduction_projection.py"
       - "src/pnf/__init__.py"
+      - "src/policy/fibred_operational_corpus_compilation.py"
       - "src/policy/streaming_postgres_corpus_compilation.py"
       - "src/storage/postgres/semantic_fibre_store.py"
+      - "scripts/run_legal_pnf_probe.py"
       - "database/postgres_migrations/021_semantic_fibres.sql"
       - "tests/pnf/test_semantic_fibres.py"
       - "tests/pnf/test_integrated_semantic_producer.py"
       - "tests/pnf/test_factor_proposals.py"
+      - "tests/pnf/test_constraint_worklist.py"
+      - "tests/policy/test_fibred_operational_corpus_compilation.py"
       - "docs/dev/FibredSemanticCompiler.md"
       - ".github/workflows/fibred-semantic-producer.yml"
   workflow_dispatch:
@@ -70,14 +76,20 @@ jobs:
             src/pnf/factor_proposals.py \
             src/pnf/semantic_fibres.py \
             src/pnf/integrated_semantic_producer.py \
+            src/pnf/fibred_build_projection.py \
+            src/pnf/constraint_worklist.py \
             src/pnf/streaming_operator_executor.py \
             src/pnf/streaming_reduction_projection.py \
             src/pnf/__init__.py \
+            src/policy/fibred_operational_corpus_compilation.py \
             src/policy/streaming_postgres_corpus_compilation.py \
             src/storage/postgres/semantic_fibre_store.py \
+            scripts/run_legal_pnf_probe.py \
             tests/pnf/test_semantic_fibres.py \
             tests/pnf/test_integrated_semantic_producer.py \
-            tests/pnf/test_factor_proposals.py
+            tests/pnf/test_factor_proposals.py \
+            tests/pnf/test_constraint_worklist.py \
+            tests/policy/test_fibred_operational_corpus_compilation.py
 
       - name: Run fibred compiler tests
         run: |
@@ -85,9 +97,11 @@ jobs:
             tests/pnf/test_semantic_fibres.py \
             tests/pnf/test_integrated_semantic_producer.py \
             tests/pnf/test_factor_proposals.py \
+            tests/pnf/test_constraint_worklist.py \
             tests/pnf/test_streaming_operator_executor.py \
             tests/pnf/test_streaming_fixed_point.py \
-            tests/pnf/test_zelph_closure_executor.py
+            tests/pnf/test_zelph_closure_executor.py \
+            tests/policy/test_fibred_operational_corpus_compilation.py
 
       - name: Validate fibre migration guards
         run: |
@@ -123,6 +137,7 @@ jobs:
           import psycopg
 
           from src.pnf.factor_proposals import FactorProposal, reduce_factor_proposals
+          from src.pnf.semantic_fibres import SemanticCoordinate
           from src.pnf.streaming_fixed_point import ObservationDelta
           from src.storage.postgres.semantic_fibre_store import (
               persist_semantic_fibre_artifacts,
@@ -130,7 +145,6 @@ jobs:
 
           document_ref = 'document:fibre-validation'
           observation_ref = 'observation:must'
-          coordinate_ref = None
           delta = ObservationDelta(
               document_ref=document_ref,
               batch_ref='batch:1',
@@ -152,8 +166,6 @@ jobs:
               coverage_barrier='sentence',
               coverage_complete=True,
           )
-          # Use the canonical coordinate projected by the current parser adapter shape.
-          from src.pnf.semantic_fibres import SemanticCoordinate
           coordinate = SemanticCoordinate(
               document_ref=document_ref,
               scope_ref='sentence:1',
@@ -213,4 +225,43 @@ jobs:
                   )
                   assert cursor.fetchone() == (True, True)
               connection.commit()
+          PY
+
+      - name: Run one fibred Legal PNF probe
+        run: |
+          mkdir -p build/fibred-probe-input
+          printf '%s\n' 'A driver must not drive unless licensed.' > build/fibred-probe-input/norm.txt
+          uv run python scripts/run_legal_pnf_probe.py \
+            --input-file build/fibred-probe-input/norm.txt \
+            --output-dir build/fibred-probe \
+            --max-files 1 \
+            --compare-legacy \
+            --closure-workers 2 \
+            --owner-partitions 2
+          uv run python - <<'PY'
+          import json
+          from pathlib import Path
+
+          summary = json.loads(
+              Path('build/fibred-probe/coverage_scorecard.json').read_text()
+          )
+          assert summary['document_count'] == 1
+          assert summary['fibred_build_count'] == 1
+          assert summary['one_proposal_contract'] is True
+          assert summary['one_reduction_authority'] is True
+          document_dir = next(Path('build/fibred-probe/documents').iterdir())
+          build = json.loads(
+              (document_dir / 'fibred_semantic_build.json').read_text()
+          )
+          assert build['fibre_ledger']['ledger_ref'].startswith(
+              'semantic-fibre-ledger:'
+          )
+          assert build['identity_promoted'] is False
+          assert build['legal_truth_closed'] is False
+          timings = json.loads(
+              (document_dir / 'probe_stage_timings.json').read_text()
+          )
+          stages = {row['stage'] for row in timings['probe_timings']}
+          assert 'fibred_document_compile' in stages
+          assert 'operator_compatibility_projection' not in stages
           PY

--- a/.github/workflows/fibred-semantic-producer.yml
+++ b/.github/workflows/fibred-semantic-producer.yml
@@ -1,0 +1,103 @@
+name: Fibred semantic producer validation
+
+on:
+  push:
+    branches:
+      - agent/fibred-semantic-producer
+  pull_request:
+    paths:
+      - "src/pnf/factor_proposals.py"
+      - "src/pnf/semantic_fibres.py"
+      - "src/pnf/integrated_semantic_producer.py"
+      - "src/pnf/streaming_operator_executor.py"
+      - "src/pnf/streaming_reduction_projection.py"
+      - "src/pnf/__init__.py"
+      - "database/postgres_migrations/021_semantic_fibres.sql"
+      - "tests/pnf/test_semantic_fibres.py"
+      - "tests/pnf/test_integrated_semantic_producer.py"
+      - "tests/pnf/test_factor_proposals.py"
+      - "docs/dev/FibredSemanticCompiler.md"
+      - ".github/workflows/fibred-semantic-producer.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sensiblaw_fibred_validation
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d sensiblaw_fibred_validation"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/sensiblaw_fibred_validation
+      PGHOST: localhost
+      PGPORT: "5432"
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: sensiblaw_fibred_validation
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install environment
+        run: |
+          python -m pip install --upgrade pip uv
+          uv sync --frozen --extra test --extra dev
+
+      - name: Apply migrations
+        run: bash scripts/apply_pg_migrations.sh
+
+      - name: Lint fibred compiler surfaces
+        run: |
+          uv run ruff check \
+            src/pnf/factor_proposals.py \
+            src/pnf/semantic_fibres.py \
+            src/pnf/integrated_semantic_producer.py \
+            src/pnf/streaming_operator_executor.py \
+            src/pnf/streaming_reduction_projection.py \
+            src/pnf/__init__.py \
+            tests/pnf/test_semantic_fibres.py \
+            tests/pnf/test_integrated_semantic_producer.py \
+            tests/pnf/test_factor_proposals.py
+
+      - name: Run fibred compiler tests
+        run: |
+          uv run pytest -q \
+            tests/pnf/test_semantic_fibres.py \
+            tests/pnf/test_integrated_semantic_producer.py \
+            tests/pnf/test_factor_proposals.py \
+            tests/pnf/test_streaming_operator_executor.py \
+            tests/pnf/test_streaming_fixed_point.py
+
+      - name: Validate fibre migration guards
+        run: |
+          python - <<'PY'
+          import os
+          import psycopg
+
+          with psycopg.connect(os.environ['DATABASE_URL']) as connection:
+              with connection.cursor() as cursor:
+                  cursor.execute("SELECT to_regclass('public.semantic_coordinate')")
+                  assert cursor.fetchone()[0] == 'semantic_coordinate'
+                  cursor.execute("SELECT to_regclass('public.semantic_fibre_element')")
+                  assert cursor.fetchone()[0] == 'semantic_fibre_element'
+                  cursor.execute("SELECT to_regclass('public.semantic_transport')")
+                  assert cursor.fetchone()[0] == 'semantic_transport'
+                  cursor.execute("SELECT to_regclass('public.semantic_axis_obligation')")
+                  assert cursor.fetchone()[0] == 'semantic_axis_obligation'
+          PY

--- a/.github/workflows/fibred-semantic-producer.yml
+++ b/.github/workflows/fibred-semantic-producer.yml
@@ -12,6 +12,8 @@ on:
       - "src/pnf/streaming_operator_executor.py"
       - "src/pnf/streaming_reduction_projection.py"
       - "src/pnf/__init__.py"
+      - "src/policy/streaming_postgres_corpus_compilation.py"
+      - "src/storage/postgres/semantic_fibre_store.py"
       - "database/postgres_migrations/021_semantic_fibres.sql"
       - "tests/pnf/test_semantic_fibres.py"
       - "tests/pnf/test_integrated_semantic_producer.py"
@@ -71,6 +73,8 @@ jobs:
             src/pnf/streaming_operator_executor.py \
             src/pnf/streaming_reduction_projection.py \
             src/pnf/__init__.py \
+            src/policy/streaming_postgres_corpus_compilation.py \
+            src/storage/postgres/semantic_fibre_store.py \
             tests/pnf/test_semantic_fibres.py \
             tests/pnf/test_integrated_semantic_producer.py \
             tests/pnf/test_factor_proposals.py
@@ -82,22 +86,131 @@ jobs:
             tests/pnf/test_integrated_semantic_producer.py \
             tests/pnf/test_factor_proposals.py \
             tests/pnf/test_streaming_operator_executor.py \
-            tests/pnf/test_streaming_fixed_point.py
+            tests/pnf/test_streaming_fixed_point.py \
+            tests/pnf/test_zelph_closure_executor.py
 
       - name: Validate fibre migration guards
         run: |
-          python - <<'PY'
+          uv run python - <<'PY'
           import os
           import psycopg
 
+          required = (
+              'semantic_coordinate',
+              'semantic_fibre_element',
+              'semantic_fibre_derivation',
+              'semantic_transport',
+              'semantic_ontology_axis',
+              'semantic_axis_obligation',
+              'semantic_fibre_boundary_obligation',
+              'semantic_fibre_summary',
+              'integrated_semantic_producer_receipt',
+          )
           with psycopg.connect(os.environ['DATABASE_URL']) as connection:
               with connection.cursor() as cursor:
-                  cursor.execute("SELECT to_regclass('public.semantic_coordinate')")
-                  assert cursor.fetchone()[0] == 'semantic_coordinate'
-                  cursor.execute("SELECT to_regclass('public.semantic_fibre_element')")
-                  assert cursor.fetchone()[0] == 'semantic_fibre_element'
-                  cursor.execute("SELECT to_regclass('public.semantic_transport')")
-                  assert cursor.fetchone()[0] == 'semantic_transport'
-                  cursor.execute("SELECT to_regclass('public.semantic_axis_obligation')")
-                  assert cursor.fetchone()[0] == 'semantic_axis_obligation'
+                  for table in required:
+                      cursor.execute(
+                          "SELECT to_regclass(%s)",
+                          (f'public.{table}',),
+                      )
+                      assert cursor.fetchone()[0] == table
+          PY
+
+      - name: Persist one fibred semantic build
+        run: |
+          uv run python - <<'PY'
+          import os
+          import psycopg
+
+          from src.pnf.factor_proposals import FactorProposal, reduce_factor_proposals
+          from src.pnf.streaming_fixed_point import ObservationDelta
+          from src.storage.postgres.semantic_fibre_store import (
+              persist_semantic_fibre_artifacts,
+          )
+
+          document_ref = 'document:fibre-validation'
+          observation_ref = 'observation:must'
+          coordinate_ref = None
+          delta = ObservationDelta(
+              document_ref=document_ref,
+              batch_ref='batch:1',
+              scope_ref='sentence:1',
+              sequence_no=0,
+              parser_contract='parser:test:v1',
+              observation_refs=(observation_ref,),
+              observations=({
+                  'observation_ref': observation_ref,
+                  'observation_type': 'parser.token',
+                  'fibre_kind': 'observation',
+                  'token': {'text': 'must', 'index': 0},
+              },),
+              token_start=0,
+              token_end=1,
+              char_start=0,
+              char_end=4,
+              token_count=1,
+              coverage_barrier='sentence',
+              coverage_complete=True,
+          )
+          # Use the canonical coordinate projected by the current parser adapter shape.
+          from src.pnf.semantic_fibres import SemanticCoordinate
+          coordinate = SemanticCoordinate(
+              document_ref=document_ref,
+              scope_ref='sentence:1',
+              source_span_refs=(observation_ref,),
+              statement_role='parser_observation',
+              factor_family='parser.token',
+          )
+          delta_row = delta.to_dict()
+          delta_row['observations'][0]['semantic_coordinate_ref'] = coordinate.coordinate_ref
+          proposal = FactorProposal(
+              document_ref=document_ref,
+              source_revision_ref='source:1',
+              factor_type_ref='semantic.normative_relation',
+              source_span_refs=('span:1',),
+              input_observation_refs=(observation_ref,),
+              dependency_factor_refs=(),
+              structural_signature='normative:v1',
+              role_bindings={'conduct': 'eventuality:drive'},
+              qualifier_state={'modality': 'obligation'},
+              producer_contract='operator:test:v1',
+              declaration_revision='v1',
+              candidate_payload={'predicate_ref': 'normative.obligation'},
+              scope_ref='sentence:1',
+              fibre_kind='composition',
+          )
+          reduction = reduce_factor_proposals(
+              document_ref=document_ref,
+              proposals=(proposal,),
+              known_observation_refs=(observation_ref,),
+          )
+          with psycopg.connect(os.environ['DATABASE_URL']) as connection:
+              with connection.cursor() as cursor:
+                  receipt = persist_semantic_fibre_artifacts(
+                      cursor,
+                      document_ref=document_ref,
+                      observation_deltas=(delta_row,),
+                      proposals=(proposal.to_dict(),),
+                      solver_jobs=(),
+                      solver_receipts=(),
+                      materialized_reduction=reduction.to_dict(),
+                  )
+                  assert receipt.fibre_ledger_ref.startswith('semantic-fibre-ledger:')
+                  cursor.execute(
+                      'SELECT count(*) FROM semantic_fibre_element WHERE document_ref = %s',
+                      (document_ref,),
+                  )
+                  assert cursor.fetchone()[0] == 2
+                  cursor.execute(
+                      'SELECT count(*) FROM semantic_fibre_summary WHERE document_ref = %s',
+                      (document_ref,),
+                  )
+                  assert cursor.fetchone()[0] == 1
+                  cursor.execute(
+                      'SELECT one_proposal_contract, one_reduction_authority '
+                      'FROM integrated_semantic_producer_receipt WHERE document_ref = %s',
+                      (document_ref,),
+                  )
+                  assert cursor.fetchone() == (True, True)
+              connection.commit()
           PY

--- a/database/postgres_migrations/021_semantic_fibres.sql
+++ b/database/postgres_migrations/021_semantic_fibres.sql
@@ -1,0 +1,203 @@
+BEGIN;
+
+ALTER TABLE pnf_factor_proposal
+    ADD COLUMN IF NOT EXISTS semantic_coordinate_ref TEXT,
+    ADD COLUMN IF NOT EXISTS scope_ref TEXT,
+    ADD COLUMN IF NOT EXISTS statement_role TEXT NOT NULL DEFAULT 'main',
+    ADD COLUMN IF NOT EXISTS coordinate_kind TEXT NOT NULL DEFAULT 'object',
+    ADD COLUMN IF NOT EXISTS fibre_kind TEXT NOT NULL DEFAULT 'hypothesis',
+    ADD COLUMN IF NOT EXISTS derivation_role TEXT NOT NULL DEFAULT 'support',
+    ADD COLUMN IF NOT EXISTS producer_scope TEXT NOT NULL DEFAULT 'integrated',
+    ADD COLUMN IF NOT EXISTS operation_contract TEXT,
+    ADD COLUMN IF NOT EXISTS ontology_axis_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS transport_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS support_state TEXT NOT NULL DEFAULT 'candidate',
+    ADD COLUMN IF NOT EXISTS confidence DOUBLE PRECISION,
+    ADD COLUMN IF NOT EXISTS assumptions JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS coverage_requirements JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS execution_metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE INDEX IF NOT EXISTS pnf_factor_proposal_coordinate_idx
+    ON pnf_factor_proposal
+    (document_ref, semantic_coordinate_ref, fibre_kind, factor_type_ref);
+
+CREATE TABLE IF NOT EXISTS semantic_coordinate (
+    coordinate_ref TEXT PRIMARY KEY,
+    document_ref TEXT NOT NULL,
+    scope_ref TEXT NOT NULL,
+    source_span_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    statement_role TEXT NOT NULL,
+    factor_family TEXT NOT NULL,
+    coordinate_kind TEXT NOT NULL CHECK (
+        coordinate_kind IN ('object', 'morphism', 'obligation', 'external')
+    ),
+    source_coordinate_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    target_coordinate_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS semantic_coordinate_document_idx
+    ON semantic_coordinate (document_ref, scope_ref, factor_family);
+
+CREATE TABLE IF NOT EXISTS semantic_fibre_element (
+    element_ref TEXT PRIMARY KEY,
+    document_ref TEXT NOT NULL,
+    coordinate_ref TEXT NOT NULL REFERENCES semantic_coordinate(coordinate_ref),
+    fibre_kind TEXT NOT NULL CHECK (fibre_kind IN (
+        'observation', 'hypothesis', 'composition', 'constraint',
+        'consequence', 'enrichment', 'residual', 'review'
+    )),
+    content_ref TEXT NOT NULL,
+    derivation_role TEXT NOT NULL CHECK (
+        derivation_role IN ('support', 'contradict', 'undetermined', 'transport')
+    ),
+    producer_contract TEXT NOT NULL,
+    operation_contract TEXT NOT NULL,
+    source_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    dependency_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    transport_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ontology_axis_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    assumptions JSONB NOT NULL DEFAULT '[]'::jsonb,
+    coverage_requirements JSONB NOT NULL DEFAULT '[]'::jsonb,
+    support_state TEXT NOT NULL,
+    confidence DOUBLE PRECISION CHECK (
+        confidence IS NULL OR (confidence >= 0.0 AND confidence <= 1.0)
+    ),
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    external BOOLEAN NOT NULL DEFAULT FALSE,
+    execution_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    authority TEXT NOT NULL CHECK (
+        authority IN ('candidate_only', 'external_candidate')
+    ),
+    semantic_state_promoted BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (semantic_state_promoted = FALSE),
+    legal_truth_closed BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (legal_truth_closed = FALSE),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (coordinate_ref, content_ref, producer_contract, operation_contract)
+);
+
+CREATE INDEX IF NOT EXISTS semantic_fibre_element_coordinate_idx
+    ON semantic_fibre_element
+    (document_ref, coordinate_ref, fibre_kind, derivation_role);
+
+CREATE TABLE IF NOT EXISTS semantic_fibre_derivation (
+    derivation_ref TEXT PRIMARY KEY,
+    document_ref TEXT NOT NULL,
+    operation_kind TEXT NOT NULL,
+    declaration_ref TEXT NOT NULL,
+    producer_contract TEXT NOT NULL,
+    input_element_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    output_element_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    sub_executor_ref TEXT NOT NULL,
+    rule_set_revision TEXT NOT NULL,
+    receipt_ref TEXT,
+    assumptions JSONB NOT NULL DEFAULT '[]'::jsonb,
+    metrics JSONB NOT NULL DEFAULT '{}'::jsonb,
+    semantic_state_promoted BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (semantic_state_promoted = FALSE),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS semantic_transport (
+    transport_ref TEXT PRIMARY KEY,
+    document_ref TEXT NOT NULL,
+    source_coordinate_ref TEXT NOT NULL,
+    target_coordinate_ref TEXT NOT NULL,
+    transport_type TEXT NOT NULL,
+    strength TEXT NOT NULL CHECK (
+        strength IN ('discoverable', 'candidate', 'close', 'exact', 'identity')
+    ),
+    evidence_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ontology_axis_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    allowed_operations JSONB NOT NULL DEFAULT '[]'::jsonb,
+    residual_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    identity_closed BOOLEAN NOT NULL DEFAULT FALSE CHECK (identity_closed = FALSE),
+    semantic_state_promoted BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (semantic_state_promoted = FALSE),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (source_coordinate_ref <> target_coordinate_ref),
+    CHECK (strength <> 'discoverable' OR NOT (allowed_operations ? 'substitute'))
+);
+
+CREATE TABLE IF NOT EXISTS semantic_ontology_axis (
+    axis_ref TEXT PRIMARY KEY,
+    label TEXT NOT NULL,
+    authority_ref TEXT NOT NULL,
+    relation_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    root_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    open_world BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS semantic_axis_obligation (
+    obligation_ref TEXT PRIMARY KEY,
+    document_ref TEXT NOT NULL,
+    coordinate_ref TEXT NOT NULL,
+    axis_ref TEXT NOT NULL REFERENCES semantic_ontology_axis(axis_ref),
+    obligation_type TEXT NOT NULL,
+    trigger_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    frontier_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    state TEXT NOT NULL CHECK (state IN (
+        'open', 'satisfied', 'contradicted', 'both',
+        'undetermined', 'inapplicable'
+    )),
+    resource_limit_reached BOOLEAN NOT NULL DEFAULT FALSE,
+    truth_closed BOOLEAN NOT NULL DEFAULT FALSE CHECK (truth_closed = FALSE),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS semantic_fibre_boundary_obligation (
+    boundary_ref TEXT PRIMARY KEY,
+    document_ref TEXT NOT NULL,
+    coordinate_ref TEXT NOT NULL,
+    scope_ref TEXT NOT NULL,
+    boundary_kind TEXT NOT NULL,
+    evidence_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    frontier_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    required_axis_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    state TEXT NOT NULL CHECK (state IN ('open', 'discharged', 'external')),
+    message TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS semantic_fibre_summary (
+    factor_ref TEXT PRIMARY KEY,
+    graph_ref TEXT NOT NULL,
+    document_ref TEXT NOT NULL,
+    semantic_coordinate_ref TEXT NOT NULL,
+    fibre_kind TEXT NOT NULL,
+    factor_type_ref TEXT NOT NULL,
+    structural_signature TEXT NOT NULL,
+    proposal_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    derivation_roles JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ontology_axis_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    transport_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    support_states JSONB NOT NULL DEFAULT '[]'::jsonb,
+    residual_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    deterministic_materialisation BOOLEAN NOT NULL DEFAULT TRUE
+        CHECK (deterministic_materialisation = TRUE),
+    identity_promoted BOOLEAN NOT NULL DEFAULT FALSE CHECK (identity_promoted = FALSE),
+    legal_truth_closed BOOLEAN NOT NULL DEFAULT FALSE CHECK (legal_truth_closed = FALSE),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS integrated_semantic_producer_receipt (
+    receipt_ref TEXT PRIMARY KEY,
+    document_ref TEXT NOT NULL,
+    contract_ref TEXT NOT NULL,
+    proposal_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    sub_executor_receipt_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    fibre_ledger_ref TEXT NOT NULL,
+    residual_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    external_proposal_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    one_proposal_contract BOOLEAN NOT NULL DEFAULT TRUE
+        CHECK (one_proposal_contract = TRUE),
+    one_reduction_authority BOOLEAN NOT NULL DEFAULT TRUE
+        CHECK (one_reduction_authority = TRUE),
+    identity_promoted BOOLEAN NOT NULL DEFAULT FALSE CHECK (identity_promoted = FALSE),
+    legal_truth_closed BOOLEAN NOT NULL DEFAULT FALSE CHECK (legal_truth_closed = FALSE),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMIT;

--- a/docs/dev/FibredSemanticCompiler.md
+++ b/docs/dev/FibredSemanticCompiler.md
@@ -1,0 +1,369 @@
+# Fibred Semantic Compiler
+
+## Status
+
+This document defines the semantic organisation implemented by the SensibLaw
+PNF compiler after the streaming fixed-point tranche.
+
+`ITIR-suite` is the suite-level control and handoff surface. `SensibLaw` owns the
+substantive deterministic semantic compiler, proposal contract, PNF reduction,
+and immutable build evidence. The fibred algebra therefore lives here rather
+than in a second suite-level implementation.
+
+## Consolidation rule
+
+The compiler has:
+
+```text
+one broad integrated semantic producer
++ one immutable proposal contract
++ one deterministic fibrewise PNF reduction boundary
+```
+
+This does **not** mean one process, model, or algorithm. Parser pools, closure
+workers, linking indexes, ontology lookups, and learned scorers may execute in
+parallel. They implement one versioned semantic producer family and cannot
+publish competing authoritative graphs.
+
+Ordinary core proposals identify:
+
+```text
+producer_contract = integrated-semantic-producer:v0_1
+operation_contract = the typing/linking/composition/closure contract used
+execution_metadata.sub_executor_ref = Python, Zelph, parser, index, or model
+```
+
+Executor telemetry is deliberately excluded from proposal identity. Two
+backends that derive the same semantic proposal therefore receive the same
+proposal reference. Their different runtimes and receipts remain auditable.
+
+External learners, LLM suggestions, imported assertions, and third-party
+repair systems remain distinguishable with `producer_scope=external`. They use
+the same proposal shape and reducer but retain their own producer authority.
+
+## Base coordinates
+
+Let \(\mathcal C\) be the base category of semantic coordinates. An implemented
+coordinate records:
+
+```text
+document
+scope
+source spans
+statement role
+factor family
+coordinate kind
+```
+
+Coordinate kinds are:
+
+```text
+object       a semantic object or question
+morphism     a candidate relation such as scope or attachment
+obligation   a validation, coverage, or ontology-axis demand
+external     a coordinate in an external knowledge base
+```
+
+Statement role is part of the coordinate. A property in a main statement and
+the same property in a qualifier do not occupy the same fibre merely because
+they share a surface predicate and span neighbourhood.
+
+## Fibres
+
+The total semantic evidence space projects to the base:
+
+\[
+\pi : \mathcal E \to \mathcal C.
+\]
+
+For a coordinate \(c\), its fibre is:
+
+\[
+\mathcal E_c = \pi^{-1}(c).
+\]
+
+A fibre may contain:
+
+```text
+observations
+hypotheses
+composed candidates
+constraint findings
+logical consequences
+enrichment evidence
+residuals
+review evidence
+```
+
+Every element is immutable and content-addressed. It retains its producer,
+operation, sources, dependencies, transports, ontology axes, assumptions,
+coverage requirements, support state, optional score, and candidate payload.
+
+The fibre ledger joins by set union over content identities. Its merge is
+associative, commutative, and idempotent.
+
+## Observation sections
+
+spaCy is an observation adapter rather than a semantic authority. It emits
+source-grounded token, lemma, part-of-speech, morphology, dependency, and
+sentence-boundary records.
+
+Each parser observation names an observation coordinate and populates its
+observation fibre. Different parser implementations can provide different
+sections over the same canonical text coordinate without changing the semantic
+base.
+
+Parser output remains fallible evidence:
+
+```text
+parser observation != semantic assertion
+```
+
+## Typing as lifting
+
+Semantic typing lifts observation elements into hypothesis fibres:
+
+\[
+\operatorname{Lift}_{type}(o) \subseteq \mathcal H_c.
+\]
+
+One observation may support several type candidates. The multiplicity is
+preserved rather than collapsed before constraints or wider context can act.
+
+Typing operations use the integrated proposal contract with
+`fibre_kind=hypothesis` and retain their own operation declaration.
+
+## Linking as controlled transport
+
+Entity and concept linking relate local text coordinates to external knowledge
+coordinates. A link is represented as a `SemanticTransport`, not as an
+unqualified rewrite.
+
+A transport declares:
+
+```text
+source and target coordinates
+transport type
+strength
+evidence
+ontology axes
+allowed operations
+residuals
+```
+
+Transport strengths include discoverable, candidate, close, exact, and
+identity. A discoverable relation such as `rdfs:seeAlso` may permit inspection
+or enrichment but is forbidden from permitting unrestricted substitution.
+Every transport record keeps `identity_closed=false` and
+`semantic_state_promoted=false`.
+
+This allows selected external evidence to be reindexed into a local fibre
+without collapsing the local and external coordinates.
+
+## Scope and attachment as base morphisms
+
+Scope and attachment proposals are candidate morphisms in the base. The edge
+itself has a fibre containing syntax, containment, typing compatibility,
+competing hosts, learned scores, rule support, and coverage evidence.
+
+A semantic edge is therefore not merely present or absent. It is a coordinate
+with a provenance-bearing fibre of candidate derivations.
+
+## Composition as compatible fibre product
+
+Operator composition constructs higher-order coordinates from diagrams of
+compatible lower-order elements. For a modal, eventuality, negation, and their
+scope candidates, the composed fibre is drawn from a compatible subset of the
+corresponding product:
+
+\[
+\mathcal E_k \subseteq
+\mathcal E_m \times \mathcal E_e \times \mathcal E_n
+\times \mathcal E_{m\to e} \times \mathcal E_{n\to e}.
+\]
+
+This makes the optimisation rule precise:
+
+```text
+reduce cheap duplicates and impossible candidates inside input fibres
+before taking expensive compositional fibre products
+```
+
+The streaming operator adapter now emits composition fibre proposals at an
+explicit sentence coordinate and records coverage requirements and assumptions.
+
+## Constraints and validation fibres
+
+Constraints inspect elements and transports associated with one or more
+coordinates. They can reject impossible combinations, preserve alternatives,
+introduce residuals, or create new validation and ontology-axis obligations.
+
+Validation is five-way:
+
+```text
+satisfied
+violated
+both
+undetermined
+inapplicable
+```
+
+The outcome is computed from supporting, contradicting, and unresolved fibre
+elements plus applicability and coverage. Absence of a contradiction does not
+become satisfaction, and incomplete ontology traversal does not become a
+violation.
+
+## Ontology subfibrations and domain-specific pressure
+
+Wikidata is not treated as one complete universal type lattice. Named ontology
+axes are first-class versioned subfibrations. Examples may include
+bibliographic, legal, biological, event, media, or BFO continuant/occurrent
+axes.
+
+A coordinate can have a rich fibre on one axis and an empty or unresolved fibre
+on another. A domain constraint can create an `AxisObligation` requesting
+classification evidence along the required axis.
+
+An axis result records its current state and frontier. Resource exhaustion is
+not closure, and every axis obligation keeps `truth_closed=false`.
+
+## Closure
+
+Logical closure monotonically extends fibres:
+
+\[
+\mathcal E_c^{n+1} = \mathcal E_c^n \sqcup \Delta\mathcal E_c.
+\]
+
+Python and Zelph implement the same internal `ClosureExecutor` boundary. They
+receive immutable revision-bound jobs and return proposal receipts. Neither
+backend owns semantic state or materialises a graph.
+
+For ordinary closure rules, decoded results are normalised under the integrated
+producer family. Backend identity remains in sub-executor and solver receipts,
+not in proposal identity. Exact proposal and reduction parity is therefore a
+meaningful backend comparison.
+
+Structural document closure and ontological closure remain separate operation
+contracts, rule revisions, provenance, cost centres, and authority contexts,
+even though both populate the same fibred state.
+
+## Learned and LLM components
+
+A learned model contributes candidate elements or an ordering within a fibre.
+For example, a country predictor can contribute scored link hypotheses, and an
+attachment model can contribute scored morphisms.
+
+A constrained lattice model may guarantee monotone or shape-constrained scoring
+behaviour. It still does not materialise the canonical factor. An LLM likewise
+may contribute external candidate derivations but cannot bypass the reducer.
+
+If a learned capability becomes stable, broad, and core, it can be absorbed as
+an internal capability of the integrated producer while retaining its model
+revision and execution receipt.
+
+## Residuals and boundary data
+
+Residuals are not discarded failures. They identify incomplete, conflicted, or
+externally dependent fibres. Examples include unresolved typing, competing
+attachments, unopened ontology axes, incomplete coverage, or unresolved
+identity candidates.
+
+A `FibreBoundaryObligation` exports the unresolved frontier from a local region.
+Regional and document coordinators route only these boundaries rather than
+recomputing every local fibre.
+
+A document fixed point requires no runnable local boundary obligation. External
+residuals may remain explicit.
+
+## Deterministic fibrewise reduction
+
+For each coordinate \(c\), the reducer computes a canonical summary:
+
+\[
+\rho_c(\mathcal E_c) = (F_c, A_c, R_c, D_c),
+\]
+
+where:
+
+```text
+F_c compatible factor representatives
+A_c retained alternatives
+R_c residual obligations
+D_c derivation and provenance evidence
+```
+
+The implementation groups by:
+
+```text
+semantic coordinate
+fibre kind
+factor type
+structural signature
+```
+
+Only proposals within the same fibre compete. Similar proposals at different
+statement roles or semantic coordinates remain separate. Incompatible contents
+inside one fibre remain explicit alternatives with a conflict residual.
+
+The global PNF graph is a deterministic materialised view over these fibrewise
+summaries. No parser, Python rule, Zelph rule, learner, ontology linker, or LLM
+publishes an independent authoritative graph.
+
+## Active execution flow
+
+```text
+canonical text
+→ parser observation fibres
+→ atomic typing/linking/role hypotheses
+→ early fibre reduction
+→ scope and attachment morphisms
+→ compatible composition fibres
+→ compositional reduction
+→ affected constraints and axis obligations
+→ Python/Zelph consequence extensions
+→ demand-driven external enrichment
+→ affected fibre reductions
+→ residual boundary routing
+→ document-local fixed point
+→ refined PNF
+→ Legal IR / PostgreSQL / SPARQL / MCP / LLM projections
+```
+
+This is iterative and delta-driven. A changed coordinate schedules only its
+dependent fibres and constraints.
+
+## Persistence
+
+Migration `021_semantic_fibres.sql` extends proposal persistence and adds:
+
+```text
+semantic_coordinate
+semantic_fibre_element
+semantic_fibre_derivation
+semantic_transport
+semantic_ontology_axis
+semantic_axis_obligation
+semantic_fibre_boundary_obligation
+semantic_fibre_summary
+integrated_semantic_producer_receipt
+```
+
+The persistence layer derives the fibred view from the ordinary streaming
+ledger and stores it in the same document transaction. Database checks prohibit
+identity promotion, legal-truth closure, or transport-driven semantic promotion.
+
+## Compatibility and migration
+
+Existing proposal constructors remain valid. Core proposals that formerly
+identified independent Python, operator, or linking producers are automatically
+normalised to the integrated producer family, while the former producer value
+becomes `operation_contract`.
+
+Existing executors and keyed owners remain the operational substrate. This
+tranche does not introduce a second fibre engine or reducer. It makes the
+already-streamed semantic state explicit as fibres and changes deterministic
+reduction identity accordingly.
+
+The suite-level integration surface may expose these receipts later through
+MCP, but substantive semantic logic remains in SensibLaw.

--- a/scripts/run_legal_pnf_probe.py
+++ b/scripts/run_legal_pnf_probe.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run a bounded legal-document probe through the streaming compiler spine."""
+"""Run a bounded legal-document probe through the fibred compiler spine."""
 
 from __future__ import annotations
 
@@ -24,12 +24,10 @@ from src.ontology.wikimedia_providers import (  # noqa: E402
 )
 from src.pnf.legal_probe import build_legal_pnf_probe  # noqa: E402
 from src.pnf.legal_semantic_build import build_legal_semantic_build  # noqa: E402
-from src.pnf.operator_composition_bridge import (  # noqa: E402
-    apply_operator_composition_to_compilation,
-)
 from src.policy.corpus_compilation import default_compiler_context  # noqa: E402
-from src.policy.operational_corpus_compilation import (  # noqa: E402
-    compile_document_operational,
+from src.policy.fibred_operational_corpus_compilation import (  # noqa: E402
+    FIBRED_OPERATIONAL_COMPILER_CONTRACT,
+    compile_document_fibred_operational,
 )
 
 
@@ -113,7 +111,7 @@ def _compile_projection_row(
 ) -> Mapping[str, Any]:
     canonical_path = projection_root / row.canonical_path
     canonical_text = canonical_path.read_text(encoding="utf-8")
-    compilation = compile_document_operational(
+    compilation = compile_document_fibred_operational(
         {
             "document_ref": _document_ref(row.canonical_sha256),
             "source_ref": row.source_ref,
@@ -188,33 +186,29 @@ def main() -> int:
         compilation = _timed(
             document_timings,
             document_ref=document_ref,
-            stage="streaming_document_compile",
+            stage="fibred_document_compile",
             operation=lambda: _compile_projection_row(
                 row,
                 projection_root,
                 closure_workers=args.closure_workers,
                 owner_partitions=args.owner_partitions,
             ),
-            backend_ref="streaming-semantic-owner:v0_1",
+            backend_ref=FIBRED_OPERATIONAL_COMPILER_CONTRACT,
         )
-        base_artifacts = compilation.get("artifacts") or {}
-        streaming = base_artifacts.get("streaming_semantic_build") or {}
+        artifacts = compilation.get("artifacts") or {}
+        streaming = artifacts.get("streaming_semantic_build") or {}
         certificate = streaming.get("fixed_point_certificate") or {}
         if certificate.get("local_fixed_point") != "reached":
             raise ValueError(
                 "Legal IR projection requires a reached local fixed point"
             )
+        if not streaming.get("one_reduction_authority"):
+            raise ValueError(
+                "Legal IR projection requires the fibred reduction authority"
+            )
+        if not artifacts.get("fibred_semantic_build"):
+            raise ValueError("fibred semantic build evidence is missing")
 
-        compilation = _timed(
-            document_timings,
-            document_ref=document_ref,
-            stage="operator_compatibility_projection",
-            operation=lambda: apply_operator_composition_to_compilation(
-                compilation
-            ),
-            backend_ref="pnf-operator-composition-bridge:v0_1",
-        )
-        artifacts = compilation.get("artifacts") or {}
         canonical_text = str(artifacts.get("canonical_text") or "")
         legacy = (
             _timed(
@@ -255,9 +249,13 @@ def main() -> int:
             details={
                 "fixed_point_certificate_ref": certificate.get(
                     "certificate_ref"
-                )
+                ),
+                "fibre_ledger_ref": streaming.get("fibre_ledger_ref"),
             },
         )
+        projection_receipt = artifacts.get(
+            "streaming_reduction_projection"
+        ) or {}
         semantic_build = _timed(
             document_timings,
             document_ref=document_ref,
@@ -268,12 +266,7 @@ def main() -> int:
                 legacy_rows=legacy,
                 declaration_revision_refs=(
                     *(artifacts.get("semantic_reduction_refs") or ()),
-                    str(
-                        (
-                            artifacts.get("operator_composition") or {}
-                        ).get("contract_ref")
-                        or ""
-                    ),
+                    str(projection_receipt.get("contract_ref") or ""),
                 ),
             ),
         )
@@ -290,6 +283,14 @@ def main() -> int:
         _write_json(
             document_dir / "refined_pnf_graph.json",
             probe["refined_pnf_graph"],
+        )
+        _write_json(
+            document_dir / "fibred_semantic_build.json",
+            artifacts["fibred_semantic_build"],
+        )
+        _write_json(
+            document_dir / "streaming_reduction_projection.json",
+            projection_receipt,
         )
         _write_json(document_dir / "legal_ir.json", probe["legal_ir"])
         _write_json(
@@ -327,9 +328,10 @@ def main() -> int:
         _write_json(
             document_dir / "probe_stage_timings.json",
             {
-                "schema_version": "sl.legal_probe_stage_timings.v0_1",
+                "schema_version": "sl.legal_probe_stage_timings.v0_2",
                 "document_ref": document_ref,
                 "fixed_point_certificate": certificate,
+                "fibre_ledger_ref": streaming.get("fibre_ledger_ref"),
                 "compiler_stage_timings": (
                     artifacts.get("semantic_stage_timing") or {}
                 ),
@@ -349,12 +351,14 @@ def main() -> int:
                 "summary": {**probe["summary"], **semantic_build["summary"]},
                 "document_output_dir": str(document_dir),
                 "parser_receipt": artifacts.get("parser_receipt") or {},
-                "operator_composition": (
-                    artifacts.get("operator_composition") or {}
-                ),
+                "streaming_reduction_projection": projection_receipt,
                 "fixed_point_certificate_ref": certificate.get(
                     "certificate_ref"
                 ),
+                "fibre_ledger_ref": streaming.get("fibre_ledger_ref"),
+                "integrated_producer_receipt_ref": (
+                    streaming.get("integrated_producer_receipt") or {}
+                ).get("receipt_ref"),
                 "stage_build_keys": artifacts.get("stage_build_keys") or {},
             }
         )
@@ -376,7 +380,7 @@ def main() -> int:
                 surface=str(row["surface"]),
                 demand_kind=str(row["demand_kind"]),
                 local_type_refs=tuple(row.get("local_type_refs") or ()),
-                context_terms=tuple(row.get("context_terms") or ()),
+                candidate_limit=int(row.get("candidate_limit") or 5),
                 priority=int(row.get("priority") or 0),
                 provenance_refs=tuple(row.get("provenance_refs") or ()),
             )
@@ -401,10 +405,11 @@ def main() -> int:
     _write_json(output_dir / "wikidata_results.json", wikidata_output)
 
     timing_summary = {
-        "schema_version": "sl.legal_probe_timing_summary.v0_1",
+        "schema_version": "sl.legal_probe_timing_summary.v0_2",
         "runtime": {
             "closure_workers": args.closure_workers,
             "owner_partitions": args.owner_partitions,
+            "compiler_contract": FIBRED_OPERATIONAL_COMPILER_CONTRACT,
         },
         "aggregate": _aggregate_timings(all_timings),
         "timings": all_timings,
@@ -414,7 +419,7 @@ def main() -> int:
         timing_summary,
     )
     summary = {
-        "schema_version": "sl.legal_pnf_probe_run.v0_4",
+        "schema_version": "sl.legal_pnf_probe_run.v0_5",
         "source_projection": str(projection_root / "manifest.json"),
         "documents": probe_rows,
         "document_count": len(probe_rows),
@@ -433,7 +438,7 @@ def main() -> int:
         ),
         "operator_factor_count": sum(
             int(
-                (row.get("operator_composition") or {}).get(
+                (row.get("streaming_reduction_projection") or {}).get(
                     "factor_count"
                 )
                 or 0
@@ -444,6 +449,9 @@ def main() -> int:
             bool(row.get("fixed_point_certificate_ref"))
             for row in probe_rows
         ),
+        "fibred_build_count": sum(
+            bool(row.get("fibre_ledger_ref")) for row in probe_rows
+        ),
         "semantic_stage_timings": "semantic_stage_timings.json",
         "wikidata_lookup_demand_count": len(wikidata_demands),
         "wikidata_network_performed": wikidata_output[
@@ -451,6 +459,8 @@ def main() -> int:
         ],
         "identity_closure_count": 0,
         "legal_conclusion_promotion_count": 0,
+        "one_proposal_contract": True,
+        "one_reduction_authority": True,
         "authority": "diagnostic_build_index",
     }
     _write_json(output_dir / "coverage_scorecard.json", summary)

--- a/src/pnf/__init__.py
+++ b/src/pnf/__init__.py
@@ -1,4 +1,4 @@
-"""Factorized PNF graph primitives."""
+"""Factorized PNF graph and fibred semantic compiler primitives."""
 
 from .binding_candidate_sets import (
     BindingAccessibilityDeclaration,
@@ -12,6 +12,7 @@ from .binding_candidate_sets import (
 from .closure import ClosureContract, assess_pnf_closure
 from .demands import derive_resolution_demands
 from .factor_proposals import (
+    INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
     CompositionDeclaration,
     CrossDocumentRelation,
     FactorProposal,
@@ -22,6 +23,13 @@ from .factor_proposals import (
     reduce_factor_proposals,
 )
 from .graph import PNFGraph
+from .integrated_semantic_producer import (
+    IntegratedProducerContract,
+    IntegratedProducerReceipt,
+    IntegratedSemanticProducer,
+    ProducerCapability,
+    SubExecutorReceipt,
+)
 from .operational_reference_binding import (
     REFERENCE_BINDING_CONTRACT_REF,
     REFERENCE_REDUCTION_DECLARATION_REF,
@@ -35,6 +43,19 @@ from .review_coordinates import (
     project_review_state,
 )
 from .revision_normalization import normalize_factor_revision_artifacts
+from .semantic_fibres import (
+    AxisObligation,
+    FibreBoundaryObligation,
+    FibreDerivation,
+    FibreElement,
+    FibreValidation,
+    OntologyAxis,
+    SemanticCoordinate,
+    SemanticFibreLedger,
+    SemanticTransport,
+    evaluate_fibre,
+    fibre_element_from_proposal_row,
+)
 from .stage_build_keys import StageBuildKeys, derive_stage_build_keys
 from .streaming_fixed_point import (
     ClosureExecutor,
@@ -56,6 +77,8 @@ from .streaming_fixed_point import (
 )
 
 __all__ = [
+    "INTEGRATED_SEMANTIC_PRODUCER_CONTRACT",
+    "AxisObligation",
     "BindingAccessibilityDeclaration",
     "BindingCandidateMember",
     "BindingCandidateSet",
@@ -70,9 +93,18 @@ __all__ = [
     "DocumentFixedPointCertificate",
     "FactorAnchor",
     "FactorProposal",
+    "FibreBoundaryObligation",
+    "FibreDerivation",
+    "FibreElement",
+    "FibreValidation",
+    "IntegratedProducerContract",
+    "IntegratedProducerReceipt",
+    "IntegratedSemanticProducer",
     "ObservationDelta",
+    "OntologyAxis",
     "OwnerKey",
     "PNFGraph",
+    "ProducerCapability",
     "ProposalReduction",
     "PythonClosureExecutor",
     "REFERENCE_BINDING_CONTRACT_REF",
@@ -80,14 +112,18 @@ __all__ = [
     "ReducedFactor",
     "ReductionResidual",
     "RegionBoundarySummary",
+    "SemanticCoordinate",
+    "SemanticFibreLedger",
     "SemanticReviewAssessment",
     "SemanticReviewCoordinate",
+    "SemanticTransport",
     "SolverJob",
     "SolverReceipt",
     "StageBuildKeys",
     "StateDelta",
     "StreamingDeclaration",
     "StreamingSemanticOwner",
+    "SubExecutorReceipt",
     "assert_finalising_claim_allowed",
     "assess_pnf_closure",
     "build_operational_reference_binding_artifacts",
@@ -95,7 +131,9 @@ __all__ = [
     "compact_binding_artifacts",
     "derive_resolution_demands",
     "derive_stage_build_keys",
+    "evaluate_fibre",
     "execute_ready_jobs",
+    "fibre_element_from_proposal_row",
     "normalize_factor_revision_artifacts",
     "owner_partition",
     "project_pronominal_reference_arguments",

--- a/src/pnf/constraint_worklist.py
+++ b/src/pnf/constraint_worklist.py
@@ -1,7 +1,9 @@
 """Adjacency-indexed, document-local constraint propagation.
 
-Only constraints incident on changed factors are placed on the worklist.  Assessments are
-immutable candidate-only evidence and never close a factor, identity, or legal conclusion.
+Only constraints incident on changed factors are placed on the worklist. An
+initial build evaluates every declared constraint; an incremental change with
+no incident constraints performs zero work. Assessments are immutable
+candidate-only evidence and never close a factor, identity, or legal conclusion.
 """
 
 from __future__ import annotations
@@ -14,7 +16,7 @@ from src.policy.algebra import ConstraintAssessment, FactorConstraint
 from src.policy.carriers.canonical import canonical_sha256
 
 
-CONSTRAINT_WORKLIST_SCHEMA_VERSION = "sl.pnf.constraint_worklist.v0_1"
+CONSTRAINT_WORKLIST_SCHEMA_VERSION = "sl.pnf.constraint_worklist.v0_2"
 
 _SUPPORTED_STRUCTURAL_CONSTRAINTS = {
     "syntactic_subject_of",
@@ -33,16 +35,20 @@ class ConstraintWorkItem:
     constraint_ref: str
     incident_factor_refs: tuple[str, ...]
     triggering_factor_refs: tuple[str, ...]
+    propagation_wave: int = 0
 
     @property
     def work_ref(self) -> str:
-        return "constraint-work:" + canonical_sha256(self.to_dict(include_ref=False))
+        return "constraint-work:" + canonical_sha256(
+            self.to_dict(include_ref=False)
+        )
 
     def to_dict(self, *, include_ref: bool = True) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "constraint_ref": self.constraint_ref,
             "incident_factor_refs": list(self.incident_factor_refs),
             "triggering_factor_refs": list(self.triggering_factor_refs),
+            "propagation_wave": self.propagation_wave,
         }
         if include_ref:
             payload["work_ref"] = self.work_ref
@@ -80,7 +86,9 @@ class ConstraintWorklistResult:
         return payload
 
 
-def _coerce_constraint(value: FactorConstraint | Mapping[str, Any]) -> FactorConstraint:
+def _coerce_constraint(
+    value: FactorConstraint | Mapping[str, Any],
+) -> FactorConstraint:
     if isinstance(value, FactorConstraint):
         return value
     return FactorConstraint(
@@ -111,7 +119,7 @@ def evaluate_constraint_worklist(
     constraints: Sequence[FactorConstraint | Mapping[str, Any]],
     changed_factor_refs: Iterable[str] | None = None,
 ) -> ConstraintWorklistResult:
-    """Evaluate only constraints incident on the changed factor frontier."""
+    """Evaluate the initial graph or only the changed-factor frontier."""
 
     known_factors = frozenset(str(ref) for ref in factor_refs)
     declarations = tuple(
@@ -134,29 +142,26 @@ def evaluate_constraint_worklist(
                 declaration.constraint_ref
             )
 
-    changed = (
-        frozenset(str(ref) for ref in changed_factor_refs)
-        if changed_factor_refs is not None
-        else known_factors
-    )
-    queue = deque(
-        sorted(
-            {
-                constraint_ref
-                for factor_ref in changed
-                for constraint_ref in adjacency.get(factor_ref, ())
-            }
-            or set(by_ref)
-        )
-    )
-    queued = set(queue)
+    if changed_factor_refs is None:
+        changed = known_factors
+        initial_constraint_refs = set(by_ref)
+    else:
+        changed = frozenset(str(ref) for ref in changed_factor_refs)
+        initial_constraint_refs = {
+            constraint_ref
+            for factor_ref in changed
+            for constraint_ref in adjacency.get(factor_ref, ())
+        }
+
+    queue = deque((constraint_ref, 0) for constraint_ref in sorted(initial_constraint_refs))
+    queued = set(initial_constraint_refs)
     assessments: dict[str, ConstraintAssessment] = {}
     work_items: list[ConstraintWorkItem] = []
-    rounds = 0
+    maximum_wave = -1
 
     while queue:
-        rounds += 1
-        constraint_ref = queue.popleft()
+        constraint_ref, wave = queue.popleft()
+        maximum_wave = max(maximum_wave, wave)
         queued.discard(constraint_ref)
         declaration = by_ref[constraint_ref]
         incident = tuple(
@@ -171,6 +176,7 @@ def evaluate_constraint_worklist(
                 constraint_ref=constraint_ref,
                 incident_factor_refs=incident,
                 triggering_factor_refs=triggers,
+                propagation_wave=wave,
             )
         )
         source_ok = set(declaration.source_factor_refs).issubset(known_factors)
@@ -204,7 +210,7 @@ def evaluate_constraint_worklist(
             for factor_ref in incident:
                 for neighbour in adjacency.get(factor_ref, ()):
                     if neighbour not in queued:
-                        queue.append(neighbour)
+                        queue.append((neighbour, wave + 1))
                         queued.add(neighbour)
 
     return ConstraintWorklistResult(
@@ -214,7 +220,7 @@ def evaluate_constraint_worklist(
         ),
         work_items=tuple(work_items),
         changed_factor_refs=tuple(sorted(changed)),
-        fixed_point_rounds=rounds,
+        fixed_point_rounds=maximum_wave + 1,
     )
 
 

--- a/src/pnf/factor_proposals.py
+++ b/src/pnf/factor_proposals.py
@@ -1,8 +1,11 @@
-"""Immutable document-local PNF proposals and deterministic reduction.
+"""Immutable fibred PNF proposals and deterministic reduction.
 
-Workers may generate proposals concurrently, but they never mutate a shared graph.
-The reducer validates references, orders by canonical keys, deduplicates byte-identical
-proposals, and retains incompatible alternatives as explicit residuals.
+Ordinary compiler operations are normalised under one integrated semantic
+producer family.  Their particular typing, linking, composition, constraint,
+closure, or enrichment operation remains explicit, while executor details stay
+outside semantic identity.  Workers may populate fibres concurrently; one
+fibrewise reducer materialises the active PNF view and retains incompatible
+alternatives and residual boundary data.
 """
 
 from __future__ import annotations
@@ -10,12 +13,40 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from typing import Any, Iterable, Mapping, Sequence
 
+from src.pnf.semantic_fibres import SemanticCoordinate
 from src.policy.carriers.canonical import canonical_sha256
 
 
-FACTOR_PROPOSAL_SCHEMA_VERSION = "sl.pnf.factor_proposal.v0_1"
-PROPOSAL_REDUCTION_SCHEMA_VERSION = "sl.pnf.proposal_reduction.v0_1"
+INTEGRATED_SEMANTIC_PRODUCER_CONTRACT = "integrated-semantic-producer:v0_1"
+FACTOR_PROPOSAL_SCHEMA_VERSION = "sl.pnf.factor_proposal.v0_2"
+PROPOSAL_REDUCTION_SCHEMA_VERSION = "sl.pnf.proposal_reduction.v0_2"
 CROSS_DOCUMENT_RELATION_SCHEMA_VERSION = "sl.pnf.cross_document_relation.v0_1"
+
+_FIBRE_KINDS = {
+    "observation",
+    "hypothesis",
+    "composition",
+    "constraint",
+    "consequence",
+    "enrichment",
+    "residual",
+    "review",
+}
+_DERIVATION_ROLES = {"support", "contradict", "undetermined", "transport"}
+_PRODUCER_SCOPES = {"integrated", "external"}
+_SUPPORT_STATES = {
+    "unscored",
+    "candidate",
+    "supported",
+    "supported_with_residuals",
+    "contested",
+    "unsupported",
+    "unresolved",
+}
+
+
+def _refs(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(sorted({str(value) for value in values if str(value)}))
 
 
 @dataclass(frozen=True)
@@ -42,6 +73,8 @@ class CompositionDeclaration:
 
 @dataclass(frozen=True)
 class FactorProposal:
+    """One immutable candidate in the fibre over a semantic coordinate."""
+
     document_ref: str
     source_revision_ref: str
     factor_type_ref: str
@@ -55,6 +88,82 @@ class FactorProposal:
     declaration_revision: str
     candidate_payload: Mapping[str, Any]
     residuals: tuple[str, ...] = ()
+    scope_ref: str | None = None
+    statement_role: str = "main"
+    coordinate_kind: str = "object"
+    semantic_coordinate_ref: str | None = None
+    fibre_kind: str = "hypothesis"
+    derivation_role: str = "support"
+    producer_scope: str = "integrated"
+    operation_contract: str | None = None
+    ontology_axis_refs: tuple[str, ...] = ()
+    transport_refs: tuple[str, ...] = ()
+    support_state: str = "candidate"
+    confidence: float | None = None
+    assumptions: tuple[str, ...] = ()
+    coverage_requirements: tuple[str, ...] = ()
+    execution_metadata: Mapping[str, Any] = field(
+        default_factory=dict,
+        compare=False,
+        hash=False,
+    )
+
+    def __post_init__(self) -> None:
+        if not self.document_ref or not self.factor_type_ref:
+            raise ValueError("factor proposal requires document and factor type")
+        if self.fibre_kind not in _FIBRE_KINDS:
+            raise ValueError("unsupported proposal fibre kind")
+        if self.derivation_role not in _DERIVATION_ROLES:
+            raise ValueError("unsupported proposal derivation role")
+        if self.producer_scope not in _PRODUCER_SCOPES:
+            raise ValueError("unsupported proposal producer scope")
+        if self.support_state not in _SUPPORT_STATES:
+            raise ValueError("unsupported proposal support state")
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("proposal confidence must be between zero and one")
+
+        spans = _refs(self.source_span_refs)
+        observations = _refs(self.input_observation_refs)
+        dependencies = _refs(self.dependency_factor_refs)
+        residuals = _refs(self.residuals)
+        axes = _refs(self.ontology_axis_refs)
+        transports = _refs(self.transport_refs)
+        assumptions = _refs(self.assumptions)
+        coverage = _refs(self.coverage_requirements)
+        object.__setattr__(self, "source_span_refs", spans)
+        object.__setattr__(self, "input_observation_refs", observations)
+        object.__setattr__(self, "dependency_factor_refs", dependencies)
+        object.__setattr__(self, "residuals", residuals)
+        object.__setattr__(self, "ontology_axis_refs", axes)
+        object.__setattr__(self, "transport_refs", transports)
+        object.__setattr__(self, "assumptions", assumptions)
+        object.__setattr__(self, "coverage_requirements", coverage)
+
+        resolved_scope = self.scope_ref or (
+            min(spans) if spans else "document-global"
+        )
+        object.__setattr__(self, "scope_ref", resolved_scope)
+
+        operation_contract = self.operation_contract
+        producer_contract = self.producer_contract
+        if self.producer_scope == "integrated":
+            operation_contract = operation_contract or producer_contract
+            producer_contract = INTEGRATED_SEMANTIC_PRODUCER_CONTRACT
+        else:
+            operation_contract = operation_contract or producer_contract
+        object.__setattr__(self, "operation_contract", operation_contract)
+        object.__setattr__(self, "producer_contract", producer_contract)
+
+        coordinate = SemanticCoordinate(
+            document_ref=self.document_ref,
+            scope_ref=resolved_scope,
+            source_span_refs=spans,
+            statement_role=self.statement_role,
+            factor_family=self.factor_type_ref,
+            coordinate_kind=self.coordinate_kind,
+        )
+        coordinate_ref = self.semantic_coordinate_ref or coordinate.coordinate_ref
+        object.__setattr__(self, "semantic_coordinate_ref", coordinate_ref)
 
     @property
     def proposal_digest(self) -> str:
@@ -65,20 +174,36 @@ class FactorProposal:
         return "factor-proposal:" + self.proposal_digest
 
     def identity_payload(self) -> dict[str, Any]:
+        """Return semantic identity without executor-specific telemetry."""
+
         return {
             "document_ref": self.document_ref,
             "source_revision_ref": self.source_revision_ref,
+            "semantic_coordinate_ref": self.semantic_coordinate_ref,
+            "scope_ref": self.scope_ref,
+            "statement_role": self.statement_role,
+            "coordinate_kind": self.coordinate_kind,
+            "fibre_kind": self.fibre_kind,
+            "derivation_role": self.derivation_role,
             "factor_type_ref": self.factor_type_ref,
-            "source_span_refs": sorted(set(self.source_span_refs)),
-            "input_observation_refs": sorted(set(self.input_observation_refs)),
-            "dependency_factor_refs": sorted(set(self.dependency_factor_refs)),
+            "source_span_refs": list(self.source_span_refs),
+            "input_observation_refs": list(self.input_observation_refs),
+            "dependency_factor_refs": list(self.dependency_factor_refs),
             "structural_signature": self.structural_signature,
             "role_bindings": dict(sorted(self.role_bindings.items())),
             "qualifier_state": dict(self.qualifier_state),
             "producer_contract": self.producer_contract,
+            "producer_scope": self.producer_scope,
+            "operation_contract": self.operation_contract,
             "declaration_revision": self.declaration_revision,
+            "ontology_axis_refs": list(self.ontology_axis_refs),
+            "transport_refs": list(self.transport_refs),
+            "support_state": self.support_state,
+            "confidence": self.confidence,
+            "assumptions": list(self.assumptions),
+            "coverage_requirements": list(self.coverage_requirements),
             "candidate_payload": dict(self.candidate_payload),
-            "residuals": sorted(set(self.residuals)),
+            "residuals": list(self.residuals),
         }
 
     def to_dict(self) -> dict[str, Any]:
@@ -87,7 +212,12 @@ class FactorProposal:
             "proposal_ref": self.proposal_ref,
             "proposal_digest": self.proposal_digest,
             **self.identity_payload(),
-            "authority": "candidate_only",
+            "execution_metadata": dict(self.execution_metadata),
+            "authority": (
+                "external_candidate"
+                if self.producer_scope == "external"
+                else "candidate_only"
+            ),
         }
 
 
@@ -98,6 +228,8 @@ class ReductionResidual:
     residual_type: str
     proposal_refs: tuple[str, ...]
     message: str
+    semantic_coordinate_ref: str | None = None
+    boundary_kind: str = "fibre"
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -107,6 +239,8 @@ class ReductionResidual:
 class ReducedFactor:
     factor_ref: str
     document_ref: str
+    semantic_coordinate_ref: str
+    fibre_kind: str
     factor_type_ref: str
     structural_signature: str
     proposal_refs: tuple[str, ...]
@@ -114,11 +248,17 @@ class ReducedFactor:
     role_bindings: Mapping[str, str]
     qualifier_state: Mapping[str, Any]
     residuals: tuple[str, ...]
+    derivation_roles: tuple[str, ...] = ()
+    ontology_axis_refs: tuple[str, ...] = ()
+    transport_refs: tuple[str, ...] = ()
+    support_states: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "factor_ref": self.factor_ref,
             "document_ref": self.document_ref,
+            "semantic_coordinate_ref": self.semantic_coordinate_ref,
+            "fibre_kind": self.fibre_kind,
             "factor_type_ref": self.factor_type_ref,
             "structural_signature": self.structural_signature,
             "proposal_refs": list(self.proposal_refs),
@@ -126,7 +266,13 @@ class ReducedFactor:
             "role_bindings": dict(self.role_bindings),
             "qualifier_state": dict(self.qualifier_state),
             "residuals": list(self.residuals),
-            "closure_state": "requires_review" if self.residuals else "locally_closed",
+            "derivation_roles": list(self.derivation_roles),
+            "ontology_axis_refs": list(self.ontology_axis_refs),
+            "transport_refs": list(self.transport_refs),
+            "support_states": list(self.support_states),
+            "closure_state": (
+                "requires_review" if self.residuals else "locally_closed"
+            ),
         }
 
 
@@ -145,6 +291,7 @@ class ProposalReduction:
                 "document_ref": self.document_ref,
                 "factors": [row.to_dict() for row in self.factors],
                 "residuals": [row.to_dict() for row in self.residuals],
+                "reduction_contract": "deterministic-fibrewise-pnf:v0_1",
             }
         )
 
@@ -155,8 +302,16 @@ class ProposalReduction:
             "graph_ref": self.graph_ref,
             "proposal_count": self.proposal_count,
             "deduplicated_count": self.deduplicated_count,
+            "semantic_coordinate_refs": sorted(
+                {row.semantic_coordinate_ref for row in self.factors}
+            ),
             "factors": [row.to_dict() for row in self.factors],
             "residuals": [row.to_dict() for row in self.residuals],
+            "reduction_contract": "deterministic-fibrewise-pnf:v0_1",
+            "integrated_producer_contract": (
+                INTEGRATED_SEMANTIC_PRODUCER_CONTRACT
+            ),
+            "fibrewise_reduction": True,
             "identity_promoted": False,
             "legal_truth_closed": False,
         }
@@ -175,7 +330,9 @@ class CrossDocumentRelation:
 
     @property
     def relation_ref(self) -> str:
-        return "cross-document-relation:" + canonical_sha256(self.identity_payload())
+        return "cross-document-relation:" + canonical_sha256(
+            self.identity_payload()
+        )
 
     def identity_payload(self) -> dict[str, Any]:
         return {
@@ -212,13 +369,21 @@ def proposal_build_key(
             "canonical_text_digest": canonical_text_digest,
             "producer_contract": producer_contract,
             "declaration_revision": declaration_revision,
-            "input_observation_digests": sorted(set(input_observation_digests)),
-            "dependency_factor_digests": sorted(set(dependency_factor_digests)),
+            "input_observation_digests": sorted(
+                set(input_observation_digests)
+            ),
+            "dependency_factor_digests": sorted(
+                set(dependency_factor_digests)
+            ),
         }
     )
 
 
 def _compatible(left: FactorProposal, right: FactorProposal) -> bool:
+    if left.semantic_coordinate_ref != right.semantic_coordinate_ref:
+        return False
+    if left.fibre_kind != right.fibre_kind:
+        return False
     if left.factor_type_ref != right.factor_type_ref:
         return False
     if left.structural_signature != right.structural_signature:
@@ -236,23 +401,37 @@ def reduce_factor_proposals(
     known_observation_refs: Iterable[str] = (),
     known_dependency_refs: Iterable[str] = (),
 ) -> ProposalReduction:
+    """Materialise canonical summaries independently for each semantic fibre."""
+
     ordered = sorted(proposals, key=lambda row: row.proposal_ref)
     for proposal in ordered:
         if proposal.document_ref != document_ref:
-            raise ValueError("cross-document proposal supplied to document-local reducer")
+            raise ValueError(
+                "cross-document proposal supplied to document-local reducer"
+            )
 
     observation_refs = set(known_observation_refs)
     dependency_refs = set(known_dependency_refs)
     validation_residuals: list[ReductionResidual] = []
     valid: list[FactorProposal] = []
     for proposal in ordered:
-        missing_observations = sorted(set(proposal.input_observation_refs) - observation_refs) if observation_refs else []
-        missing_dependencies = sorted(set(proposal.dependency_factor_refs) - dependency_refs) if dependency_refs else []
+        missing_observations = (
+            sorted(set(proposal.input_observation_refs) - observation_refs)
+            if observation_refs
+            else []
+        )
+        missing_dependencies = (
+            sorted(set(proposal.dependency_factor_refs) - dependency_refs)
+            if dependency_refs
+            else []
+        )
         if missing_observations or missing_dependencies:
-            residual_type = "missing_reduction_input"
             residual_ref = "reduction-residual:" + canonical_sha256(
                 {
                     "proposal_ref": proposal.proposal_ref,
+                    "semantic_coordinate_ref": (
+                        proposal.semantic_coordinate_ref
+                    ),
                     "missing_observations": missing_observations,
                     "missing_dependencies": missing_dependencies,
                 }
@@ -261,9 +440,16 @@ def reduce_factor_proposals(
                 ReductionResidual(
                     residual_ref=residual_ref,
                     document_ref=document_ref,
-                    residual_type=residual_type,
+                    residual_type="missing_reduction_input",
                     proposal_refs=(proposal.proposal_ref,),
-                    message="proposal retained outside reduction because declared inputs are unavailable",
+                    message=(
+                        "proposal retained outside reduction because declared "
+                        "inputs are unavailable"
+                    ),
+                    semantic_coordinate_ref=(
+                        proposal.semantic_coordinate_ref
+                    ),
+                    boundary_kind="input_frontier",
                 )
             )
             continue
@@ -273,7 +459,14 @@ def reduce_factor_proposals(
     deduplicated = sorted(unique.values(), key=lambda row: row.proposal_ref)
     groups: list[list[FactorProposal]] = []
     for proposal in deduplicated:
-        matched = next((group for group in groups if all(_compatible(proposal, item) for item in group)), None)
+        matched = next(
+            (
+                group
+                for group in groups
+                if all(_compatible(proposal, item) for item in group)
+            ),
+            None,
+        )
         if matched is None:
             groups.append([proposal])
         else:
@@ -281,39 +474,85 @@ def reduce_factor_proposals(
 
     factors: list[ReducedFactor] = []
     incompatibility_residuals: list[ReductionResidual] = []
-    signature_groups: dict[tuple[str, str], list[list[FactorProposal]]] = {}
+    signature_groups: dict[
+        tuple[str, str, str, str],
+        list[list[FactorProposal]],
+    ] = {}
     for group in groups:
-        key = (group[0].factor_type_ref, group[0].structural_signature)
+        key = (
+            str(group[0].semantic_coordinate_ref),
+            group[0].fibre_kind,
+            group[0].factor_type_ref,
+            group[0].structural_signature,
+        )
         signature_groups.setdefault(key, []).append(group)
 
     for key, compatible_groups in sorted(signature_groups.items()):
         if len(compatible_groups) > 1:
-            refs = tuple(sorted(row.proposal_ref for group in compatible_groups for row in group))
+            refs = tuple(
+                sorted(
+                    row.proposal_ref
+                    for group in compatible_groups
+                    for row in group
+                )
+            )
             incompatibility_residuals.append(
                 ReductionResidual(
-                    residual_ref="reduction-residual:" + canonical_sha256({"kind": "incompatible_alternatives", "refs": refs}),
+                    residual_ref="reduction-residual:"
+                    + canonical_sha256(
+                        {
+                            "kind": "incompatible_alternatives",
+                            "semantic_coordinate_ref": key[0],
+                            "refs": refs,
+                        }
+                    ),
                     document_ref=document_ref,
                     residual_type="incompatible_alternatives",
                     proposal_refs=refs,
-                    message="structurally related proposals disagree on one or more occupied coordinates",
+                    message=(
+                        "proposals in one semantic fibre disagree on one or "
+                        "more occupied coordinates"
+                    ),
+                    semantic_coordinate_ref=key[0],
+                    boundary_kind="conflicted_fibre",
                 )
             )
         for group in compatible_groups:
-            proposal_refs = tuple(sorted(row.proposal_ref for row in group))
+            proposal_refs = tuple(
+                sorted(row.proposal_ref for row in group)
+            )
             roles: dict[str, str] = {}
             qualifiers: dict[str, Any] = {}
             residuals: set[str] = set()
             alternatives: list[Mapping[str, Any]] = []
+            derivation_roles: set[str] = set()
+            axes: set[str] = set()
+            transports: set[str] = set()
+            support_states: set[str] = set()
             for proposal in sorted(group, key=lambda row: row.proposal_ref):
                 roles.update(proposal.role_bindings)
                 qualifiers.update(proposal.qualifier_state)
                 residuals.update(proposal.residuals)
-                alternatives.append(dict(proposal.candidate_payload))
+                derivation_roles.add(proposal.derivation_role)
+                axes.update(proposal.ontology_axis_refs)
+                transports.update(proposal.transport_refs)
+                support_states.add(proposal.support_state)
+                alternatives.append(
+                    {
+                        **dict(proposal.candidate_payload),
+                        "proposal_ref": proposal.proposal_ref,
+                        "derivation_role": proposal.derivation_role,
+                        "support_state": proposal.support_state,
+                        "confidence": proposal.confidence,
+                    }
+                )
             factor_ref = "factor:" + canonical_sha256(
                 {
                     "document_ref": document_ref,
-                    "factor_type_ref": key[0],
-                    "structural_signature": key[1],
+                    "semantic_coordinate_ref": key[0],
+                    "fibre_kind": key[1],
+                    "factor_type_ref": key[2],
+                    "structural_signature": key[3],
                     "proposal_refs": proposal_refs,
                 }
             )
@@ -321,20 +560,31 @@ def reduce_factor_proposals(
                 ReducedFactor(
                     factor_ref=factor_ref,
                     document_ref=document_ref,
-                    factor_type_ref=key[0],
-                    structural_signature=key[1],
+                    semantic_coordinate_ref=key[0],
+                    fibre_kind=key[1],
+                    factor_type_ref=key[2],
+                    structural_signature=key[3],
                     proposal_refs=proposal_refs,
                     alternatives=tuple(alternatives),
                     role_bindings=dict(sorted(roles.items())),
                     qualifier_state=qualifiers,
                     residuals=tuple(sorted(residuals)),
+                    derivation_roles=tuple(sorted(derivation_roles)),
+                    ontology_axis_refs=tuple(sorted(axes)),
+                    transport_refs=tuple(sorted(transports)),
+                    support_states=tuple(sorted(support_states)),
                 )
             )
 
     return ProposalReduction(
         document_ref=document_ref,
         factors=tuple(sorted(factors, key=lambda row: row.factor_ref)),
-        residuals=tuple(sorted((*validation_residuals, *incompatibility_residuals), key=lambda row: row.residual_ref)),
+        residuals=tuple(
+            sorted(
+                (*validation_residuals, *incompatibility_residuals),
+                key=lambda row: row.residual_ref,
+            )
+        ),
         proposal_count=len(ordered),
         deduplicated_count=len(valid) - len(deduplicated),
     )
@@ -343,6 +593,7 @@ def reduce_factor_proposals(
 __all__ = [
     "CROSS_DOCUMENT_RELATION_SCHEMA_VERSION",
     "FACTOR_PROPOSAL_SCHEMA_VERSION",
+    "INTEGRATED_SEMANTIC_PRODUCER_CONTRACT",
     "PROPOSAL_REDUCTION_SCHEMA_VERSION",
     "CompositionDeclaration",
     "CrossDocumentRelation",

--- a/src/pnf/fibred_build_projection.py
+++ b/src/pnf/fibred_build_projection.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping
 
 from src.pnf.factor_proposals import (
     INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
@@ -10,11 +10,14 @@ from src.pnf.factor_proposals import (
 )
 from src.pnf.integrated_semantic_producer import IntegratedProducerReceipt
 from src.pnf.semantic_fibres import (
+    AxisObligation,
     FibreBoundaryObligation,
     FibreDerivation,
     FibreElement,
+    OntologyAxis,
     SemanticCoordinate,
     SemanticFibreLedger,
+    SemanticTransport,
     fibre_element_from_proposal_row,
 )
 
@@ -65,10 +68,62 @@ def _proposal_from_mapping(row: Mapping[str, Any]) -> FactorProposal:
     )
 
 
+def _transport(row: Mapping[str, Any]) -> SemanticTransport:
+    return SemanticTransport(
+        document_ref=str(row["document_ref"]),
+        source_coordinate_ref=str(row["source_coordinate_ref"]),
+        target_coordinate_ref=str(row["target_coordinate_ref"]),
+        transport_type=str(row["transport_type"]),
+        strength=str(row["strength"]),
+        evidence_refs=tuple(row.get("evidence_refs") or ()),
+        ontology_axis_refs=tuple(row.get("ontology_axis_refs") or ()),
+        allowed_operations=tuple(row.get("allowed_operations") or ()),
+        residual_refs=tuple(row.get("residual_refs") or ()),
+    )
+
+
+def _axis(row: Mapping[str, Any]) -> OntologyAxis:
+    return OntologyAxis(
+        axis_ref=str(row["axis_ref"]),
+        label=str(row["label"]),
+        authority_ref=str(row["authority_ref"]),
+        relation_refs=tuple(row.get("relation_refs") or ()),
+        root_refs=tuple(row.get("root_refs") or ()),
+        open_world=bool(row.get("open_world", True)),
+    )
+
+
+def _axis_obligation(row: Mapping[str, Any]) -> AxisObligation:
+    return AxisObligation(
+        document_ref=str(row["document_ref"]),
+        coordinate_ref=str(row["coordinate_ref"]),
+        axis_ref=str(row["axis_ref"]),
+        obligation_type=str(row["obligation_type"]),
+        trigger_refs=tuple(row.get("trigger_refs") or ()),
+        frontier_refs=tuple(row.get("frontier_refs") or ()),
+        state=str(row.get("state") or "open"),
+        resource_limit_reached=bool(row.get("resource_limit_reached", False)),
+    )
+
+
+def _boundary(row: Mapping[str, Any]) -> FibreBoundaryObligation:
+    return FibreBoundaryObligation(
+        document_ref=str(row["document_ref"]),
+        coordinate_ref=str(row["coordinate_ref"]),
+        scope_ref=str(row["scope_ref"]),
+        boundary_kind=str(row["boundary_kind"]),
+        evidence_refs=tuple(row.get("evidence_refs") or ()),
+        frontier_refs=tuple(row.get("frontier_refs") or ()),
+        required_axis_refs=tuple(row.get("required_axis_refs") or ()),
+        state=str(row.get("state") or "open"),
+        message=str(row.get("message") or ""),
+    )
+
+
 def project_fibred_semantic_build(
     streaming_build: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Return fibred coordinates, elements, derivations, boundaries, and receipt."""
+    """Return the complete fibred execution view and integrated receipt."""
 
     document_ref = str(streaming_build.get("document_ref") or "")
     coordinates: dict[str, SemanticCoordinate] = {}
@@ -198,7 +253,27 @@ def project_fibred_semantic_build(
             )
         )
 
-    boundaries: list[FibreBoundaryObligation] = []
+    transports = tuple(
+        _transport(row)
+        for row in streaming_build.get("semantic_transports") or ()
+        if isinstance(row, Mapping)
+    )
+    axes = tuple(
+        _axis(row)
+        for row in streaming_build.get("ontology_axes") or ()
+        if isinstance(row, Mapping)
+    )
+    axis_obligations = tuple(
+        _axis_obligation(row)
+        for row in streaming_build.get("axis_obligations") or ()
+        if isinstance(row, Mapping)
+    )
+
+    boundary_by_ref: dict[str, FibreBoundaryObligation] = {}
+    for row in streaming_build.get("fibre_boundary_obligations") or ():
+        if isinstance(row, Mapping):
+            boundary = _boundary(row)
+            boundary_by_ref[boundary.boundary_ref] = boundary
     materialized = streaming_build.get("materialized_reduction") or {}
     for residual in materialized.get("residuals") or ():
         if not isinstance(residual, Mapping):
@@ -210,33 +285,39 @@ def project_fibred_semantic_build(
         if coordinate is None:
             continue
         boundary_kind = str(residual.get("boundary_kind") or "fibre")
-        boundaries.append(
-            FibreBoundaryObligation(
-                document_ref=document_ref,
-                coordinate_ref=coordinate_ref,
-                scope_ref=coordinate.scope_ref,
-                boundary_kind=boundary_kind,
-                evidence_refs=tuple(residual.get("proposal_refs") or ()),
-                frontier_refs=(str(residual.get("residual_ref") or ""),),
-                state=(
-                    "external"
-                    if boundary_kind in {"input_frontier", "ontology_axis"}
-                    else "open"
-                ),
-                message=str(residual.get("message") or ""),
-            )
+        boundary = FibreBoundaryObligation(
+            document_ref=document_ref,
+            coordinate_ref=coordinate_ref,
+            scope_ref=coordinate.scope_ref,
+            boundary_kind=boundary_kind,
+            evidence_refs=tuple(residual.get("proposal_refs") or ()),
+            frontier_refs=(str(residual.get("residual_ref") or ""),),
+            state=(
+                "external"
+                if boundary_kind in {"input_frontier", "ontology_axis"}
+                else "open"
+            ),
+            message=str(residual.get("message") or ""),
         )
+        boundary_by_ref[boundary.boundary_ref] = boundary
 
     ledger = SemanticFibreLedger(
         coordinates=tuple(
             coordinates[key] for key in sorted(coordinates)
         ),
         elements=tuple(sorted(elements, key=lambda row: row.element_ref)),
+        transports=tuple(
+            sorted(transports, key=lambda row: row.transport_ref)
+        ),
         derivations=tuple(
             sorted(derivations, key=lambda row: row.derivation_ref)
         ),
+        ontology_axes=tuple(sorted(axes, key=lambda row: row.axis_ref)),
+        axis_obligations=tuple(
+            sorted(axis_obligations, key=lambda row: row.obligation_ref)
+        ),
         boundary_obligations=tuple(
-            sorted(boundaries, key=lambda row: row.boundary_ref)
+            boundary_by_ref[key] for key in sorted(boundary_by_ref)
         ),
     )
     producer_receipt = IntegratedProducerReceipt(
@@ -265,7 +346,12 @@ def project_fibred_semantic_build(
         "integrated_producer_receipt": producer_receipt.to_dict(),
         "semantic_coordinates": [row.to_dict() for row in ledger.coordinates],
         "fibre_elements": [row.to_dict() for row in ledger.elements],
+        "semantic_transports": [row.to_dict() for row in ledger.transports],
         "fibre_derivations": [row.to_dict() for row in ledger.derivations],
+        "ontology_axes": [row.to_dict() for row in ledger.ontology_axes],
+        "axis_obligations": [
+            row.to_dict() for row in ledger.axis_obligations
+        ],
         "fibre_boundary_obligations": [
             row.to_dict() for row in ledger.boundary_obligations
         ],

--- a/src/pnf/fibred_build_projection.py
+++ b/src/pnf/fibred_build_projection.py
@@ -1,0 +1,279 @@
+"""Pure projection from streaming execution evidence to fibred build evidence."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from src.pnf.factor_proposals import (
+    INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
+    FactorProposal,
+)
+from src.pnf.integrated_semantic_producer import IntegratedProducerReceipt
+from src.pnf.semantic_fibres import (
+    FibreBoundaryObligation,
+    FibreDerivation,
+    FibreElement,
+    SemanticCoordinate,
+    SemanticFibreLedger,
+    fibre_element_from_proposal_row,
+)
+
+
+def _proposal_from_mapping(row: Mapping[str, Any]) -> FactorProposal:
+    return FactorProposal(
+        document_ref=str(row["document_ref"]),
+        source_revision_ref=str(row["source_revision_ref"]),
+        factor_type_ref=str(row["factor_type_ref"]),
+        source_span_refs=tuple(row.get("source_span_refs") or ()),
+        input_observation_refs=tuple(
+            row.get("input_observation_refs") or ()
+        ),
+        dependency_factor_refs=tuple(
+            row.get("dependency_factor_refs") or ()
+        ),
+        structural_signature=str(row.get("structural_signature") or ""),
+        role_bindings=dict(row.get("role_bindings") or {}),
+        qualifier_state=dict(row.get("qualifier_state") or {}),
+        producer_contract=str(row.get("producer_contract") or ""),
+        declaration_revision=str(row.get("declaration_revision") or ""),
+        candidate_payload=dict(row.get("candidate_payload") or {}),
+        residuals=tuple(row.get("residuals") or ()),
+        scope_ref=str(row.get("scope_ref") or "document-global"),
+        statement_role=str(row.get("statement_role") or "main"),
+        coordinate_kind=str(row.get("coordinate_kind") or "object"),
+        semantic_coordinate_ref=str(
+            row.get("semantic_coordinate_ref") or ""
+        )
+        or None,
+        fibre_kind=str(row.get("fibre_kind") or "hypothesis"),
+        derivation_role=str(row.get("derivation_role") or "support"),
+        producer_scope=str(row.get("producer_scope") or "integrated"),
+        operation_contract=str(row.get("operation_contract") or "") or None,
+        ontology_axis_refs=tuple(row.get("ontology_axis_refs") or ()),
+        transport_refs=tuple(row.get("transport_refs") or ()),
+        support_state=str(row.get("support_state") or "candidate"),
+        confidence=(
+            float(row["confidence"])
+            if row.get("confidence") is not None
+            else None
+        ),
+        assumptions=tuple(row.get("assumptions") or ()),
+        coverage_requirements=tuple(
+            row.get("coverage_requirements") or ()
+        ),
+        execution_metadata=dict(row.get("execution_metadata") or {}),
+    )
+
+
+def project_fibred_semantic_build(
+    streaming_build: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return fibred coordinates, elements, derivations, boundaries, and receipt."""
+
+    document_ref = str(streaming_build.get("document_ref") or "")
+    coordinates: dict[str, SemanticCoordinate] = {}
+    elements: list[FibreElement] = []
+    content_to_element_ref: dict[str, str] = {}
+
+    for delta in streaming_build.get("observation_deltas") or ():
+        if not isinstance(delta, Mapping):
+            continue
+        scope_ref = str(delta.get("scope_ref") or "document-global")
+        parser_contract = str(delta.get("parser_contract") or "")
+        for observation in delta.get("observations") or ():
+            if not isinstance(observation, Mapping):
+                continue
+            observation_ref = str(observation.get("observation_ref") or "")
+            if not observation_ref:
+                continue
+            coordinate = SemanticCoordinate(
+                document_ref=document_ref,
+                scope_ref=scope_ref,
+                source_span_refs=(observation_ref,),
+                statement_role="parser_observation",
+                factor_family=str(
+                    observation.get("observation_type") or "parser.observation"
+                ),
+                coordinate_kind="object",
+            )
+            declared_coordinate_ref = str(
+                observation.get("semantic_coordinate_ref") or ""
+            )
+            if declared_coordinate_ref and (
+                declared_coordinate_ref != coordinate.coordinate_ref
+            ):
+                raise ValueError("parser observation coordinate is not canonical")
+            element = FibreElement(
+                document_ref=document_ref,
+                coordinate_ref=coordinate.coordinate_ref,
+                fibre_kind="observation",
+                content_ref=observation_ref,
+                derivation_role="support",
+                producer_contract=INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
+                operation_contract=parser_contract,
+                source_refs=(observation_ref,),
+                support_state="candidate",
+                payload=dict(observation),
+                execution_metadata={"parser_contract": parser_contract},
+            )
+            coordinates[coordinate.coordinate_ref] = coordinate
+            elements.append(element)
+            content_to_element_ref[observation_ref] = element.element_ref
+
+    proposals = tuple(
+        _proposal_from_mapping(row)
+        for row in streaming_build.get("proposals") or ()
+        if isinstance(row, Mapping)
+    )
+    for proposal in proposals:
+        coordinate = SemanticCoordinate(
+            document_ref=proposal.document_ref,
+            scope_ref=str(proposal.scope_ref),
+            source_span_refs=proposal.source_span_refs,
+            statement_role=proposal.statement_role,
+            factor_family=proposal.factor_type_ref,
+            coordinate_kind=proposal.coordinate_kind,
+        )
+        if coordinate.coordinate_ref != proposal.semantic_coordinate_ref:
+            raise ValueError("proposal coordinate is not canonical")
+        element = fibre_element_from_proposal_row(proposal.to_dict())
+        coordinates[coordinate.coordinate_ref] = coordinate
+        elements.append(element)
+        content_to_element_ref[proposal.proposal_ref] = element.element_ref
+
+    jobs = {
+        str(row.get("job_ref") or ""): row
+        for row in streaming_build.get("solver_jobs") or ()
+        if isinstance(row, Mapping) and row.get("job_ref")
+    }
+    proposal_rows = {row.proposal_ref: row for row in proposals}
+    derivations: list[FibreDerivation] = []
+    receipt_refs: list[str] = []
+    for receipt in streaming_build.get("solver_receipts") or ():
+        if not isinstance(receipt, Mapping):
+            continue
+        receipt_ref = str(receipt.get("receipt_ref") or "")
+        if receipt_ref:
+            receipt_refs.append(receipt_ref)
+        job = jobs.get(str(receipt.get("job_ref") or ""), {})
+        output_proposals = [
+            proposal_rows[str(ref)]
+            for ref in receipt.get("proposal_refs") or ()
+            if str(ref) in proposal_rows
+        ]
+        operation_contract = str(
+            output_proposals[0].operation_contract
+            if output_proposals
+            else job.get("declaration_ref") or "unknown-operation"
+        )
+        operation_kind = str(
+            (
+                output_proposals[0].execution_metadata.get("operation_kind")
+                if output_proposals
+                else None
+            )
+            or "closure"
+        )
+        derivations.append(
+            FibreDerivation(
+                document_ref=document_ref,
+                operation_kind=operation_kind,
+                declaration_ref=str(job.get("declaration_ref") or ""),
+                producer_contract=INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
+                input_element_refs=tuple(
+                    content_to_element_ref.get(str(ref), str(ref))
+                    for ref in receipt.get("input_refs") or ()
+                ),
+                output_element_refs=tuple(
+                    content_to_element_ref[row.proposal_ref]
+                    for row in output_proposals
+                ),
+                sub_executor_ref=str(receipt.get("backend_ref") or ""),
+                rule_set_revision=str(
+                    receipt.get("rule_set_revision") or ""
+                ),
+                receipt_ref=receipt_ref or None,
+                assumptions=tuple(receipt.get("assumptions") or ()),
+                metrics=dict(receipt.get("metrics") or {}),
+            )
+        )
+
+    boundaries: list[FibreBoundaryObligation] = []
+    materialized = streaming_build.get("materialized_reduction") or {}
+    for residual in materialized.get("residuals") or ():
+        if not isinstance(residual, Mapping):
+            continue
+        coordinate_ref = str(
+            residual.get("semantic_coordinate_ref") or ""
+        )
+        coordinate = coordinates.get(coordinate_ref)
+        if coordinate is None:
+            continue
+        boundary_kind = str(residual.get("boundary_kind") or "fibre")
+        boundaries.append(
+            FibreBoundaryObligation(
+                document_ref=document_ref,
+                coordinate_ref=coordinate_ref,
+                scope_ref=coordinate.scope_ref,
+                boundary_kind=boundary_kind,
+                evidence_refs=tuple(residual.get("proposal_refs") or ()),
+                frontier_refs=(str(residual.get("residual_ref") or ""),),
+                state=(
+                    "external"
+                    if boundary_kind in {"input_frontier", "ontology_axis"}
+                    else "open"
+                ),
+                message=str(residual.get("message") or ""),
+            )
+        )
+
+    ledger = SemanticFibreLedger(
+        coordinates=tuple(
+            coordinates[key] for key in sorted(coordinates)
+        ),
+        elements=tuple(sorted(elements, key=lambda row: row.element_ref)),
+        derivations=tuple(
+            sorted(derivations, key=lambda row: row.derivation_ref)
+        ),
+        boundary_obligations=tuple(
+            sorted(boundaries, key=lambda row: row.boundary_ref)
+        ),
+    )
+    producer_receipt = IntegratedProducerReceipt(
+        document_ref=document_ref,
+        contract_ref=INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
+        proposal_refs=tuple(sorted(row.proposal_ref for row in proposals)),
+        sub_executor_receipt_refs=tuple(sorted(set(receipt_refs))),
+        fibre_ledger_ref=ledger.ledger_ref,
+        residual_refs=tuple(
+            sorted(
+                str(row.get("residual_ref") or "")
+                for row in materialized.get("residuals") or ()
+                if isinstance(row, Mapping) and row.get("residual_ref")
+            )
+        ),
+        external_proposal_refs=tuple(
+            sorted(
+                row.proposal_ref
+                for row in proposals
+                if row.producer_scope == "external"
+            )
+        ),
+    )
+    return {
+        "fibre_ledger": ledger.to_dict(),
+        "integrated_producer_receipt": producer_receipt.to_dict(),
+        "semantic_coordinates": [row.to_dict() for row in ledger.coordinates],
+        "fibre_elements": [row.to_dict() for row in ledger.elements],
+        "fibre_derivations": [row.to_dict() for row in ledger.derivations],
+        "fibre_boundary_obligations": [
+            row.to_dict() for row in ledger.boundary_obligations
+        ],
+        "one_proposal_contract": True,
+        "one_reduction_authority": True,
+        "identity_promoted": False,
+        "legal_truth_closed": False,
+    }
+
+
+__all__ = ["project_fibred_semantic_build"]

--- a/src/pnf/fibred_build_projection.py
+++ b/src/pnf/fibred_build_projection.py
@@ -216,11 +216,6 @@ def project_fibred_semantic_build(
             for ref in receipt.get("proposal_refs") or ()
             if str(ref) in proposal_rows
         ]
-        operation_contract = str(
-            output_proposals[0].operation_contract
-            if output_proposals
-            else job.get("declaration_ref") or "unknown-operation"
-        )
         operation_kind = str(
             (
                 output_proposals[0].execution_metadata.get("operation_kind")

--- a/src/pnf/integrated_semantic_producer.py
+++ b/src/pnf/integrated_semantic_producer.py
@@ -1,0 +1,422 @@
+"""One integrated semantic producer over the fibred PNF proposal contract.
+
+spaCy adapters, deterministic Python operations, Zelph closure, ontology
+lookups, and selected learned scorers may be internal executors.  They do not
+publish parallel semantic graphs.  Ordinary results are normalised under one
+producer family, retain their operation contract and executor receipt, and
+enter the same fibrewise deterministic reducer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.pnf.factor_proposals import (
+    INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
+    FactorProposal,
+)
+from src.pnf.semantic_fibres import (
+    AxisObligation,
+    FibreBoundaryObligation,
+    FibreDerivation,
+    OntologyAxis,
+    SemanticCoordinate,
+    SemanticFibreLedger,
+    SemanticTransport,
+    fibre_element_from_proposal_row,
+)
+from src.policy.carriers.canonical import canonical_sha256
+
+
+INTEGRATED_PRODUCER_RECEIPT_SCHEMA_VERSION = (
+    "sl.pnf.integrated_producer_receipt.v0_1"
+)
+SUB_EXECUTOR_RECEIPT_SCHEMA_VERSION = "sl.pnf.sub_executor_receipt.v0_1"
+INTEGRATED_PRODUCER_CONTRACT_SCHEMA_VERSION = (
+    "sl.pnf.integrated_producer_contract.v0_1"
+)
+
+_OPERATION_KINDS = {
+    "observation",
+    "typing",
+    "linking",
+    "attachment",
+    "composition",
+    "constraint",
+    "closure",
+    "enrichment",
+    "residual",
+}
+
+_OPERATION_TO_FIBRE = {
+    "observation": "observation",
+    "typing": "hypothesis",
+    "linking": "hypothesis",
+    "attachment": "hypothesis",
+    "composition": "composition",
+    "constraint": "constraint",
+    "closure": "consequence",
+    "enrichment": "enrichment",
+    "residual": "residual",
+}
+
+
+def _refs(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(sorted({str(value) for value in values if str(value)}))
+
+
+@dataclass(frozen=True)
+class ProducerCapability:
+    operation_kind: str
+    operation_contract: str
+    executor_refs: tuple[str, ...]
+    declaration_refs: tuple[str, ...] = ()
+    ontology_axis_refs: tuple[str, ...] = ()
+    core: bool = True
+
+    def __post_init__(self) -> None:
+        if self.operation_kind not in _OPERATION_KINDS:
+            raise ValueError("unsupported integrated producer operation")
+
+    @property
+    def capability_ref(self) -> str:
+        return "integrated-producer-capability:" + canonical_sha256(
+            self.to_dict(include_ref=False)
+        )
+
+    def to_dict(self, *, include_ref: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "operation_kind": self.operation_kind,
+            "operation_contract": self.operation_contract,
+            "executor_refs": list(_refs(self.executor_refs)),
+            "declaration_refs": list(_refs(self.declaration_refs)),
+            "ontology_axis_refs": list(_refs(self.ontology_axis_refs)),
+            "core": self.core,
+        }
+        if include_ref:
+            payload["capability_ref"] = self.capability_ref
+        return payload
+
+
+@dataclass(frozen=True)
+class IntegratedProducerContract:
+    contract_ref: str = INTEGRATED_SEMANTIC_PRODUCER_CONTRACT
+    contract_revision: str = "v0_1"
+    proposal_schema_ref: str = "sl.pnf.factor_proposal.v0_2"
+    reduction_contract_ref: str = "deterministic-fibrewise-pnf:v0_1"
+    capabilities: tuple[ProducerCapability, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": INTEGRATED_PRODUCER_CONTRACT_SCHEMA_VERSION,
+            "contract_ref": self.contract_ref,
+            "contract_revision": self.contract_revision,
+            "proposal_schema_ref": self.proposal_schema_ref,
+            "reduction_contract_ref": self.reduction_contract_ref,
+            "capabilities": [
+                row.to_dict()
+                for row in sorted(
+                    self.capabilities,
+                    key=lambda value: value.capability_ref,
+                )
+            ],
+            "one_proposal_contract": True,
+            "one_reduction_authority": True,
+            "parallel_authoritative_graphs": False,
+        }
+
+
+@dataclass(frozen=True)
+class SubExecutorReceipt:
+    document_ref: str
+    operation_kind: str
+    operation_contract: str
+    sub_executor_ref: str
+    declaration_ref: str
+    rule_set_revision: str
+    input_refs: tuple[str, ...]
+    proposal_refs: tuple[str, ...]
+    residual_refs: tuple[str, ...] = ()
+    assumptions: tuple[str, ...] = ()
+    metrics: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.operation_kind not in _OPERATION_KINDS:
+            raise ValueError("unsupported sub-executor operation")
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "document_ref": self.document_ref,
+            "operation_kind": self.operation_kind,
+            "operation_contract": self.operation_contract,
+            "sub_executor_ref": self.sub_executor_ref,
+            "declaration_ref": self.declaration_ref,
+            "rule_set_revision": self.rule_set_revision,
+            "input_refs": list(_refs(self.input_refs)),
+            "proposal_refs": list(_refs(self.proposal_refs)),
+            "residual_refs": list(_refs(self.residual_refs)),
+            "assumptions": list(_refs(self.assumptions)),
+        }
+
+    @property
+    def receipt_ref(self) -> str:
+        return "semantic-sub-executor-receipt:" + canonical_sha256(
+            self.identity_payload()
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SUB_EXECUTOR_RECEIPT_SCHEMA_VERSION,
+            "receipt_ref": self.receipt_ref,
+            **self.identity_payload(),
+            "metrics": dict(self.metrics),
+            "semantic_state_promoted": False,
+        }
+
+
+@dataclass(frozen=True)
+class IntegratedProducerReceipt:
+    document_ref: str
+    contract_ref: str
+    proposal_refs: tuple[str, ...]
+    sub_executor_receipt_refs: tuple[str, ...]
+    fibre_ledger_ref: str
+    residual_refs: tuple[str, ...] = ()
+    external_proposal_refs: tuple[str, ...] = ()
+
+    @property
+    def receipt_ref(self) -> str:
+        return "integrated-semantic-producer-receipt:" + canonical_sha256(
+            self.to_dict(include_ref=False)
+        )
+
+    def to_dict(self, *, include_ref: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": INTEGRATED_PRODUCER_RECEIPT_SCHEMA_VERSION,
+            "document_ref": self.document_ref,
+            "contract_ref": self.contract_ref,
+            "proposal_refs": list(_refs(self.proposal_refs)),
+            "sub_executor_receipt_refs": list(
+                _refs(self.sub_executor_receipt_refs)
+            ),
+            "fibre_ledger_ref": self.fibre_ledger_ref,
+            "residual_refs": list(_refs(self.residual_refs)),
+            "external_proposal_refs": list(_refs(self.external_proposal_refs)),
+            "one_proposal_contract": True,
+            "one_reduction_authority": True,
+            "identity_promoted": False,
+            "legal_truth_closed": False,
+        }
+        if include_ref:
+            payload["receipt_ref"] = self.receipt_ref
+        return payload
+
+
+class IntegratedSemanticProducer:
+    """Normalise internal executors into one proposal and fibre contract."""
+
+    def __init__(self, contract: IntegratedProducerContract | None = None):
+        self.contract = contract or IntegratedProducerContract()
+
+    def normalise_proposals(
+        self,
+        proposals: Sequence[FactorProposal],
+        *,
+        operation_kind: str,
+        operation_contract: str,
+        sub_executor_ref: str,
+        ontology_axis_refs: Iterable[str] = (),
+        execution_metadata: Mapping[str, Any] | None = None,
+    ) -> tuple[FactorProposal, ...]:
+        if operation_kind not in _OPERATION_KINDS:
+            raise ValueError("unsupported integrated producer operation")
+        fibre_kind = _OPERATION_TO_FIBRE[operation_kind]
+        metadata = {
+            "sub_executor_ref": sub_executor_ref,
+            "operation_kind": operation_kind,
+            **dict(execution_metadata or {}),
+        }
+        return tuple(
+            sorted(
+                (
+                    replace(
+                        proposal,
+                        producer_contract=self.contract.contract_ref,
+                        producer_scope="integrated",
+                        operation_contract=operation_contract,
+                        fibre_kind=fibre_kind,
+                        ontology_axis_refs=_refs(
+                            (
+                                *proposal.ontology_axis_refs,
+                                *tuple(ontology_axis_refs),
+                            )
+                        ),
+                        execution_metadata={
+                            **dict(proposal.execution_metadata),
+                            **metadata,
+                        },
+                    )
+                    for proposal in proposals
+                ),
+                key=lambda row: row.proposal_ref,
+            )
+        )
+
+    def sub_executor_receipt(
+        self,
+        *,
+        document_ref: str,
+        operation_kind: str,
+        operation_contract: str,
+        sub_executor_ref: str,
+        declaration_ref: str,
+        rule_set_revision: str,
+        input_refs: Iterable[str],
+        proposals: Sequence[FactorProposal],
+        residual_refs: Iterable[str] = (),
+        assumptions: Iterable[str] = (),
+        metrics: Mapping[str, Any] | None = None,
+    ) -> SubExecutorReceipt:
+        return SubExecutorReceipt(
+            document_ref=document_ref,
+            operation_kind=operation_kind,
+            operation_contract=operation_contract,
+            sub_executor_ref=sub_executor_ref,
+            declaration_ref=declaration_ref,
+            rule_set_revision=rule_set_revision,
+            input_refs=_refs(input_refs),
+            proposal_refs=_refs(row.proposal_ref for row in proposals),
+            residual_refs=_refs(residual_refs),
+            assumptions=_refs(assumptions),
+            metrics=dict(metrics or {}),
+        )
+
+    def fibre_ledger(
+        self,
+        *,
+        proposals: Sequence[FactorProposal],
+        sub_executor_receipts: Sequence[SubExecutorReceipt] = (),
+        transports: Sequence[SemanticTransport] = (),
+        ontology_axes: Sequence[OntologyAxis] = (),
+        axis_obligations: Sequence[AxisObligation] = (),
+        boundary_obligations: Sequence[FibreBoundaryObligation] = (),
+    ) -> SemanticFibreLedger:
+        coordinates: dict[str, SemanticCoordinate] = {}
+        elements = []
+        proposal_by_ref = {row.proposal_ref: row for row in proposals}
+        for proposal in proposals:
+            coordinate = SemanticCoordinate(
+                document_ref=proposal.document_ref,
+                scope_ref=str(proposal.scope_ref),
+                source_span_refs=proposal.source_span_refs,
+                statement_role=proposal.statement_role,
+                factor_family=proposal.factor_type_ref,
+                coordinate_kind=proposal.coordinate_kind,
+            )
+            if coordinate.coordinate_ref != proposal.semantic_coordinate_ref:
+                raise ValueError(
+                    "proposal coordinate disagrees with canonical coordinate"
+                )
+            coordinates[coordinate.coordinate_ref] = coordinate
+            elements.append(
+                fibre_element_from_proposal_row(proposal.to_dict())
+            )
+
+        element_ref_by_proposal = {
+            row.content_ref: row.element_ref for row in elements
+        }
+        derivations: list[FibreDerivation] = []
+        for receipt in sub_executor_receipts:
+            output_refs = tuple(
+                element_ref_by_proposal[proposal_ref]
+                for proposal_ref in receipt.proposal_refs
+                if proposal_ref in element_ref_by_proposal
+            )
+            derivations.append(
+                FibreDerivation(
+                    document_ref=receipt.document_ref,
+                    operation_kind=receipt.operation_kind,
+                    declaration_ref=receipt.declaration_ref,
+                    producer_contract=self.contract.contract_ref,
+                    input_element_refs=receipt.input_refs,
+                    output_element_refs=output_refs,
+                    sub_executor_ref=receipt.sub_executor_ref,
+                    rule_set_revision=receipt.rule_set_revision,
+                    receipt_ref=receipt.receipt_ref,
+                    assumptions=receipt.assumptions,
+                    metrics=receipt.metrics,
+                )
+            )
+            for proposal_ref in receipt.proposal_refs:
+                if proposal_ref not in proposal_by_ref:
+                    raise ValueError(
+                        "sub-executor receipt refers to unknown proposal"
+                    )
+
+        return SemanticFibreLedger(
+            coordinates=tuple(
+                coordinates[key] for key in sorted(coordinates)
+            ),
+            elements=tuple(
+                sorted(elements, key=lambda row: row.element_ref)
+            ),
+            transports=tuple(
+                sorted(transports, key=lambda row: row.transport_ref)
+            ),
+            derivations=tuple(
+                sorted(derivations, key=lambda row: row.derivation_ref)
+            ),
+            ontology_axes=tuple(
+                sorted(ontology_axes, key=lambda row: row.axis_ref)
+            ),
+            axis_obligations=tuple(
+                sorted(
+                    axis_obligations,
+                    key=lambda row: row.obligation_ref,
+                )
+            ),
+            boundary_obligations=tuple(
+                sorted(
+                    boundary_obligations,
+                    key=lambda row: row.boundary_ref,
+                )
+            ),
+        )
+
+    def receipt(
+        self,
+        *,
+        document_ref: str,
+        proposals: Sequence[FactorProposal],
+        fibre_ledger: SemanticFibreLedger,
+        sub_executor_receipts: Sequence[SubExecutorReceipt] = (),
+        residual_refs: Iterable[str] = (),
+    ) -> IntegratedProducerReceipt:
+        return IntegratedProducerReceipt(
+            document_ref=document_ref,
+            contract_ref=self.contract.contract_ref,
+            proposal_refs=_refs(row.proposal_ref for row in proposals),
+            sub_executor_receipt_refs=_refs(
+                row.receipt_ref for row in sub_executor_receipts
+            ),
+            fibre_ledger_ref=fibre_ledger.ledger_ref,
+            residual_refs=_refs(residual_refs),
+            external_proposal_refs=_refs(
+                row.proposal_ref
+                for row in proposals
+                if row.producer_scope == "external"
+            ),
+        )
+
+
+__all__ = [
+    "INTEGRATED_PRODUCER_CONTRACT_SCHEMA_VERSION",
+    "INTEGRATED_PRODUCER_RECEIPT_SCHEMA_VERSION",
+    "SUB_EXECUTOR_RECEIPT_SCHEMA_VERSION",
+    "IntegratedProducerContract",
+    "IntegratedProducerReceipt",
+    "IntegratedSemanticProducer",
+    "ProducerCapability",
+    "SubExecutorReceipt",
+]

--- a/src/pnf/semantic_fibres.py
+++ b/src/pnf/semantic_fibres.py
@@ -1,0 +1,633 @@
+"""Fibred semantic carriers for the integrated PNF compiler.
+
+The base coordinate system records which semantic question is being considered.
+Parser observations, hypotheses, composed candidates, constraint findings,
+consequences, enrichment evidence, and residuals live as provenance-bearing
+fibre elements over those coordinates.  Transports relate coordinates without
+silently closing identity, while the deterministic PNF reducer remains the only
+materialisation authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping
+
+from src.policy.carriers.canonical import canonical_sha256
+
+
+SEMANTIC_COORDINATE_SCHEMA_VERSION = "sl.pnf.semantic_coordinate.v0_1"
+SEMANTIC_FIBRE_ELEMENT_SCHEMA_VERSION = "sl.pnf.semantic_fibre_element.v0_1"
+SEMANTIC_FIBRE_LEDGER_SCHEMA_VERSION = "sl.pnf.semantic_fibre_ledger.v0_1"
+SEMANTIC_TRANSPORT_SCHEMA_VERSION = "sl.pnf.semantic_transport.v0_1"
+ONTOLOGY_AXIS_SCHEMA_VERSION = "sl.pnf.ontology_axis.v0_1"
+AXIS_OBLIGATION_SCHEMA_VERSION = "sl.pnf.axis_obligation.v0_1"
+FIBRE_BOUNDARY_SCHEMA_VERSION = "sl.pnf.fibre_boundary_obligation.v0_1"
+FIBRE_DERIVATION_SCHEMA_VERSION = "sl.pnf.fibre_derivation.v0_1"
+FIBRE_VALIDATION_SCHEMA_VERSION = "sl.pnf.fibre_validation.v0_1"
+
+_COORDINATE_KINDS = {"object", "morphism", "obligation", "external"}
+_FIBRE_KINDS = {
+    "observation",
+    "hypothesis",
+    "composition",
+    "constraint",
+    "consequence",
+    "enrichment",
+    "residual",
+    "review",
+}
+_DERIVATION_ROLES = {"support", "contradict", "undetermined", "transport"}
+_SUPPORT_STATES = {
+    "unscored",
+    "candidate",
+    "supported",
+    "supported_with_residuals",
+    "contested",
+    "unsupported",
+    "unresolved",
+}
+_TRANSPORT_STRENGTHS = {
+    "discoverable",
+    "candidate",
+    "close",
+    "exact",
+    "identity",
+}
+_AXIS_STATES = {
+    "open",
+    "satisfied",
+    "contradicted",
+    "both",
+    "undetermined",
+    "inapplicable",
+}
+_BOUNDARY_STATES = {"open", "discharged", "external"}
+_VALIDATION_OUTCOMES = {
+    "satisfied",
+    "violated",
+    "both",
+    "undetermined",
+    "inapplicable",
+}
+
+
+def _refs(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(sorted({str(value) for value in values if str(value)}))
+
+
+@dataclass(frozen=True)
+class SemanticCoordinate:
+    """One base point over which semantic evidence and alternatives accumulate."""
+
+    document_ref: str
+    scope_ref: str
+    source_span_refs: tuple[str, ...]
+    statement_role: str
+    factor_family: str
+    coordinate_kind: str = "object"
+    source_coordinate_refs: tuple[str, ...] = ()
+    target_coordinate_refs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.coordinate_kind not in _COORDINATE_KINDS:
+            raise ValueError("unsupported semantic coordinate kind")
+        if not self.document_ref or not self.scope_ref or not self.factor_family:
+            raise ValueError("semantic coordinates require document, scope, and family")
+        if self.source_span_refs != _refs(self.source_span_refs):
+            raise ValueError("source span references must be canonically ordered")
+
+    @property
+    def coordinate_ref(self) -> str:
+        return "semantic-coordinate:" + canonical_sha256(
+            self.to_dict(include_ref=False)
+        )
+
+    def to_dict(self, *, include_ref: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": SEMANTIC_COORDINATE_SCHEMA_VERSION,
+            "document_ref": self.document_ref,
+            "scope_ref": self.scope_ref,
+            "source_span_refs": list(self.source_span_refs),
+            "statement_role": self.statement_role,
+            "factor_family": self.factor_family,
+            "coordinate_kind": self.coordinate_kind,
+            "source_coordinate_refs": list(_refs(self.source_coordinate_refs)),
+            "target_coordinate_refs": list(_refs(self.target_coordinate_refs)),
+        }
+        if include_ref:
+            payload["coordinate_ref"] = self.coordinate_ref
+        return payload
+
+
+@dataclass(frozen=True)
+class OntologyAxis:
+    """A named, versioned classification subfibration."""
+
+    axis_ref: str
+    label: str
+    authority_ref: str
+    relation_refs: tuple[str, ...]
+    root_refs: tuple[str, ...]
+    open_world: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": ONTOLOGY_AXIS_SCHEMA_VERSION,
+            "axis_ref": self.axis_ref,
+            "label": self.label,
+            "authority_ref": self.authority_ref,
+            "relation_refs": list(_refs(self.relation_refs)),
+            "root_refs": list(_refs(self.root_refs)),
+            "open_world": self.open_world,
+        }
+
+
+@dataclass(frozen=True)
+class SemanticTransport:
+    """Controlled evidence transport between semantic coordinates or bases."""
+
+    document_ref: str
+    source_coordinate_ref: str
+    target_coordinate_ref: str
+    transport_type: str
+    strength: str
+    evidence_refs: tuple[str, ...]
+    ontology_axis_refs: tuple[str, ...] = ()
+    allowed_operations: tuple[str, ...] = ("inspect",)
+    residual_refs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.strength not in _TRANSPORT_STRENGTHS:
+            raise ValueError("unsupported semantic transport strength")
+        operations = set(self.allowed_operations)
+        if self.strength == "discoverable" and "substitute" in operations:
+            raise ValueError("discoverable transports cannot permit substitution")
+        if not self.source_coordinate_ref or not self.target_coordinate_ref:
+            raise ValueError("semantic transport requires source and target")
+
+    @property
+    def transport_ref(self) -> str:
+        return "semantic-transport:" + canonical_sha256(
+            self.to_dict(include_ref=False)
+        )
+
+    def to_dict(self, *, include_ref: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": SEMANTIC_TRANSPORT_SCHEMA_VERSION,
+            "document_ref": self.document_ref,
+            "source_coordinate_ref": self.source_coordinate_ref,
+            "target_coordinate_ref": self.target_coordinate_ref,
+            "transport_type": self.transport_type,
+            "strength": self.strength,
+            "evidence_refs": list(_refs(self.evidence_refs)),
+            "ontology_axis_refs": list(_refs(self.ontology_axis_refs)),
+            "allowed_operations": list(_refs(self.allowed_operations)),
+            "residual_refs": list(_refs(self.residual_refs)),
+            "identity_closed": False,
+            "semantic_state_promoted": False,
+        }
+        if include_ref:
+            payload["transport_ref"] = self.transport_ref
+        return payload
+
+
+@dataclass(frozen=True)
+class FibreElement:
+    """One provenance-bearing item in the fibre over a semantic coordinate."""
+
+    document_ref: str
+    coordinate_ref: str
+    fibre_kind: str
+    content_ref: str
+    derivation_role: str
+    producer_contract: str
+    operation_contract: str
+    source_refs: tuple[str, ...] = ()
+    dependency_refs: tuple[str, ...] = ()
+    transport_refs: tuple[str, ...] = ()
+    ontology_axis_refs: tuple[str, ...] = ()
+    assumptions: tuple[str, ...] = ()
+    coverage_requirements: tuple[str, ...] = ()
+    support_state: str = "candidate"
+    confidence: float | None = None
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    external: bool = False
+    execution_metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.fibre_kind not in _FIBRE_KINDS:
+            raise ValueError("unsupported semantic fibre kind")
+        if self.derivation_role not in _DERIVATION_ROLES:
+            raise ValueError("unsupported fibre derivation role")
+        if self.support_state not in _SUPPORT_STATES:
+            raise ValueError("unsupported fibre support state")
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("fibre confidence must be between zero and one")
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "document_ref": self.document_ref,
+            "coordinate_ref": self.coordinate_ref,
+            "fibre_kind": self.fibre_kind,
+            "content_ref": self.content_ref,
+            "derivation_role": self.derivation_role,
+            "producer_contract": self.producer_contract,
+            "operation_contract": self.operation_contract,
+            "source_refs": list(_refs(self.source_refs)),
+            "dependency_refs": list(_refs(self.dependency_refs)),
+            "transport_refs": list(_refs(self.transport_refs)),
+            "ontology_axis_refs": list(_refs(self.ontology_axis_refs)),
+            "assumptions": list(_refs(self.assumptions)),
+            "coverage_requirements": list(_refs(self.coverage_requirements)),
+            "support_state": self.support_state,
+            "confidence": self.confidence,
+            "payload": dict(self.payload),
+            "external": self.external,
+        }
+
+    @property
+    def element_ref(self) -> str:
+        return "semantic-fibre-element:" + canonical_sha256(
+            self.identity_payload()
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SEMANTIC_FIBRE_ELEMENT_SCHEMA_VERSION,
+            "element_ref": self.element_ref,
+            **self.identity_payload(),
+            "execution_metadata": dict(self.execution_metadata),
+            "authority": "external_candidate" if self.external else "candidate_only",
+        }
+
+
+@dataclass(frozen=True)
+class FibreDerivation:
+    """Receipt-bearing derivation between fibre elements."""
+
+    document_ref: str
+    operation_kind: str
+    declaration_ref: str
+    producer_contract: str
+    input_element_refs: tuple[str, ...]
+    output_element_refs: tuple[str, ...]
+    sub_executor_ref: str
+    rule_set_revision: str
+    receipt_ref: str | None = None
+    assumptions: tuple[str, ...] = ()
+    metrics: Mapping[str, Any] = field(default_factory=dict)
+
+    def identity_payload(self) -> dict[str, Any]:
+        return {
+            "document_ref": self.document_ref,
+            "operation_kind": self.operation_kind,
+            "declaration_ref": self.declaration_ref,
+            "producer_contract": self.producer_contract,
+            "input_element_refs": list(_refs(self.input_element_refs)),
+            "output_element_refs": list(_refs(self.output_element_refs)),
+            "sub_executor_ref": self.sub_executor_ref,
+            "rule_set_revision": self.rule_set_revision,
+            "receipt_ref": self.receipt_ref,
+            "assumptions": list(_refs(self.assumptions)),
+        }
+
+    @property
+    def derivation_ref(self) -> str:
+        return "semantic-fibre-derivation:" + canonical_sha256(
+            self.identity_payload()
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": FIBRE_DERIVATION_SCHEMA_VERSION,
+            "derivation_ref": self.derivation_ref,
+            **self.identity_payload(),
+            "metrics": dict(self.metrics),
+        }
+
+
+@dataclass(frozen=True)
+class AxisObligation:
+    """Demand for evidence along one named ontology axis."""
+
+    document_ref: str
+    coordinate_ref: str
+    axis_ref: str
+    obligation_type: str
+    trigger_refs: tuple[str, ...]
+    frontier_refs: tuple[str, ...] = ()
+    state: str = "open"
+    resource_limit_reached: bool = False
+
+    def __post_init__(self) -> None:
+        if self.state not in _AXIS_STATES:
+            raise ValueError("unsupported ontology-axis obligation state")
+
+    @property
+    def obligation_ref(self) -> str:
+        return "semantic-axis-obligation:" + canonical_sha256(
+            self.to_dict(include_ref=False)
+        )
+
+    def to_dict(self, *, include_ref: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": AXIS_OBLIGATION_SCHEMA_VERSION,
+            "document_ref": self.document_ref,
+            "coordinate_ref": self.coordinate_ref,
+            "axis_ref": self.axis_ref,
+            "obligation_type": self.obligation_type,
+            "trigger_refs": list(_refs(self.trigger_refs)),
+            "frontier_refs": list(_refs(self.frontier_refs)),
+            "state": self.state,
+            "resource_limit_reached": self.resource_limit_reached,
+            "truth_closed": False,
+        }
+        if include_ref:
+            payload["obligation_ref"] = self.obligation_ref
+        return payload
+
+
+@dataclass(frozen=True)
+class FibreBoundaryObligation:
+    """Boundary data exported by an incomplete, conflicted, or external fibre."""
+
+    document_ref: str
+    coordinate_ref: str
+    scope_ref: str
+    boundary_kind: str
+    evidence_refs: tuple[str, ...]
+    frontier_refs: tuple[str, ...] = ()
+    required_axis_refs: tuple[str, ...] = ()
+    state: str = "open"
+    message: str = ""
+
+    def __post_init__(self) -> None:
+        if self.state not in _BOUNDARY_STATES:
+            raise ValueError("unsupported fibre boundary state")
+
+    @property
+    def boundary_ref(self) -> str:
+        return "semantic-fibre-boundary:" + canonical_sha256(
+            self.to_dict(include_ref=False)
+        )
+
+    def to_dict(self, *, include_ref: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": FIBRE_BOUNDARY_SCHEMA_VERSION,
+            "document_ref": self.document_ref,
+            "coordinate_ref": self.coordinate_ref,
+            "scope_ref": self.scope_ref,
+            "boundary_kind": self.boundary_kind,
+            "evidence_refs": list(_refs(self.evidence_refs)),
+            "frontier_refs": list(_refs(self.frontier_refs)),
+            "required_axis_refs": list(_refs(self.required_axis_refs)),
+            "state": self.state,
+            "message": self.message,
+        }
+        if include_ref:
+            payload["boundary_ref"] = self.boundary_ref
+        return payload
+
+
+@dataclass(frozen=True)
+class FibreValidation:
+    """Five-way validation result derived from one fibre and its coverage."""
+
+    coordinate_ref: str
+    outcome: str
+    supporting_element_refs: tuple[str, ...]
+    contradicting_element_refs: tuple[str, ...]
+    undetermined_element_refs: tuple[str, ...]
+    residual_refs: tuple[str, ...]
+    ontology_axis_refs: tuple[str, ...]
+    applicable: bool
+    coverage_complete: bool
+
+    def __post_init__(self) -> None:
+        if self.outcome not in _VALIDATION_OUTCOMES:
+            raise ValueError("unsupported fibre validation outcome")
+
+    @property
+    def validation_ref(self) -> str:
+        return "semantic-fibre-validation:" + canonical_sha256(
+            self.to_dict(include_ref=False)
+        )
+
+    def to_dict(self, *, include_ref: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": FIBRE_VALIDATION_SCHEMA_VERSION,
+            "coordinate_ref": self.coordinate_ref,
+            "outcome": self.outcome,
+            "supporting_element_refs": list(_refs(self.supporting_element_refs)),
+            "contradicting_element_refs": list(
+                _refs(self.contradicting_element_refs)
+            ),
+            "undetermined_element_refs": list(
+                _refs(self.undetermined_element_refs)
+            ),
+            "residual_refs": list(_refs(self.residual_refs)),
+            "ontology_axis_refs": list(_refs(self.ontology_axis_refs)),
+            "applicable": self.applicable,
+            "coverage_complete": self.coverage_complete,
+            "truth_closed": False,
+        }
+        if include_ref:
+            payload["validation_ref"] = self.validation_ref
+        return payload
+
+
+def evaluate_fibre(
+    *,
+    coordinate_ref: str,
+    elements: Iterable[FibreElement],
+    residual_refs: Iterable[str] = (),
+    ontology_axis_refs: Iterable[str] = (),
+    applicable: bool = True,
+    coverage_complete: bool = False,
+) -> FibreValidation:
+    rows = tuple(elements)
+    supporting = _refs(
+        row.element_ref for row in rows if row.derivation_role == "support"
+    )
+    contradicting = _refs(
+        row.element_ref for row in rows if row.derivation_role == "contradict"
+    )
+    undetermined = _refs(
+        row.element_ref for row in rows if row.derivation_role == "undetermined"
+    )
+    if not applicable:
+        outcome = "inapplicable"
+    elif supporting and contradicting:
+        outcome = "both"
+    elif supporting:
+        outcome = "satisfied"
+    elif contradicting:
+        outcome = "violated"
+    else:
+        outcome = "undetermined"
+    return FibreValidation(
+        coordinate_ref=coordinate_ref,
+        outcome=outcome,
+        supporting_element_refs=supporting,
+        contradicting_element_refs=contradicting,
+        undetermined_element_refs=undetermined,
+        residual_refs=_refs(residual_refs),
+        ontology_axis_refs=_refs(ontology_axis_refs),
+        applicable=applicable,
+        coverage_complete=coverage_complete,
+    )
+
+
+@dataclass(frozen=True)
+class SemanticFibreLedger:
+    """ACI ledger of the fibred semantic state beneath deterministic reduction."""
+
+    coordinates: tuple[SemanticCoordinate, ...] = ()
+    elements: tuple[FibreElement, ...] = ()
+    transports: tuple[SemanticTransport, ...] = ()
+    derivations: tuple[FibreDerivation, ...] = ()
+    ontology_axes: tuple[OntologyAxis, ...] = ()
+    axis_obligations: tuple[AxisObligation, ...] = ()
+    boundary_obligations: tuple[FibreBoundaryObligation, ...] = ()
+
+    def join(self, other: "SemanticFibreLedger") -> "SemanticFibreLedger":
+        coordinates = {
+            row.coordinate_ref: row for row in (*self.coordinates, *other.coordinates)
+        }
+        elements = {
+            row.element_ref: row for row in (*self.elements, *other.elements)
+        }
+        transports = {
+            row.transport_ref: row for row in (*self.transports, *other.transports)
+        }
+        derivations = {
+            row.derivation_ref: row
+            for row in (*self.derivations, *other.derivations)
+        }
+        axes = {row.axis_ref: row for row in (*self.ontology_axes, *other.ontology_axes)}
+        axis_obligations = {
+            row.obligation_ref: row
+            for row in (*self.axis_obligations, *other.axis_obligations)
+        }
+        boundaries = {
+            row.boundary_ref: row
+            for row in (*self.boundary_obligations, *other.boundary_obligations)
+        }
+        return SemanticFibreLedger(
+            coordinates=tuple(coordinates[key] for key in sorted(coordinates)),
+            elements=tuple(elements[key] for key in sorted(elements)),
+            transports=tuple(transports[key] for key in sorted(transports)),
+            derivations=tuple(derivations[key] for key in sorted(derivations)),
+            ontology_axes=tuple(axes[key] for key in sorted(axes)),
+            axis_obligations=tuple(
+                axis_obligations[key] for key in sorted(axis_obligations)
+            ),
+            boundary_obligations=tuple(
+                boundaries[key] for key in sorted(boundaries)
+            ),
+        )
+
+    def fibre(self, coordinate_ref: str) -> tuple[FibreElement, ...]:
+        return tuple(
+            row for row in self.elements if row.coordinate_ref == coordinate_ref
+        )
+
+    @property
+    def ledger_ref(self) -> str:
+        return "semantic-fibre-ledger:" + canonical_sha256(
+            self.to_dict(include_ref=False)
+        )
+
+    def to_dict(self, *, include_ref: bool = True) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": SEMANTIC_FIBRE_LEDGER_SCHEMA_VERSION,
+            "coordinates": [row.to_dict() for row in self.coordinates],
+            "elements": [row.to_dict() for row in self.elements],
+            "transports": [row.to_dict() for row in self.transports],
+            "derivations": [row.to_dict() for row in self.derivations],
+            "ontology_axes": [row.to_dict() for row in self.ontology_axes],
+            "axis_obligations": [
+                row.to_dict() for row in self.axis_obligations
+            ],
+            "boundary_obligations": [
+                row.to_dict() for row in self.boundary_obligations
+            ],
+            "merge_properties": ["associative", "commutative", "idempotent"],
+            "identity_promoted": False,
+            "legal_truth_closed": False,
+        }
+        if include_ref:
+            payload["ledger_ref"] = self.ledger_ref
+        return payload
+
+
+def fibre_element_from_proposal_row(
+    proposal: Mapping[str, Any],
+    *,
+    execution_metadata: Mapping[str, Any] | None = None,
+) -> FibreElement:
+    return FibreElement(
+        document_ref=str(proposal["document_ref"]),
+        coordinate_ref=str(proposal["semantic_coordinate_ref"]),
+        fibre_kind=str(proposal.get("fibre_kind") or "hypothesis"),
+        content_ref=str(proposal["proposal_ref"]),
+        derivation_role=str(proposal.get("derivation_role") or "support"),
+        producer_contract=str(proposal["producer_contract"]),
+        operation_contract=str(proposal.get("operation_contract") or ""),
+        source_refs=tuple(
+            str(ref)
+            for ref in (
+                *(proposal.get("source_span_refs") or ()),
+                *(proposal.get("input_observation_refs") or ()),
+            )
+        ),
+        dependency_refs=tuple(
+            str(ref) for ref in proposal.get("dependency_factor_refs") or ()
+        ),
+        transport_refs=tuple(
+            str(ref) for ref in proposal.get("transport_refs") or ()
+        ),
+        ontology_axis_refs=tuple(
+            str(ref) for ref in proposal.get("ontology_axis_refs") or ()
+        ),
+        assumptions=tuple(str(ref) for ref in proposal.get("assumptions") or ()),
+        coverage_requirements=tuple(
+            str(ref) for ref in proposal.get("coverage_requirements") or ()
+        ),
+        support_state=str(proposal.get("support_state") or "candidate"),
+        confidence=(
+            float(proposal["confidence"])
+            if proposal.get("confidence") is not None
+            else None
+        ),
+        payload=dict(proposal.get("candidate_payload") or {}),
+        external=str(proposal.get("producer_scope") or "integrated") == "external",
+        execution_metadata=dict(
+            execution_metadata or proposal.get("execution_metadata") or {}
+        ),
+    )
+
+
+__all__ = [
+    "AXIS_OBLIGATION_SCHEMA_VERSION",
+    "AxisObligation",
+    "FIBRE_BOUNDARY_SCHEMA_VERSION",
+    "FIBRE_DERIVATION_SCHEMA_VERSION",
+    "FIBRE_VALIDATION_SCHEMA_VERSION",
+    "FibreBoundaryObligation",
+    "FibreDerivation",
+    "FibreElement",
+    "FibreValidation",
+    "ONTOLOGY_AXIS_SCHEMA_VERSION",
+    "OntologyAxis",
+    "SEMANTIC_COORDINATE_SCHEMA_VERSION",
+    "SEMANTIC_FIBRE_ELEMENT_SCHEMA_VERSION",
+    "SEMANTIC_FIBRE_LEDGER_SCHEMA_VERSION",
+    "SEMANTIC_TRANSPORT_SCHEMA_VERSION",
+    "SemanticCoordinate",
+    "SemanticFibreLedger",
+    "SemanticTransport",
+    "evaluate_fibre",
+    "fibre_element_from_proposal_row",
+]

--- a/src/pnf/streaming_operator_executor.py
+++ b/src/pnf/streaming_operator_executor.py
@@ -1,9 +1,10 @@
-"""Sentence-delta adapter for streaming generic operator composition.
+"""Sentence-delta adapter for fibred streaming operator composition.
 
-The public parser may still return a complete document record, but this adapter exposes
-that record as immutable sentence batches. Each complete sentence activates an
-independent revision-bound operator-composition job. Jobs may execute concurrently and
-stream proposal receipts back to the keyed document owner.
+The public parser may still return a complete document record, but this adapter
+exposes it as immutable sentence batches.  Parser observations name their base
+semantic coordinates.  Each complete sentence activates an independent,
+revision-bound composition job whose output is normalised under the integrated
+semantic producer proposal contract.
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ from src.language.operator_composition import (
     compose_operator_factors,
 )
 from src.pnf.factor_proposals import FactorProposal
+from src.pnf.semantic_fibres import SemanticCoordinate
 from src.pnf.streaming_fixed_point import (
     CoverageNotice,
     ObservationDelta,
@@ -28,10 +30,10 @@ from src.policy.carriers.canonical import canonical_sha256
 
 
 STREAMING_OPERATOR_DECLARATION_REF = (
-    "streaming-declaration:operator-composition:v0_1"
+    "streaming-declaration:operator-composition:v0_2"
 )
 STREAMING_OPERATOR_ADAPTER_REF = (
-    "parser-delta-adapter:operator-composition:v0_1"
+    "parser-delta-adapter:operator-composition:v0_2"
 )
 
 
@@ -59,7 +61,7 @@ def parser_sentence_deltas(
     document_ref: str,
     parsed_document: Mapping[str, Any],
 ) -> tuple[ObservationDelta, ...]:
-    """Project parser sentences into stable, complete semantic observation batches."""
+    """Project parser sentences into stable, complete observation fibres."""
 
     deltas: list[ObservationDelta] = []
     token_cursor = 0
@@ -69,15 +71,26 @@ def parser_sentence_deltas(
         tokens = tuple(dict(row) for row in sentence.get("tokens") or ())
         if not tokens:
             continue
+        scope_ref = f"document-sentence:{document_ref}:{sentence_index}"
         observations: list[dict[str, Any]] = []
         observation_refs: list[str] = []
         for token in tokens:
             ref = _observation_ref(document_ref, sentence_index, token)
+            coordinate = SemanticCoordinate(
+                document_ref=document_ref,
+                scope_ref=scope_ref,
+                source_span_refs=(ref,),
+                statement_role="parser_observation",
+                factor_family="parser.token",
+                coordinate_kind="object",
+            )
             observation_refs.append(ref)
             observations.append(
                 {
                     "observation_ref": ref,
+                    "semantic_coordinate_ref": coordinate.coordinate_ref,
                     "observation_type": "parser.token",
+                    "fibre_kind": "observation",
                     "sentence_index": sentence_index,
                     "token": token,
                     "authority": "parser_observation_only",
@@ -86,7 +99,6 @@ def parser_sentence_deltas(
         observation_refs = sorted(set(observation_refs))
         char_start = min(int(row.get("start", 0)) for row in tokens)
         char_end = max(int(row.get("end", char_start)) for row in tokens)
-        scope_ref = f"document-sentence:{document_ref}:{sentence_index}"
         batch_ref = "parser-sentence-batch:" + canonical_sha256(
             {
                 "document_ref": document_ref,
@@ -136,7 +148,7 @@ def operator_streaming_declaration() -> StreamingDeclaration:
         scope_kind="sentence",
         coverage_barrier="sentence",
         affected_index="semantic.operator_composition",
-        declaration_revision="v0_1",
+        declaration_revision="v0_2",
         priority=40,
     )
 
@@ -144,8 +156,12 @@ def operator_streaming_declaration() -> StreamingDeclaration:
 def _proposal_from_factor(
     *,
     document_ref: str,
+    scope_ref: str,
     factor: Mapping[str, Any],
     observation_refs: Sequence[str],
+    assumptions: Sequence[str],
+    coverage_requirements: Sequence[str],
+    declaration_ref: str,
 ) -> FactorProposal:
     metadata = dict(factor.get("metadata") or {})
     alternatives = [
@@ -181,11 +197,9 @@ def _proposal_from_factor(
         ),
         role_bindings=dict(metadata.get("role_bindings") or {}),
         qualifier_state=dict(metadata.get("qualifier_state") or {}),
-        producer_contract=str(
-            metadata.get("composition_contract_ref")
-            or OPERATOR_COMPOSITION_CONTRACT
-        ),
-        declaration_revision="v0_1",
+        producer_contract=OPERATOR_COMPOSITION_CONTRACT,
+        operation_contract=OPERATOR_COMPOSITION_CONTRACT,
+        declaration_revision="v0_2",
         candidate_payload={
             "source_factor_ref": str(factor.get("factor_ref") or ""),
             "predicate_ref": str(metadata.get("predicate_ref") or ""),
@@ -195,11 +209,22 @@ def _proposal_from_factor(
         residuals=tuple(
             str(value) for value in factor.get("residuals") or ()
         ),
+        scope_ref=scope_ref,
+        statement_role="main",
+        coordinate_kind="object",
+        fibre_kind="composition",
+        derivation_role="support",
+        assumptions=tuple(assumptions),
+        coverage_requirements=tuple(coverage_requirements),
+        execution_metadata={
+            "operation_kind": "composition",
+            "declaration_ref": declaration_ref,
+        },
     )
 
 
 def solve_operator_job(job: SolverJob) -> tuple[FactorProposal, ...]:
-    """Pure closure handler for one complete sentence observation delta."""
+    """Pure composition handler for one complete observation fibre batch."""
 
     delta = dict(job.input_payload.get("observation_delta") or {})
     observations = tuple(delta.get("observations") or ())
@@ -221,8 +246,12 @@ def solve_operator_job(job: SolverJob) -> tuple[FactorProposal, ...]:
     return tuple(
         _proposal_from_factor(
             document_ref=job.owner_key.document_ref,
+            scope_ref=job.owner_key.scope_ref,
             factor=factor.to_dict(),
             observation_refs=job.input_refs,
+            assumptions=job.assumptions,
+            coverage_requirements=job.coverage_requirements,
+            declaration_ref=job.declaration_ref,
         )
         for factor in factors
     )
@@ -235,7 +264,7 @@ def build_streaming_operator_state(
     closure_workers: int = 2,
     partition_count: int = 1,
 ) -> StreamingSemanticOwner:
-    """Run sentence jobs concurrently and return the converged keyed owner state."""
+    """Run sentence jobs concurrently and return converged keyed owner state."""
 
     owner = StreamingSemanticOwner(
         document_ref=document_ref,

--- a/src/pnf/streaming_reduction_projection.py
+++ b/src/pnf/streaming_reduction_projection.py
@@ -1,8 +1,9 @@
-"""Project a deterministic streamed proposal reduction into the PNF graph.
+"""Project deterministic fibrewise proposal reduction into the PNF graph.
 
-The projection is a compatibility materialisation only.  It consumes the converged
-proposal ledger and reduced-factor revision, preserves all proposal alternatives and
-residuals, and never re-runs parser/operator composition.
+The projection consumes the converged proposal ledger and reduced fibre
+summaries, preserves every proposal alternative and residual, and never re-runs
+parser or operator composition.  It is a materialised view, not a second
+semantic authority.
 """
 
 from __future__ import annotations
@@ -10,13 +11,14 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from src.language.operator_composition import OPERATOR_COMPOSITION_CONTRACT
+from src.pnf.factor_proposals import INTEGRATED_SEMANTIC_PRODUCER_CONTRACT
 from src.pnf.graph import PNFGraph
 from src.policy.algebra import Factor, TypedAlternative
 from src.policy.carriers.canonical import canonical_sha256
 
 
 STREAMING_REDUCTION_PROJECTION_CONTRACT = (
-    "streaming-reduction-pnf-projection:v0_1"
+    "streaming-reduction-pnf-projection:v0_2"
 )
 
 
@@ -38,6 +40,15 @@ def _factor_from_reduction(
                     (row.get("candidate_payload") or {}).get("predicate_ref")
                     or ""
                 ),
+                "semantic_coordinate_ref": str(
+                    row.get("semantic_coordinate_ref") or ""
+                ),
+                "fibre_kind": str(row.get("fibre_kind") or "hypothesis"),
+                "derivation_role": str(
+                    row.get("derivation_role") or "support"
+                ),
+                "support_state": str(row.get("support_state") or "candidate"),
+                "confidence": row.get("confidence"),
                 "role_bindings": dict(row.get("role_bindings") or {}),
                 "qualifier_state": dict(row.get("qualifier_state") or {}),
                 "candidate_payload": dict(row.get("candidate_payload") or {}),
@@ -48,11 +59,17 @@ def _factor_from_reduction(
                 sorted(
                     {
                         str(row.get("producer_contract") or ""),
+                        str(row.get("operation_contract") or ""),
                         str(row.get("declaration_revision") or ""),
                         *(str(ref) for ref in row.get("source_span_refs") or ()),
                         *(
                             str(ref)
                             for ref in row.get("input_observation_refs") or ()
+                        ),
+                        *(str(ref) for ref in row.get("transport_refs") or ()),
+                        *(
+                            str(ref)
+                            for ref in row.get("ontology_axis_refs") or ()
                         ),
                     }
                     - {""}
@@ -61,7 +78,9 @@ def _factor_from_reduction(
         )
         for index, row in enumerate(proposal_rows)
     )
-    residuals = tuple(sorted(str(value) for value in reduced.get("residuals") or ()))
+    residuals = tuple(
+        sorted(str(value) for value in reduced.get("residuals") or ())
+    )
     provenance_refs = tuple(
         sorted(
             {
@@ -86,17 +105,41 @@ def _factor_from_reduction(
         ),
         metadata={
             "factor_revision_ref": str(reduced["factor_revision_ref"]),
+            "semantic_coordinate_ref": str(
+                reduced.get("semantic_coordinate_ref") or ""
+            ),
+            "fibre_kind": str(reduced.get("fibre_kind") or "hypothesis"),
             "structural_signature_ref": str(
                 reduced.get("structural_signature") or ""
             ),
             "role_bindings": role_bindings,
             "qualifier_state": qualifier_state,
             "proposal_refs": proposal_refs,
+            "derivation_roles": list(
+                reduced.get("derivation_roles") or ()
+            ),
+            "ontology_axis_refs": list(
+                reduced.get("ontology_axis_refs") or ()
+            ),
+            "transport_refs": list(reduced.get("transport_refs") or ()),
+            "support_states": list(reduced.get("support_states") or ()),
             "provenance_refs": provenance_refs,
             "streaming_reduction_ref": reduction_ref,
             "projection_contract_ref": STREAMING_REDUCTION_PROJECTION_CONTRACT,
+            "integrated_producer_contract": (
+                INTEGRATED_SEMANTIC_PRODUCER_CONTRACT
+            ),
             "authority": "candidate_pnf_only",
         },
+    )
+
+
+def _is_operator_proposal(row: Mapping[str, Any]) -> bool:
+    operation_contract = str(row.get("operation_contract") or "")
+    producer_contract = str(row.get("producer_contract") or "")
+    return operation_contract == OPERATOR_COMPOSITION_CONTRACT or (
+        not operation_contract
+        and producer_contract == OPERATOR_COMPOSITION_CONTRACT
     )
 
 
@@ -105,7 +148,7 @@ def project_streaming_reduction(
     graph: PNFGraph,
     streaming_build: Mapping[str, Any],
 ) -> tuple[PNFGraph, dict[str, Any]]:
-    """Return a PNF graph containing streamed operator-composition factors."""
+    """Return the PNF graph materialised from streamed composition fibres."""
 
     materialized = streaming_build.get("materialized_reduction") or {}
     reduction_ref = str(materialized.get("graph_ref") or "")
@@ -115,10 +158,7 @@ def project_streaming_reduction(
         if isinstance(row, Mapping) and row.get("proposal_ref")
     }
     operator_proposal_refs = {
-        ref
-        for ref, row in proposals.items()
-        if str(row.get("producer_contract") or "")
-        == OPERATOR_COMPOSITION_CONTRACT
+        ref for ref, row in proposals.items() if _is_operator_proposal(row)
     }
     selected = [
         row
@@ -143,6 +183,13 @@ def project_streaming_reduction(
         "input_graph_ref": graph.graph_ref,
         "streaming_reduction_ref": reduction_ref,
         "factor_refs": [row.factor_ref for row in factors],
+        "semantic_coordinate_refs": sorted(
+            {
+                str(row.metadata.get("semantic_coordinate_ref") or "")
+                for row in factors
+            }
+            - {""}
+        ),
     }
     receipt = {
         **receipt_identity,
@@ -152,6 +199,7 @@ def project_streaming_reduction(
         "factor_count": len(factors),
         "parser_observation_source": "streaming_observation_ledger",
         "reparsed": False,
+        "fibrewise_materialisation": True,
         "shared_graph_mutation": False,
         "identity_promoted": False,
         "legal_truth_closed": False,

--- a/src/pnf/streaming_reduction_projection.py
+++ b/src/pnf/streaming_reduction_projection.py
@@ -2,8 +2,10 @@
 
 The projection consumes the converged proposal ledger and reduced fibre
 summaries, preserves every proposal alternative and residual, and never re-runs
-parser or operator composition.  It is a materialised view, not a second
-semantic authority.
+parser or operator composition. It is a materialised view, not a second
+semantic authority. Reduced fibre-summary identity remains explicit while the
+source compatibility factor reference is retained when downstream graph APIs
+require replacement at an existing coordinate.
 """
 
 from __future__ import annotations
@@ -22,6 +24,19 @@ STREAMING_REDUCTION_PROJECTION_CONTRACT = (
 )
 
 
+def _materialized_factor_ref(
+    reduced: Mapping[str, Any],
+    proposal_rows: list[Mapping[str, Any]],
+) -> str:
+    source_refs = {
+        str((row.get("candidate_payload") or {}).get("source_factor_ref") or "")
+        for row in proposal_rows
+    } - {""}
+    if len(source_refs) == 1:
+        return next(iter(source_refs))
+    return str(reduced["factor_ref"])
+
+
 def _factor_from_reduction(
     *,
     reduced: Mapping[str, Any],
@@ -32,9 +47,10 @@ def _factor_from_reduction(
         sorted(str(ref) for ref in reduced.get("proposal_refs") or ())
     )
     proposal_rows = [proposals[ref] for ref in proposal_refs if ref in proposals]
+    factor_ref = _materialized_factor_ref(reduced, proposal_rows)
     alternatives = tuple(
         TypedAlternative(
-            alternative_ref=f"{str(reduced['factor_ref'])}:proposal:{index}",
+            alternative_ref=f"{factor_ref}:proposal:{index}",
             value={
                 "predicate_ref": str(
                     (row.get("candidate_payload") or {}).get("predicate_ref")
@@ -95,8 +111,21 @@ def _factor_from_reduction(
     )
     role_bindings = dict(reduced.get("role_bindings") or {})
     qualifier_state = dict(reduced.get("qualifier_state") or {})
+    fibre_summary_ref = str(reduced["factor_ref"])
+    factor_revision_ref = str(
+        reduced.get("factor_revision_ref")
+        or "factor-revision:"
+        + canonical_sha256(
+            {
+                "factor_ref": factor_ref,
+                "fibre_summary_ref": fibre_summary_ref,
+                "proposal_refs": proposal_refs,
+                "residuals": residuals,
+            }
+        )
+    )
     return Factor(
-        factor_ref=str(reduced["factor_ref"]),
+        factor_ref=factor_ref,
         factor_type=str(reduced["factor_type_ref"]),
         alternatives=alternatives,
         residuals=residuals,
@@ -104,7 +133,8 @@ def _factor_from_reduction(
             "requires_external_resolution" if residuals else "locally_closed"
         ),
         metadata={
-            "factor_revision_ref": str(reduced["factor_revision_ref"]),
+            "factor_revision_ref": factor_revision_ref,
+            "fibre_summary_ref": fibre_summary_ref,
             "semantic_coordinate_ref": str(
                 reduced.get("semantic_coordinate_ref") or ""
             ),
@@ -183,6 +213,13 @@ def project_streaming_reduction(
         "input_graph_ref": graph.graph_ref,
         "streaming_reduction_ref": reduction_ref,
         "factor_refs": [row.factor_ref for row in factors],
+        "fibre_summary_refs": sorted(
+            {
+                str(row.metadata.get("fibre_summary_ref") or "")
+                for row in factors
+            }
+            - {""}
+        ),
         "semantic_coordinate_refs": sorted(
             {
                 str(row.metadata.get("semantic_coordinate_ref") or "")
@@ -200,6 +237,7 @@ def project_streaming_reduction(
         "parser_observation_source": "streaming_observation_ledger",
         "reparsed": False,
         "fibrewise_materialisation": True,
+        "compatibility_factor_refs_preserved": True,
         "shared_graph_mutation": False,
         "identity_promoted": False,
         "legal_truth_closed": False,

--- a/src/pnf/streaming_reduction_projection.py
+++ b/src/pnf/streaming_reduction_projection.py
@@ -3,9 +3,10 @@
 The projection consumes the converged proposal ledger and reduced fibre
 summaries, preserves every proposal alternative and residual, and never re-runs
 parser or operator composition. It is a materialised view, not a second
-semantic authority. Reduced fibre-summary identity remains explicit while the
-source compatibility factor reference is retained when downstream graph APIs
-require replacement at an existing coordinate.
+semantic authority. Reduced fibre-summary identity remains explicit while a
+source compatibility factor reference is retained when one exists. A genuinely
+new composed coordinate is added deterministically rather than forced through a
+replacement-only API.
 """
 
 from __future__ import annotations
@@ -173,6 +174,25 @@ def _is_operator_proposal(row: Mapping[str, Any]) -> bool:
     )
 
 
+def _admit_factor(graph: PNFGraph, factor: Factor[Any]) -> tuple[PNFGraph, str]:
+    known_refs = {row.factor_ref for row in graph.factors}
+    if factor.factor_ref in known_refs:
+        return graph.replace_factor(factor), "replaced"
+    return (
+        PNFGraph(
+            graph_ref=graph.graph_ref,
+            document_ref=graph.document_ref,
+            factors=tuple(
+                sorted((*graph.factors, factor), key=lambda row: row.factor_ref)
+            ),
+            constraints=graph.constraints,
+            relation_refs=graph.relation_refs,
+            residuals=graph.residuals,
+        ),
+        "added",
+    )
+
+
 def project_streaming_reduction(
     *,
     graph: PNFGraph,
@@ -200,19 +220,24 @@ def project_streaming_reduction(
     ]
     result = graph
     factors = []
+    admissions: list[dict[str, str]] = []
     for row in sorted(selected, key=lambda value: str(value["factor_ref"])):
         factor = _factor_from_reduction(
             reduced=row,
             proposals=proposals,
             reduction_ref=reduction_ref,
         )
-        result = result.replace_factor(factor)
+        result, admission = _admit_factor(result, factor)
         factors.append(factor)
+        admissions.append(
+            {"factor_ref": factor.factor_ref, "admission": admission}
+        )
     receipt_identity = {
         "contract_ref": STREAMING_REDUCTION_PROJECTION_CONTRACT,
         "input_graph_ref": graph.graph_ref,
         "streaming_reduction_ref": reduction_ref,
         "factor_refs": [row.factor_ref for row in factors],
+        "admissions": admissions,
         "fibre_summary_refs": sorted(
             {
                 str(row.metadata.get("fibre_summary_ref") or "")
@@ -234,6 +259,12 @@ def project_streaming_reduction(
         + canonical_sha256(receipt_identity),
         "output_graph_ref": result.graph_ref,
         "factor_count": len(factors),
+        "added_factor_count": sum(
+            row["admission"] == "added" for row in admissions
+        ),
+        "replaced_factor_count": sum(
+            row["admission"] == "replaced" for row in admissions
+        ),
         "parser_observation_source": "streaming_observation_ledger",
         "reparsed": False,
         "fibrewise_materialisation": True,

--- a/src/policy/fibred_operational_corpus_compilation.py
+++ b/src/policy/fibred_operational_corpus_compilation.py
@@ -1,0 +1,211 @@
+"""Fibred operational wrapper over the streaming document compiler.
+
+The existing compiler still performs canonical parsing, mention licensing,
+structural typing, local meets, and streaming job execution. This wrapper makes
+the deterministic streamed fibre reduction the PNF materialised view returned
+to persistence and downstream projections, while retaining the pre-fibre
+artifacts as compatibility evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any, Mapping
+
+from src.pnf import PNFGraph, derive_resolution_demands
+from src.pnf.fibred_build_projection import project_fibred_semantic_build
+from src.pnf.streaming_reduction_projection import project_streaming_reduction
+from src.policy import corpus_compilation as legacy
+from src.policy.algebra import Factor, FactorConstraint, TypedAlternative
+from src.policy.carriers.canonical import canonical_sha256
+from src.policy.operational_corpus_compilation import (
+    OPERATIONAL_COMPILER_CONTRACT,
+    compile_document_operational,
+)
+
+
+FIBRED_OPERATIONAL_COMPILER_CONTRACT = (
+    "postgres-fibred-semantic-compiler:v0_1"
+)
+
+
+def _alternative(row: Mapping[str, Any]) -> TypedAlternative[Any]:
+    return TypedAlternative(
+        alternative_ref=str(row["alternative_ref"]),
+        value=row.get("value"),
+        type_ref=str(row["type_ref"]),
+        derivation_refs=tuple(row.get("derivation_refs") or ()),
+        evidence_refs=tuple(row.get("evidence_refs") or ()),
+        authority_state=str(row.get("authority_state") or "candidate_only"),
+        metadata=dict(row.get("metadata") or {}),
+    )
+
+
+def _constraint(row: Mapping[str, Any]) -> FactorConstraint:
+    return FactorConstraint(
+        constraint_ref=str(row["constraint_ref"]),
+        constraint_type=str(row["constraint_type"]),
+        payload=dict(row.get("payload") or {}),
+        provenance_refs=tuple(row.get("provenance_refs") or ()),
+        source_factor_refs=tuple(row.get("source_factor_refs") or ()),
+        target_factor_refs=tuple(row.get("target_factor_refs") or ()),
+        alternative_group=(
+            str(row["alternative_group"])
+            if row.get("alternative_group") is not None
+            else None
+        ),
+        required=bool(row.get("required", True)),
+        residual_on_failure=(
+            str(row["residual_on_failure"])
+            if row.get("residual_on_failure")
+            else None
+        ),
+    )
+
+
+def _factor(row: Mapping[str, Any]) -> Factor[Any]:
+    return Factor(
+        factor_ref=str(row["factor_ref"]),
+        factor_type=str(row["factor_type"]),
+        alternatives=tuple(
+            _alternative(value)
+            for value in row.get("alternatives") or ()
+            if isinstance(value, Mapping)
+        ),
+        constraints=tuple(
+            _constraint(value)
+            for value in row.get("constraints") or ()
+            if isinstance(value, Mapping)
+        ),
+        residuals=tuple(row.get("residuals") or ()),
+        closure_state=str(row.get("closure_state") or "open"),
+        metadata=dict(row.get("metadata") or {}),
+    )
+
+
+def _graph(row: Mapping[str, Any]) -> PNFGraph:
+    return PNFGraph(
+        graph_ref=str(row["graph_ref"]),
+        document_ref=str(row["document_ref"]),
+        factors=tuple(
+            _factor(value)
+            for value in row.get("factors") or ()
+            if isinstance(value, Mapping)
+        ),
+        constraints=tuple(
+            _constraint(value)
+            for value in row.get("constraints") or ()
+            if isinstance(value, Mapping)
+        ),
+        relation_refs=tuple(row.get("relation_refs") or ()),
+        residuals=tuple(row.get("residuals") or ()),
+    )
+
+
+def _reidentify_graph(graph: PNFGraph) -> PNFGraph:
+    graph_ref = "pnf-fibred-graph:" + canonical_sha256(
+        {
+            "document_ref": graph.document_ref,
+            "factors": [row.to_dict() for row in graph.factors],
+            "constraints": [row.to_dict() for row in graph.constraints],
+            "relation_refs": list(graph.relation_refs),
+            "residuals": list(graph.residuals),
+            "materialisation_contract": "deterministic-fibrewise-pnf:v0_1",
+        }
+    )
+    return replace(graph, graph_ref=graph_ref)
+
+
+def compile_document_fibred_operational(
+    document_input: Mapping[str, Any],
+    compiler_context: legacy.CompilerContext,
+    *,
+    closure_workers: int = 2,
+    owner_partitions: int = 2,
+) -> legacy.DocumentCompilation:
+    """Compile a document and return the fibrewise PNF materialised view."""
+
+    base = compile_document_operational(
+        document_input,
+        compiler_context,
+        closure_workers=closure_workers,
+        owner_partitions=owner_partitions,
+    )
+    artifacts = dict(base.artifacts)
+    streaming_build = dict(artifacts.get("streaming_semantic_build") or {})
+    source_graph_row = (
+        artifacts.get("refined_pnf_graph")
+        or artifacts.get("pnf_graph")
+        or {}
+    )
+    source_graph = _graph(source_graph_row)
+    fibred_graph, projection_receipt = project_streaming_reduction(
+        graph=source_graph,
+        streaming_build=streaming_build,
+    )
+    fibred_graph = _reidentify_graph(fibred_graph)
+    fibred_build = project_fibred_semantic_build(streaming_build)
+    streaming_build.update(
+        {
+            "fibred_semantic_build": fibred_build,
+            "fibre_ledger_ref": fibred_build["fibre_ledger"]["ledger_ref"],
+            "integrated_producer_receipt": fibred_build[
+                "integrated_producer_receipt"
+            ],
+            "fibre_boundary_obligations": fibred_build[
+                "fibre_boundary_obligations"
+            ],
+            "materialized_pnf_graph_ref": fibred_graph.graph_ref,
+            "materialized_view_authority": "deterministic_fibrewise_pnf",
+            "one_proposal_contract": True,
+            "one_reduction_authority": True,
+        }
+    )
+    compatibility_refinements = list(
+        artifacts.get("factor_refinements") or ()
+    )
+    demands = derive_resolution_demands(fibred_graph)
+    phase_boundary = dict(artifacts.get("phase_boundary") or {})
+    phase_boundary.update(
+        {
+            "fibred_semantic_state": True,
+            "one_integrated_producer": True,
+            "one_proposal_contract": True,
+            "one_reduction_authority": True,
+        }
+    )
+    artifacts.update(
+        {
+            "pre_fibre_pnf_graph": artifacts.get("pnf_graph"),
+            "pre_fibre_refined_pnf_graph": artifacts.get(
+                "refined_pnf_graph"
+            ),
+            "compatibility_factor_refinements": compatibility_refinements,
+            "factor_refinements": [],
+            "pnf_graph": fibred_graph.to_dict(),
+            "refined_pnf_graph": fibred_graph.to_dict(),
+            "resolution_demands": [row.to_dict() for row in demands],
+            "streaming_semantic_build": streaming_build,
+            "fibred_semantic_build": fibred_build,
+            "streaming_reduction_projection": projection_receipt,
+            "operational_compiler_contract": (
+                FIBRED_OPERATIONAL_COMPILER_CONTRACT
+            ),
+            "base_operational_compiler_contract": OPERATIONAL_COMPILER_CONTRACT,
+            "phase_boundary": phase_boundary,
+        }
+    )
+    return legacy.DocumentCompilation(
+        document_ref=base.document_ref,
+        content_sha256=base.content_sha256,
+        media_type=base.media_type,
+        artifacts=artifacts,
+        status=base.status,
+        failure=base.failure,
+    )
+
+
+__all__ = [
+    "FIBRED_OPERATIONAL_COMPILER_CONTRACT",
+    "compile_document_fibred_operational",
+]

--- a/src/policy/fibred_operational_corpus_compilation.py
+++ b/src/policy/fibred_operational_corpus_compilation.py
@@ -3,8 +3,9 @@
 The existing compiler still performs canonical parsing, mention licensing,
 structural typing, local meets, and streaming job execution. This wrapper makes
 the deterministic streamed fibre reduction the PNF materialised view returned
-to persistence and downstream projections, while retaining the pre-fibre
-artifacts as compatibility evidence.
+to persistence and downstream projections, evaluates the constraint frontier
+against that view, and retains pre-fibre artifacts only as compatibility
+evidence.
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ from dataclasses import replace
 from typing import Any, Mapping
 
 from src.pnf import PNFGraph, derive_resolution_demands
+from src.pnf.constraint_worklist import evaluate_constraint_worklist
 from src.pnf.fibred_build_projection import project_fibred_semantic_build
 from src.pnf.streaming_reduction_projection import project_streaming_reduction
 from src.policy import corpus_compilation as legacy
@@ -144,6 +146,15 @@ def compile_document_fibred_operational(
         streaming_build=streaming_build,
     )
     fibred_graph = _reidentify_graph(fibred_graph)
+    changed_factor_refs = tuple(
+        str(ref) for ref in projection_receipt.get("factor_refs") or ()
+    )
+    constraint_worklist = evaluate_constraint_worklist(
+        document_ref=fibred_graph.document_ref,
+        factor_refs=(row.factor_ref for row in fibred_graph.factors),
+        constraints=fibred_graph.constraints,
+        changed_factor_refs=(changed_factor_refs or None),
+    )
     fibred_build = project_fibred_semantic_build(streaming_build)
     streaming_build.update(
         {
@@ -157,6 +168,7 @@ def compile_document_fibred_operational(
             ],
             "materialized_pnf_graph_ref": fibred_graph.graph_ref,
             "materialized_view_authority": "deterministic_fibrewise_pnf",
+            "constraint_worklist_ref": constraint_worklist.result_ref,
             "one_proposal_contract": True,
             "one_reduction_authority": True,
         }
@@ -169,6 +181,7 @@ def compile_document_fibred_operational(
     phase_boundary.update(
         {
             "fibred_semantic_state": True,
+            "constraints_after_fibre_materialisation": True,
             "one_integrated_producer": True,
             "one_proposal_contract": True,
             "one_reduction_authority": True,
@@ -180,8 +193,15 @@ def compile_document_fibred_operational(
             "pre_fibre_refined_pnf_graph": artifacts.get(
                 "refined_pnf_graph"
             ),
+            "pre_fibre_constraint_assessments": artifacts.get(
+                "constraint_assessments"
+            ),
             "compatibility_factor_refinements": compatibility_refinements,
             "factor_refinements": [],
+            "constraint_assessments": [
+                row.to_dict() for row in constraint_worklist.assessments
+            ],
+            "fibred_constraint_worklist": constraint_worklist.to_dict(),
             "pnf_graph": fibred_graph.to_dict(),
             "refined_pnf_graph": fibred_graph.to_dict(),
             "resolution_demands": [row.to_dict() for row in demands],

--- a/src/policy/streaming_postgres_corpus_compilation.py
+++ b/src/policy/streaming_postgres_corpus_compilation.py
@@ -180,9 +180,7 @@ def persist_streaming_document_compilation(
     compatibility_refinements = tuple(
         artifacts.get("compatibility_factor_refinements") or refinements
     )
-    candidate_sets = tuple(
-        artifacts.get("binding_candidate_sets") or ()
-    )
+    candidate_sets = tuple(artifacts.get("binding_candidate_sets") or ())
     factor_anchors = tuple(artifacts.get("factor_anchors") or ())
     candidate_set_builds = tuple(
         artifacts.get("binding_candidate_set_builds") or ()
@@ -200,6 +198,9 @@ def persist_streaming_document_compilation(
         )
     if not streaming_build.get("one_reduction_authority"):
         raise ValueError("fibred build requires one reduction authority")
+    expected_producer_receipt = (
+        streaming_build.get("integrated_producer_receipt") or {}
+    )
 
     persistence_started = monotonic_ns()
     with store.savepoint() as cursor:
@@ -290,7 +291,7 @@ def persist_streaming_document_compilation(
             streaming_build=streaming_build,
             stage_timing_ledger=persisted_stage_timing,
         )
-        persist_semantic_fibre_artifacts(
+        persisted_producer_receipt = persist_semantic_fibre_artifacts(
             cursor,
             document_ref=compilation.document_ref,
             observation_deltas=tuple(
@@ -337,6 +338,19 @@ def persist_streaming_document_compilation(
                 if isinstance(row, Mapping)
             ),
         )
+        if expected_producer_receipt:
+            if persisted_producer_receipt.fibre_ledger_ref != str(
+                expected_producer_receipt.get("fibre_ledger_ref") or ""
+            ):
+                raise ValueError(
+                    "persisted fibre ledger disagrees with compiler receipt"
+                )
+            if persisted_producer_receipt.receipt_ref != str(
+                expected_producer_receipt.get("receipt_ref") or ""
+            ):
+                raise ValueError(
+                    "persisted producer receipt disagrees with compiler receipt"
+                )
         persist_completed_operational_build(
             cursor,
             document_ref=compilation.document_ref,

--- a/src/policy/streaming_postgres_corpus_compilation.py
+++ b/src/policy/streaming_postgres_corpus_compilation.py
@@ -1,4 +1,4 @@
-"""Transactional PostgreSQL persistence for streaming semantic document builds."""
+"""Transactional PostgreSQL persistence for fibred streaming document builds."""
 
 from __future__ import annotations
 
@@ -6,9 +6,9 @@ from time import monotonic_ns
 from typing import Any, Mapping
 
 from src.policy.corpus_compilation import CompilerContext
-from src.policy.operational_corpus_compilation import (
-    OPERATIONAL_COMPILER_CONTRACT,
-    compile_document_operational,
+from src.policy.fibred_operational_corpus_compilation import (
+    FIBRED_OPERATIONAL_COMPILER_CONTRACT,
+    compile_document_fibred_operational,
 )
 from src.policy.postgres_corpus_compilation import (
     _canonical_source_coordinates,
@@ -55,7 +55,7 @@ def _with_persistence_timing(
         elapsed_ms=elapsed_ms,
         backend_ref="postgresql",
         details={
-            "transaction_scope": "document_immutable_build",
+            "transaction_scope": "document_immutable_fibred_build",
             "excludes": [
                 "semantic_stage_timing_insert",
                 "completed_build_receipt_insert",
@@ -89,7 +89,7 @@ def persist_streaming_document_compilation(
     closure_workers: int = 2,
     owner_partitions: int = 2,
 ) -> tuple[str, ...]:
-    """Compile and persist one immutable document and its fixed-point evidence."""
+    """Compile and persist one immutable fibred fixed-point document build."""
 
     document_ref = str(entry["document_ref"])
     content_sha256 = str(entry["content_sha256"])
@@ -132,7 +132,7 @@ def persist_streaming_document_compilation(
         cached_demand_refs = load_completed_operational_build(
             cursor,
             document_ref=document_ref,
-            compiler_contract_ref=OPERATIONAL_COMPILER_CONTRACT,
+            compiler_contract_ref=FIBRED_OPERATIONAL_COMPILER_CONTRACT,
             build_key_sha256=build_key_sha256,
         )
         if cached_demand_refs is not None:
@@ -145,7 +145,7 @@ def persist_streaming_document_compilation(
             )
             return cached_demand_refs
 
-    compilation = compile_document_operational(
+    compilation = compile_document_fibred_operational(
         {
             "document_ref": document_ref,
             "content_sha256": content_sha256,
@@ -162,6 +162,10 @@ def persist_streaming_document_compilation(
         raise ValueError(
             "operational compiler build key disagrees with persistence"
         )
+    if artifacts.get("operational_compiler_contract") != (
+        FIBRED_OPERATIONAL_COMPILER_CONTRACT
+    ):
+        raise ValueError("catalogue persistence requires the fibred compiler")
     source_normalisation = artifacts.get("source_normalisation") or {}
     if str(source_normalisation.get("adapter_ref") or "") != media_adapter_ref:
         raise ValueError(
@@ -173,6 +177,9 @@ def persist_streaming_document_compilation(
         expected_sha256=canonical_text_sha256,
     )
     refinements = tuple(artifacts.get("factor_refinements") or ())
+    compatibility_refinements = tuple(
+        artifacts.get("compatibility_factor_refinements") or refinements
+    )
     candidate_sets = tuple(
         artifacts.get("binding_candidate_sets") or ()
     )
@@ -191,6 +198,8 @@ def persist_streaming_document_compilation(
         raise ValueError(
             "only locally fixed-point streaming builds may be persisted"
         )
+    if not streaming_build.get("one_reduction_authority"):
+        raise ValueError("fibred build requires one reduction authority")
 
     persistence_started = monotonic_ns()
     with store.savepoint() as cursor:
@@ -258,7 +267,7 @@ def persist_streaming_document_compilation(
         persist_binding_candidate_sets(
             cursor,
             candidate_sets=candidate_sets,
-            refinements=refinements,
+            refinements=compatibility_refinements,
             factor_revisions=base_factor_revisions,
             factor_anchors=factor_anchors,
             builds=candidate_set_builds,
@@ -331,7 +340,7 @@ def persist_streaming_document_compilation(
         persist_completed_operational_build(
             cursor,
             document_ref=compilation.document_ref,
-            compiler_contract_ref=OPERATIONAL_COMPILER_CONTRACT,
+            compiler_contract_ref=FIBRED_OPERATIONAL_COMPILER_CONTRACT,
             build_key_sha256=build_key_sha256,
             graph_ref=str(artifacts["pnf_graph"]["graph_ref"]),
             demand_refs=demand_refs,

--- a/src/policy/streaming_postgres_corpus_compilation.py
+++ b/src/policy/streaming_postgres_corpus_compilation.py
@@ -27,6 +27,9 @@ from src.storage.postgres.operational_build_store import (
     load_completed_operational_build,
     persist_completed_operational_build,
 )
+from src.storage.postgres.semantic_fibre_store import (
+    persist_semantic_fibre_artifacts,
+)
 from src.storage.postgres.semantic_store import (
     persist_pnf_graph,
     persist_resolution_artifacts,
@@ -277,6 +280,53 @@ def persist_streaming_document_compilation(
             document_ref=compilation.document_ref,
             streaming_build=streaming_build,
             stage_timing_ledger=persisted_stage_timing,
+        )
+        persist_semantic_fibre_artifacts(
+            cursor,
+            document_ref=compilation.document_ref,
+            observation_deltas=tuple(
+                row
+                for row in streaming_build.get("observation_deltas") or ()
+                if isinstance(row, Mapping)
+            ),
+            proposals=tuple(
+                row
+                for row in streaming_build.get("proposals") or ()
+                if isinstance(row, Mapping)
+            ),
+            solver_jobs=tuple(
+                row
+                for row in streaming_build.get("solver_jobs") or ()
+                if isinstance(row, Mapping)
+            ),
+            solver_receipts=tuple(
+                row
+                for row in streaming_build.get("solver_receipts") or ()
+                if isinstance(row, Mapping)
+            ),
+            materialized_reduction=(
+                streaming_build.get("materialized_reduction") or {}
+            ),
+            transports=tuple(
+                row
+                for row in streaming_build.get("semantic_transports") or ()
+                if isinstance(row, Mapping)
+            ),
+            ontology_axes=tuple(
+                row
+                for row in streaming_build.get("ontology_axes") or ()
+                if isinstance(row, Mapping)
+            ),
+            axis_obligations=tuple(
+                row
+                for row in streaming_build.get("axis_obligations") or ()
+                if isinstance(row, Mapping)
+            ),
+            boundary_obligations=tuple(
+                row
+                for row in streaming_build.get("fibre_boundary_obligations") or ()
+                if isinstance(row, Mapping)
+            ),
         )
         persist_completed_operational_build(
             cursor,

--- a/src/storage/postgres/semantic_fibre_store.py
+++ b/src/storage/postgres/semantic_fibre_store.py
@@ -1,0 +1,584 @@
+"""PostgreSQL persistence for the fibred integrated semantic compiler."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Sequence
+
+from src.pnf.factor_proposals import INTEGRATED_SEMANTIC_PRODUCER_CONTRACT
+from src.pnf.integrated_semantic_producer import IntegratedProducerReceipt
+from src.pnf.semantic_fibres import (
+    AxisObligation,
+    FibreBoundaryObligation,
+    FibreDerivation,
+    FibreElement,
+    OntologyAxis,
+    SemanticCoordinate,
+    SemanticFibreLedger,
+    SemanticTransport,
+    fibre_element_from_proposal_row,
+)
+
+
+def _json(value: object) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def _persist_coordinate(cursor: Any, row: SemanticCoordinate) -> None:
+    payload = row.to_dict()
+    cursor.execute(
+        """
+        INSERT INTO semantic_coordinate
+            (coordinate_ref, document_ref, scope_ref, source_span_refs,
+             statement_role, factor_family, coordinate_kind,
+             source_coordinate_refs, target_coordinate_refs)
+        VALUES (%s, %s, %s, %s::jsonb, %s, %s, %s, %s::jsonb, %s::jsonb)
+        ON CONFLICT (coordinate_ref) DO NOTHING
+        """,
+        (
+            payload["coordinate_ref"],
+            payload["document_ref"],
+            payload["scope_ref"],
+            _json(payload["source_span_refs"]),
+            payload["statement_role"],
+            payload["factor_family"],
+            payload["coordinate_kind"],
+            _json(payload["source_coordinate_refs"]),
+            _json(payload["target_coordinate_refs"]),
+        ),
+    )
+
+
+def _persist_element(cursor: Any, row: FibreElement) -> None:
+    payload = row.to_dict()
+    cursor.execute(
+        """
+        INSERT INTO semantic_fibre_element
+            (element_ref, document_ref, coordinate_ref, fibre_kind, content_ref,
+             derivation_role, producer_contract, operation_contract, source_refs,
+             dependency_refs, transport_refs, ontology_axis_refs, assumptions,
+             coverage_requirements, support_state, confidence, payload, external,
+             execution_metadata, authority, semantic_state_promoted,
+             legal_truth_closed)
+        VALUES
+            (%s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb,
+             %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb, %s, %s,
+             %s::jsonb, %s, %s::jsonb, %s, FALSE, FALSE)
+        ON CONFLICT (element_ref) DO NOTHING
+        """,
+        (
+            payload["element_ref"],
+            payload["document_ref"],
+            payload["coordinate_ref"],
+            payload["fibre_kind"],
+            payload["content_ref"],
+            payload["derivation_role"],
+            payload["producer_contract"],
+            payload["operation_contract"],
+            _json(payload["source_refs"]),
+            _json(payload["dependency_refs"]),
+            _json(payload["transport_refs"]),
+            _json(payload["ontology_axis_refs"]),
+            _json(payload["assumptions"]),
+            _json(payload["coverage_requirements"]),
+            payload["support_state"],
+            payload["confidence"],
+            _json(payload["payload"]),
+            payload["external"],
+            _json(payload["execution_metadata"]),
+            payload["authority"],
+        ),
+    )
+
+
+def _persist_derivation(cursor: Any, row: FibreDerivation) -> None:
+    payload = row.to_dict()
+    cursor.execute(
+        """
+        INSERT INTO semantic_fibre_derivation
+            (derivation_ref, document_ref, operation_kind, declaration_ref,
+             producer_contract, input_element_refs, output_element_refs,
+             sub_executor_ref, rule_set_revision, receipt_ref, assumptions,
+             metrics, semantic_state_promoted)
+        VALUES
+            (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s, %s,
+             %s::jsonb, %s::jsonb, FALSE)
+        ON CONFLICT (derivation_ref) DO NOTHING
+        """,
+        (
+            payload["derivation_ref"],
+            payload["document_ref"],
+            payload["operation_kind"],
+            payload["declaration_ref"],
+            payload["producer_contract"],
+            _json(payload["input_element_refs"]),
+            _json(payload["output_element_refs"]),
+            payload["sub_executor_ref"],
+            payload["rule_set_revision"],
+            payload["receipt_ref"],
+            _json(payload["assumptions"]),
+            _json(payload["metrics"]),
+        ),
+    )
+
+
+def _proposal_coordinate(proposal: Mapping[str, Any]) -> SemanticCoordinate:
+    coordinate = SemanticCoordinate(
+        document_ref=str(proposal["document_ref"]),
+        scope_ref=str(proposal.get("scope_ref") or "document-global"),
+        source_span_refs=tuple(
+            str(ref) for ref in proposal.get("source_span_refs") or ()
+        ),
+        statement_role=str(proposal.get("statement_role") or "main"),
+        factor_family=str(proposal["factor_type_ref"]),
+        coordinate_kind=str(proposal.get("coordinate_kind") or "object"),
+    )
+    declared_ref = str(proposal.get("semantic_coordinate_ref") or "")
+    if declared_ref and declared_ref != coordinate.coordinate_ref:
+        raise ValueError("persisted proposal coordinate is not canonical")
+    return coordinate
+
+
+def _persist_proposal_extension(cursor: Any, proposal: Mapping[str, Any]) -> None:
+    cursor.execute(
+        """
+        UPDATE pnf_factor_proposal
+        SET semantic_coordinate_ref = %s,
+            scope_ref = %s,
+            statement_role = %s,
+            coordinate_kind = %s,
+            fibre_kind = %s,
+            derivation_role = %s,
+            producer_scope = %s,
+            operation_contract = %s,
+            ontology_axis_refs = %s::jsonb,
+            transport_refs = %s::jsonb,
+            support_state = %s,
+            confidence = %s,
+            assumptions = %s::jsonb,
+            coverage_requirements = %s::jsonb,
+            execution_metadata = %s::jsonb
+        WHERE proposal_ref = %s
+        """,
+        (
+            proposal.get("semantic_coordinate_ref"),
+            proposal.get("scope_ref"),
+            proposal.get("statement_role") or "main",
+            proposal.get("coordinate_kind") or "object",
+            proposal.get("fibre_kind") or "hypothesis",
+            proposal.get("derivation_role") or "support",
+            proposal.get("producer_scope") or "integrated",
+            proposal.get("operation_contract"),
+            _json(proposal.get("ontology_axis_refs") or ()),
+            _json(proposal.get("transport_refs") or ()),
+            proposal.get("support_state") or "candidate",
+            proposal.get("confidence"),
+            _json(proposal.get("assumptions") or ()),
+            _json(proposal.get("coverage_requirements") or ()),
+            _json(proposal.get("execution_metadata") or {}),
+            proposal["proposal_ref"],
+        ),
+    )
+
+
+def _persist_optional_transport(cursor: Any, row: Mapping[str, Any]) -> None:
+    cursor.execute(
+        """
+        INSERT INTO semantic_transport
+            (transport_ref, document_ref, source_coordinate_ref,
+             target_coordinate_ref, transport_type, strength, evidence_refs,
+             ontology_axis_refs, allowed_operations, residual_refs,
+             identity_closed, semantic_state_promoted)
+        VALUES
+            (%s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb,
+             %s::jsonb, %s::jsonb, FALSE, FALSE)
+        ON CONFLICT (transport_ref) DO NOTHING
+        """,
+        (
+            row["transport_ref"],
+            row["document_ref"],
+            row["source_coordinate_ref"],
+            row["target_coordinate_ref"],
+            row["transport_type"],
+            row["strength"],
+            _json(row.get("evidence_refs") or ()),
+            _json(row.get("ontology_axis_refs") or ()),
+            _json(row.get("allowed_operations") or ()),
+            _json(row.get("residual_refs") or ()),
+        ),
+    )
+
+
+def persist_semantic_fibre_artifacts(
+    cursor: Any,
+    *,
+    document_ref: str,
+    observation_deltas: Sequence[Mapping[str, Any]],
+    proposals: Sequence[Mapping[str, Any]],
+    solver_jobs: Sequence[Mapping[str, Any]],
+    solver_receipts: Sequence[Mapping[str, Any]],
+    materialized_reduction: Mapping[str, Any],
+    transports: Sequence[Mapping[str, Any]] = (),
+    ontology_axes: Sequence[Mapping[str, Any]] = (),
+    axis_obligations: Sequence[Mapping[str, Any]] = (),
+    boundary_obligations: Sequence[Mapping[str, Any]] = (),
+) -> IntegratedProducerReceipt:
+    """Persist the fibred view derived from the ordinary streaming evidence."""
+
+    coordinates: dict[str, SemanticCoordinate] = {}
+    elements: list[FibreElement] = []
+    content_to_element_ref: dict[str, str] = {}
+
+    for delta in observation_deltas:
+        parser_contract = str(delta.get("parser_contract") or "")
+        scope_ref = str(delta.get("scope_ref") or "document-global")
+        for observation in delta.get("observations") or ():
+            if not isinstance(observation, Mapping):
+                continue
+            observation_ref = str(observation.get("observation_ref") or "")
+            coordinate_ref = str(
+                observation.get("semantic_coordinate_ref") or ""
+            )
+            if not observation_ref or not coordinate_ref:
+                continue
+            coordinate = SemanticCoordinate(
+                document_ref=document_ref,
+                scope_ref=scope_ref,
+                source_span_refs=(observation_ref,),
+                statement_role="parser_observation",
+                factor_family=str(
+                    observation.get("observation_type") or "parser.observation"
+                ),
+                coordinate_kind="object",
+            )
+            if coordinate.coordinate_ref != coordinate_ref:
+                raise ValueError("parser observation coordinate is not canonical")
+            element = FibreElement(
+                document_ref=document_ref,
+                coordinate_ref=coordinate_ref,
+                fibre_kind="observation",
+                content_ref=observation_ref,
+                derivation_role="support",
+                producer_contract=INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
+                operation_contract=parser_contract,
+                source_refs=(observation_ref,),
+                support_state="candidate",
+                payload=dict(observation),
+                execution_metadata={"parser_contract": parser_contract},
+            )
+            coordinates[coordinate_ref] = coordinate
+            elements.append(element)
+            content_to_element_ref[observation_ref] = element.element_ref
+
+    for proposal in proposals:
+        coordinate = _proposal_coordinate(proposal)
+        element = fibre_element_from_proposal_row(proposal)
+        coordinates[coordinate.coordinate_ref] = coordinate
+        elements.append(element)
+        content_to_element_ref[str(proposal["proposal_ref"])] = element.element_ref
+        _persist_proposal_extension(cursor, proposal)
+
+    for coordinate in coordinates.values():
+        _persist_coordinate(cursor, coordinate)
+    for element in elements:
+        _persist_element(cursor, element)
+
+    jobs = {
+        str(row.get("job_ref") or ""): row
+        for row in solver_jobs
+        if row.get("job_ref")
+    }
+    proposal_by_ref = {
+        str(row.get("proposal_ref") or ""): row
+        for row in proposals
+        if row.get("proposal_ref")
+    }
+    derivations: list[FibreDerivation] = []
+    for receipt in solver_receipts:
+        job = jobs.get(str(receipt.get("job_ref") or ""), {})
+        proposal_refs = tuple(
+            str(ref) for ref in receipt.get("proposal_refs") or ()
+        )
+        proposal_rows = [
+            proposal_by_ref[ref] for ref in proposal_refs if ref in proposal_by_ref
+        ]
+        operation_contract = str(
+            proposal_rows[0].get("operation_contract")
+            if proposal_rows
+            else job.get("declaration_ref") or ""
+        )
+        operation_kind = str(
+            (
+                proposal_rows[0].get("execution_metadata") or {}
+            ).get("operation_kind")
+            if proposal_rows
+            else "closure"
+        )
+        derivation = FibreDerivation(
+            document_ref=document_ref,
+            operation_kind=operation_kind or "closure",
+            declaration_ref=str(job.get("declaration_ref") or ""),
+            producer_contract=INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
+            input_element_refs=tuple(
+                content_to_element_ref.get(str(ref), str(ref))
+                for ref in receipt.get("input_refs") or ()
+            ),
+            output_element_refs=tuple(
+                content_to_element_ref[ref]
+                for ref in proposal_refs
+                if ref in content_to_element_ref
+            ),
+            sub_executor_ref=str(receipt.get("backend_ref") or ""),
+            rule_set_revision=str(receipt.get("rule_set_revision") or ""),
+            receipt_ref=str(receipt.get("receipt_ref") or "") or None,
+            assumptions=tuple(
+                str(ref) for ref in receipt.get("assumptions") or ()
+            ),
+            metrics=dict(receipt.get("metrics") or {}),
+        )
+        derivations.append(derivation)
+        _persist_derivation(cursor, derivation)
+
+    transport_rows = tuple(
+        SemanticTransport(
+            document_ref=str(row["document_ref"]),
+            source_coordinate_ref=str(row["source_coordinate_ref"]),
+            target_coordinate_ref=str(row["target_coordinate_ref"]),
+            transport_type=str(row["transport_type"]),
+            strength=str(row["strength"]),
+            evidence_refs=tuple(row.get("evidence_refs") or ()),
+            ontology_axis_refs=tuple(row.get("ontology_axis_refs") or ()),
+            allowed_operations=tuple(row.get("allowed_operations") or ()),
+            residual_refs=tuple(row.get("residual_refs") or ()),
+        )
+        for row in transports
+    )
+    for row in transport_rows:
+        _persist_optional_transport(cursor, row.to_dict())
+
+    axis_rows = tuple(
+        OntologyAxis(
+            axis_ref=str(row["axis_ref"]),
+            label=str(row["label"]),
+            authority_ref=str(row["authority_ref"]),
+            relation_refs=tuple(row.get("relation_refs") or ()),
+            root_refs=tuple(row.get("root_refs") or ()),
+            open_world=bool(row.get("open_world", True)),
+        )
+        for row in ontology_axes
+    )
+    for row in axis_rows:
+        payload = row.to_dict()
+        cursor.execute(
+            """
+            INSERT INTO semantic_ontology_axis
+                (axis_ref, label, authority_ref, relation_refs, root_refs,
+                 open_world)
+            VALUES (%s, %s, %s, %s::jsonb, %s::jsonb, %s)
+            ON CONFLICT (axis_ref) DO NOTHING
+            """,
+            (
+                payload["axis_ref"],
+                payload["label"],
+                payload["authority_ref"],
+                _json(payload["relation_refs"]),
+                _json(payload["root_refs"]),
+                payload["open_world"],
+            ),
+        )
+
+    obligation_rows = tuple(
+        AxisObligation(
+            document_ref=str(row["document_ref"]),
+            coordinate_ref=str(row["coordinate_ref"]),
+            axis_ref=str(row["axis_ref"]),
+            obligation_type=str(row["obligation_type"]),
+            trigger_refs=tuple(row.get("trigger_refs") or ()),
+            frontier_refs=tuple(row.get("frontier_refs") or ()),
+            state=str(row.get("state") or "open"),
+            resource_limit_reached=bool(
+                row.get("resource_limit_reached", False)
+            ),
+        )
+        for row in axis_obligations
+    )
+    for row in obligation_rows:
+        payload = row.to_dict()
+        cursor.execute(
+            """
+            INSERT INTO semantic_axis_obligation
+                (obligation_ref, document_ref, coordinate_ref, axis_ref,
+                 obligation_type, trigger_refs, frontier_refs, state,
+                 resource_limit_reached, truth_closed)
+            VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s, FALSE)
+            ON CONFLICT (obligation_ref) DO NOTHING
+            """,
+            (
+                payload["obligation_ref"],
+                payload["document_ref"],
+                payload["coordinate_ref"],
+                payload["axis_ref"],
+                payload["obligation_type"],
+                _json(payload["trigger_refs"]),
+                _json(payload["frontier_refs"]),
+                payload["state"],
+                payload["resource_limit_reached"],
+            ),
+        )
+
+    boundary_rows = tuple(
+        FibreBoundaryObligation(
+            document_ref=str(row["document_ref"]),
+            coordinate_ref=str(row["coordinate_ref"]),
+            scope_ref=str(row["scope_ref"]),
+            boundary_kind=str(row["boundary_kind"]),
+            evidence_refs=tuple(row.get("evidence_refs") or ()),
+            frontier_refs=tuple(row.get("frontier_refs") or ()),
+            required_axis_refs=tuple(row.get("required_axis_refs") or ()),
+            state=str(row.get("state") or "open"),
+            message=str(row.get("message") or ""),
+        )
+        for row in boundary_obligations
+    )
+    for row in boundary_rows:
+        payload = row.to_dict()
+        cursor.execute(
+            """
+            INSERT INTO semantic_fibre_boundary_obligation
+                (boundary_ref, document_ref, coordinate_ref, scope_ref,
+                 boundary_kind, evidence_refs, frontier_refs,
+                 required_axis_refs, state, message)
+            VALUES
+                (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb,
+                 %s::jsonb, %s, %s)
+            ON CONFLICT (boundary_ref) DO NOTHING
+            """,
+            (
+                payload["boundary_ref"],
+                payload["document_ref"],
+                payload["coordinate_ref"],
+                payload["scope_ref"],
+                payload["boundary_kind"],
+                _json(payload["evidence_refs"]),
+                _json(payload["frontier_refs"]),
+                _json(payload["required_axis_refs"]),
+                payload["state"],
+                payload["message"],
+            ),
+        )
+
+    graph_ref = str(materialized_reduction.get("graph_ref") or "")
+    for factor in materialized_reduction.get("factors") or ():
+        cursor.execute(
+            """
+            INSERT INTO semantic_fibre_summary
+                (factor_ref, graph_ref, document_ref, semantic_coordinate_ref,
+                 fibre_kind, factor_type_ref, structural_signature,
+                 proposal_refs, derivation_roles, ontology_axis_refs,
+                 transport_refs, support_states, residual_refs,
+                 deterministic_materialisation, identity_promoted,
+                 legal_truth_closed)
+            VALUES
+                (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb,
+                 %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb,
+                 TRUE, FALSE, FALSE)
+            ON CONFLICT (factor_ref) DO NOTHING
+            """,
+            (
+                factor["factor_ref"],
+                graph_ref,
+                document_ref,
+                factor.get("semantic_coordinate_ref"),
+                factor.get("fibre_kind") or "hypothesis",
+                factor["factor_type_ref"],
+                factor.get("structural_signature") or "",
+                _json(factor.get("proposal_refs") or ()),
+                _json(factor.get("derivation_roles") or ()),
+                _json(factor.get("ontology_axis_refs") or ()),
+                _json(factor.get("transport_refs") or ()),
+                _json(factor.get("support_states") or ()),
+                _json(factor.get("residuals") or ()),
+            ),
+        )
+
+    ledger = SemanticFibreLedger(
+        coordinates=tuple(
+            coordinates[key] for key in sorted(coordinates)
+        ),
+        elements=tuple(sorted(elements, key=lambda row: row.element_ref)),
+        transports=tuple(
+            sorted(transport_rows, key=lambda row: row.transport_ref)
+        ),
+        derivations=tuple(
+            sorted(derivations, key=lambda row: row.derivation_ref)
+        ),
+        ontology_axes=tuple(sorted(axis_rows, key=lambda row: row.axis_ref)),
+        axis_obligations=tuple(
+            sorted(obligation_rows, key=lambda row: row.obligation_ref)
+        ),
+        boundary_obligations=tuple(
+            sorted(boundary_rows, key=lambda row: row.boundary_ref)
+        ),
+    )
+    producer_receipt = IntegratedProducerReceipt(
+        document_ref=document_ref,
+        contract_ref=INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
+        proposal_refs=tuple(
+            sorted(str(row["proposal_ref"]) for row in proposals)
+        ),
+        sub_executor_receipt_refs=tuple(
+            sorted(
+                str(row.get("receipt_ref") or "")
+                for row in solver_receipts
+                if row.get("receipt_ref")
+            )
+        ),
+        fibre_ledger_ref=ledger.ledger_ref,
+        residual_refs=tuple(
+            sorted(
+                str(row.get("residual_ref") or "")
+                for row in materialized_reduction.get("residuals") or ()
+                if row.get("residual_ref")
+            )
+        ),
+        external_proposal_refs=tuple(
+            sorted(
+                str(row["proposal_ref"])
+                for row in proposals
+                if str(row.get("producer_scope") or "integrated") == "external"
+            )
+        ),
+    )
+    payload = producer_receipt.to_dict()
+    cursor.execute(
+        """
+        INSERT INTO integrated_semantic_producer_receipt
+            (receipt_ref, document_ref, contract_ref, proposal_refs,
+             sub_executor_receipt_refs, fibre_ledger_ref, residual_refs,
+             external_proposal_refs, one_proposal_contract,
+             one_reduction_authority, identity_promoted, legal_truth_closed)
+        VALUES
+            (%s, %s, %s, %s::jsonb, %s::jsonb, %s, %s::jsonb,
+             %s::jsonb, TRUE, TRUE, FALSE, FALSE)
+        ON CONFLICT (receipt_ref) DO NOTHING
+        """,
+        (
+            payload["receipt_ref"],
+            payload["document_ref"],
+            payload["contract_ref"],
+            _json(payload["proposal_refs"]),
+            _json(payload["sub_executor_receipt_refs"]),
+            payload["fibre_ledger_ref"],
+            _json(payload["residual_refs"]),
+            _json(payload["external_proposal_refs"]),
+        ),
+    )
+    return producer_receipt
+
+
+__all__ = ["persist_semantic_fibre_artifacts"]

--- a/src/storage/postgres/semantic_fibre_store.py
+++ b/src/storage/postgres/semantic_fibre_store.py
@@ -186,7 +186,8 @@ def _persist_proposal_extension(cursor: Any, proposal: Mapping[str, Any]) -> Non
     )
 
 
-def _persist_optional_transport(cursor: Any, row: Mapping[str, Any]) -> None:
+def _persist_transport(cursor: Any, row: SemanticTransport) -> None:
+    payload = row.to_dict()
     cursor.execute(
         """
         INSERT INTO semantic_transport
@@ -200,40 +201,98 @@ def _persist_optional_transport(cursor: Any, row: Mapping[str, Any]) -> None:
         ON CONFLICT (transport_ref) DO NOTHING
         """,
         (
-            row["transport_ref"],
-            row["document_ref"],
-            row["source_coordinate_ref"],
-            row["target_coordinate_ref"],
-            row["transport_type"],
-            row["strength"],
-            _json(row.get("evidence_refs") or ()),
-            _json(row.get("ontology_axis_refs") or ()),
-            _json(row.get("allowed_operations") or ()),
-            _json(row.get("residual_refs") or ()),
+            payload["transport_ref"],
+            payload["document_ref"],
+            payload["source_coordinate_ref"],
+            payload["target_coordinate_ref"],
+            payload["transport_type"],
+            payload["strength"],
+            _json(payload["evidence_refs"]),
+            _json(payload["ontology_axis_refs"]),
+            _json(payload["allowed_operations"]),
+            _json(payload["residual_refs"]),
         ),
     )
 
 
-def persist_semantic_fibre_artifacts(
-    cursor: Any,
-    *,
+def _persist_axis(cursor: Any, row: OntologyAxis) -> None:
+    payload = row.to_dict()
+    cursor.execute(
+        """
+        INSERT INTO semantic_ontology_axis
+            (axis_ref, label, authority_ref, relation_refs, root_refs, open_world)
+        VALUES (%s, %s, %s, %s::jsonb, %s::jsonb, %s)
+        ON CONFLICT (axis_ref) DO NOTHING
+        """,
+        (
+            payload["axis_ref"],
+            payload["label"],
+            payload["authority_ref"],
+            _json(payload["relation_refs"]),
+            _json(payload["root_refs"]),
+            payload["open_world"],
+        ),
+    )
+
+
+def _persist_axis_obligation(cursor: Any, row: AxisObligation) -> None:
+    payload = row.to_dict()
+    cursor.execute(
+        """
+        INSERT INTO semantic_axis_obligation
+            (obligation_ref, document_ref, coordinate_ref, axis_ref,
+             obligation_type, trigger_refs, frontier_refs, state,
+             resource_limit_reached, truth_closed)
+        VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s, FALSE)
+        ON CONFLICT (obligation_ref) DO NOTHING
+        """,
+        (
+            payload["obligation_ref"],
+            payload["document_ref"],
+            payload["coordinate_ref"],
+            payload["axis_ref"],
+            payload["obligation_type"],
+            _json(payload["trigger_refs"]),
+            _json(payload["frontier_refs"]),
+            payload["state"],
+            payload["resource_limit_reached"],
+        ),
+    )
+
+
+def _persist_boundary(cursor: Any, row: FibreBoundaryObligation) -> None:
+    payload = row.to_dict()
+    cursor.execute(
+        """
+        INSERT INTO semantic_fibre_boundary_obligation
+            (boundary_ref, document_ref, coordinate_ref, scope_ref,
+             boundary_kind, evidence_refs, frontier_refs,
+             required_axis_refs, state, message)
+        VALUES
+            (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb, %s, %s)
+        ON CONFLICT (boundary_ref) DO NOTHING
+        """,
+        (
+            payload["boundary_ref"],
+            payload["document_ref"],
+            payload["coordinate_ref"],
+            payload["scope_ref"],
+            payload["boundary_kind"],
+            _json(payload["evidence_refs"]),
+            _json(payload["frontier_refs"]),
+            _json(payload["required_axis_refs"]),
+            payload["state"],
+            payload["message"],
+        ),
+    )
+
+
+def _observation_elements(
     document_ref: str,
     observation_deltas: Sequence[Mapping[str, Any]],
-    proposals: Sequence[Mapping[str, Any]],
-    solver_jobs: Sequence[Mapping[str, Any]],
-    solver_receipts: Sequence[Mapping[str, Any]],
-    materialized_reduction: Mapping[str, Any],
-    transports: Sequence[Mapping[str, Any]] = (),
-    ontology_axes: Sequence[Mapping[str, Any]] = (),
-    axis_obligations: Sequence[Mapping[str, Any]] = (),
-    boundary_obligations: Sequence[Mapping[str, Any]] = (),
-) -> IntegratedProducerReceipt:
-    """Persist the fibred view derived from the ordinary streaming evidence."""
-
+) -> tuple[dict[str, SemanticCoordinate], list[FibreElement]]:
     coordinates: dict[str, SemanticCoordinate] = {}
     elements: list[FibreElement] = []
-    content_to_element_ref: dict[str, str] = {}
-
     for delta in observation_deltas:
         parser_contract = str(delta.get("parser_contract") or "")
         scope_ref = str(delta.get("scope_ref") or "document-global")
@@ -273,30 +332,21 @@ def persist_semantic_fibre_artifacts(
             )
             coordinates[coordinate_ref] = coordinate
             elements.append(element)
-            content_to_element_ref[observation_ref] = element.element_ref
+    return coordinates, elements
 
-    for proposal in proposals:
-        coordinate = _proposal_coordinate(proposal)
-        element = fibre_element_from_proposal_row(proposal)
-        coordinates[coordinate.coordinate_ref] = coordinate
-        elements.append(element)
-        content_to_element_ref[str(proposal["proposal_ref"])] = element.element_ref
-        _persist_proposal_extension(cursor, proposal)
 
-    for coordinate in coordinates.values():
-        _persist_coordinate(cursor, coordinate)
-    for element in elements:
-        _persist_element(cursor, element)
-
+def _fibre_derivations(
+    *,
+    document_ref: str,
+    solver_jobs: Sequence[Mapping[str, Any]],
+    solver_receipts: Sequence[Mapping[str, Any]],
+    proposal_by_ref: Mapping[str, Mapping[str, Any]],
+    content_to_element_ref: Mapping[str, str],
+) -> tuple[FibreDerivation, ...]:
     jobs = {
         str(row.get("job_ref") or ""): row
         for row in solver_jobs
         if row.get("job_ref")
-    }
-    proposal_by_ref = {
-        str(row.get("proposal_ref") or ""): row
-        for row in proposals
-        if row.get("proposal_ref")
     }
     derivations: list[FibreDerivation] = []
     for receipt in solver_receipts:
@@ -305,45 +355,90 @@ def persist_semantic_fibre_artifacts(
             str(ref) for ref in receipt.get("proposal_refs") or ()
         )
         proposal_rows = [
-            proposal_by_ref[ref] for ref in proposal_refs if ref in proposal_by_ref
+            proposal_by_ref[ref]
+            for ref in proposal_refs
+            if ref in proposal_by_ref
         ]
-        operation_contract = str(
-            proposal_rows[0].get("operation_contract")
+        operation_kind = (
+            str(
+                (proposal_rows[0].get("execution_metadata") or {}).get(
+                    "operation_kind"
+                )
+                or ""
+            )
             if proposal_rows
-            else job.get("declaration_ref") or ""
+            else ""
+        ) or "closure"
+        derivations.append(
+            FibreDerivation(
+                document_ref=document_ref,
+                operation_kind=operation_kind,
+                declaration_ref=str(job.get("declaration_ref") or ""),
+                producer_contract=INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
+                input_element_refs=tuple(
+                    content_to_element_ref.get(str(ref), str(ref))
+                    for ref in receipt.get("input_refs") or ()
+                ),
+                output_element_refs=tuple(
+                    content_to_element_ref[ref]
+                    for ref in proposal_refs
+                    if ref in content_to_element_ref
+                ),
+                sub_executor_ref=str(receipt.get("backend_ref") or ""),
+                rule_set_revision=str(receipt.get("rule_set_revision") or ""),
+                receipt_ref=str(receipt.get("receipt_ref") or "") or None,
+                assumptions=tuple(
+                    str(ref) for ref in receipt.get("assumptions") or ()
+                ),
+                metrics=dict(receipt.get("metrics") or {}),
+            )
         )
-        operation_kind = str(
-            (
-                proposal_rows[0].get("execution_metadata") or {}
-            ).get("operation_kind")
-            if proposal_rows
-            else "closure"
-        )
-        derivation = FibreDerivation(
-            document_ref=document_ref,
-            operation_kind=operation_kind or "closure",
-            declaration_ref=str(job.get("declaration_ref") or ""),
-            producer_contract=INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
-            input_element_refs=tuple(
-                content_to_element_ref.get(str(ref), str(ref))
-                for ref in receipt.get("input_refs") or ()
-            ),
-            output_element_refs=tuple(
-                content_to_element_ref[ref]
-                for ref in proposal_refs
-                if ref in content_to_element_ref
-            ),
-            sub_executor_ref=str(receipt.get("backend_ref") or ""),
-            rule_set_revision=str(receipt.get("rule_set_revision") or ""),
-            receipt_ref=str(receipt.get("receipt_ref") or "") or None,
-            assumptions=tuple(
-                str(ref) for ref in receipt.get("assumptions") or ()
-            ),
-            metrics=dict(receipt.get("metrics") or {}),
-        )
-        derivations.append(derivation)
-        _persist_derivation(cursor, derivation)
+    return tuple(sorted(derivations, key=lambda row: row.derivation_ref))
 
+
+def persist_semantic_fibre_artifacts(
+    cursor: Any,
+    *,
+    document_ref: str,
+    observation_deltas: Sequence[Mapping[str, Any]],
+    proposals: Sequence[Mapping[str, Any]],
+    solver_jobs: Sequence[Mapping[str, Any]],
+    solver_receipts: Sequence[Mapping[str, Any]],
+    materialized_reduction: Mapping[str, Any],
+    transports: Sequence[Mapping[str, Any]] = (),
+    ontology_axes: Sequence[Mapping[str, Any]] = (),
+    axis_obligations: Sequence[Mapping[str, Any]] = (),
+    boundary_obligations: Sequence[Mapping[str, Any]] = (),
+) -> IntegratedProducerReceipt:
+    """Persist and return the exact fibre receipt derived from stream evidence."""
+
+    coordinates, elements = _observation_elements(
+        document_ref,
+        observation_deltas,
+    )
+    content_to_element_ref = {
+        row.content_ref: row.element_ref for row in elements
+    }
+    proposal_by_ref = {
+        str(row.get("proposal_ref") or ""): row
+        for row in proposals
+        if row.get("proposal_ref")
+    }
+    for proposal in proposals:
+        coordinate = _proposal_coordinate(proposal)
+        element = fibre_element_from_proposal_row(proposal)
+        coordinates[coordinate.coordinate_ref] = coordinate
+        elements.append(element)
+        content_to_element_ref[str(proposal["proposal_ref"])] = element.element_ref
+        _persist_proposal_extension(cursor, proposal)
+
+    derivations = _fibre_derivations(
+        document_ref=document_ref,
+        solver_jobs=solver_jobs,
+        solver_receipts=solver_receipts,
+        proposal_by_ref=proposal_by_ref,
+        content_to_element_ref=content_to_element_ref,
+    )
     transport_rows = tuple(
         SemanticTransport(
             document_ref=str(row["document_ref"]),
@@ -358,9 +453,6 @@ def persist_semantic_fibre_artifacts(
         )
         for row in transports
     )
-    for row in transport_rows:
-        _persist_optional_transport(cursor, row.to_dict())
-
     axis_rows = tuple(
         OntologyAxis(
             axis_ref=str(row["axis_ref"]),
@@ -372,26 +464,6 @@ def persist_semantic_fibre_artifacts(
         )
         for row in ontology_axes
     )
-    for row in axis_rows:
-        payload = row.to_dict()
-        cursor.execute(
-            """
-            INSERT INTO semantic_ontology_axis
-                (axis_ref, label, authority_ref, relation_refs, root_refs,
-                 open_world)
-            VALUES (%s, %s, %s, %s::jsonb, %s::jsonb, %s)
-            ON CONFLICT (axis_ref) DO NOTHING
-            """,
-            (
-                payload["axis_ref"],
-                payload["label"],
-                payload["authority_ref"],
-                _json(payload["relation_refs"]),
-                _json(payload["root_refs"]),
-                payload["open_world"],
-            ),
-        )
-
     obligation_rows = tuple(
         AxisObligation(
             document_ref=str(row["document_ref"]),
@@ -407,30 +479,6 @@ def persist_semantic_fibre_artifacts(
         )
         for row in axis_obligations
     )
-    for row in obligation_rows:
-        payload = row.to_dict()
-        cursor.execute(
-            """
-            INSERT INTO semantic_axis_obligation
-                (obligation_ref, document_ref, coordinate_ref, axis_ref,
-                 obligation_type, trigger_refs, frontier_refs, state,
-                 resource_limit_reached, truth_closed)
-            VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s, FALSE)
-            ON CONFLICT (obligation_ref) DO NOTHING
-            """,
-            (
-                payload["obligation_ref"],
-                payload["document_ref"],
-                payload["coordinate_ref"],
-                payload["axis_ref"],
-                payload["obligation_type"],
-                _json(payload["trigger_refs"]),
-                _json(payload["frontier_refs"]),
-                payload["state"],
-                payload["resource_limit_reached"],
-            ),
-        )
-
     boundary_rows = tuple(
         FibreBoundaryObligation(
             document_ref=str(row["document_ref"]),
@@ -445,32 +493,21 @@ def persist_semantic_fibre_artifacts(
         )
         for row in boundary_obligations
     )
-    for row in boundary_rows:
-        payload = row.to_dict()
-        cursor.execute(
-            """
-            INSERT INTO semantic_fibre_boundary_obligation
-                (boundary_ref, document_ref, coordinate_ref, scope_ref,
-                 boundary_kind, evidence_refs, frontier_refs,
-                 required_axis_refs, state, message)
-            VALUES
-                (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb,
-                 %s::jsonb, %s, %s)
-            ON CONFLICT (boundary_ref) DO NOTHING
-            """,
-            (
-                payload["boundary_ref"],
-                payload["document_ref"],
-                payload["coordinate_ref"],
-                payload["scope_ref"],
-                payload["boundary_kind"],
-                _json(payload["evidence_refs"]),
-                _json(payload["frontier_refs"]),
-                _json(payload["required_axis_refs"]),
-                payload["state"],
-                payload["message"],
-            ),
-        )
+
+    for coordinate in coordinates.values():
+        _persist_coordinate(cursor, coordinate)
+    for element in elements:
+        _persist_element(cursor, element)
+    for derivation in derivations:
+        _persist_derivation(cursor, derivation)
+    for transport in transport_rows:
+        _persist_transport(cursor, transport)
+    for axis in axis_rows:
+        _persist_axis(cursor, axis)
+    for obligation in obligation_rows:
+        _persist_axis_obligation(cursor, obligation)
+    for boundary in boundary_rows:
+        _persist_boundary(cursor, boundary)
 
     graph_ref = str(materialized_reduction.get("graph_ref") or "")
     for factor in materialized_reduction.get("factors") or ():
@@ -514,9 +551,7 @@ def persist_semantic_fibre_artifacts(
         transports=tuple(
             sorted(transport_rows, key=lambda row: row.transport_ref)
         ),
-        derivations=tuple(
-            sorted(derivations, key=lambda row: row.derivation_ref)
-        ),
+        derivations=derivations,
         ontology_axes=tuple(sorted(axis_rows, key=lambda row: row.axis_ref)),
         axis_obligations=tuple(
             sorted(obligation_rows, key=lambda row: row.obligation_ref)

--- a/tests/pnf/test_constraint_worklist.py
+++ b/tests/pnf/test_constraint_worklist.py
@@ -7,10 +7,10 @@ from src.policy.algebra import FactorConstraint
 def _constraint(ref: str, source: str, target: str) -> FactorConstraint:
     return FactorConstraint(
         constraint_ref=ref,
+        constraint_type="syntactic_subject_of",
         source_factor_refs=(source,),
         target_factor_refs=(target,),
-        relation_type="syntactic_subject_of",
-        evidence_refs=(f"evidence:{ref}",),
+        provenance_refs=(f"evidence:{ref}",),
     )
 
 
@@ -29,6 +29,7 @@ def test_initial_constraint_fixed_point_evaluates_all_constraints() -> None:
         "constraint:bc",
     }
     assert result.fixed_point_rounds == 1
+    assert {row.propagation_wave for row in result.work_items} == {0}
     assert result.to_dict()["pending_work_items"] == 0
 
 
@@ -49,6 +50,7 @@ def test_targeted_change_evaluates_only_incident_constraints() -> None:
     assert [row.constraint_ref for row in result.work_items] == [
         "constraint:bc"
     ]
+    assert result.fixed_point_rounds == 1
 
 
 def test_unrelated_change_does_not_fall_back_to_full_scan() -> None:

--- a/tests/pnf/test_factor_proposals.py
+++ b/tests/pnf/test_factor_proposals.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from src.pnf.factor_proposals import (
+    INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
     CrossDocumentRelation,
     FactorProposal,
     proposal_build_key,
@@ -8,7 +11,12 @@ from src.pnf.factor_proposals import (
 )
 
 
-def _proposal(*, bearer: str, payload: str = "drive") -> FactorProposal:
+def _proposal(
+    *,
+    bearer: str,
+    payload: str = "drive",
+    statement_role: str = "main",
+) -> FactorProposal:
     return FactorProposal(
         document_ref="document:qld-road-rules",
         source_revision_ref="source-revision:1",
@@ -23,6 +31,8 @@ def _proposal(*, bearer: str, payload: str = "drive") -> FactorProposal:
         declaration_revision="v0_1",
         candidate_payload={"predicate_ref": payload},
         residuals=("jurisdiction_unresolved",),
+        statement_role=statement_role,
+        fibre_kind="composition",
     )
 
 
@@ -45,6 +55,7 @@ def test_reducer_is_order_independent_and_deduplicates_exact_proposals() -> None
     assert len(left.factors) == 1
     assert left.factors[0].proposal_refs == (first.proposal_ref,)
     assert left.to_dict()["legal_truth_closed"] is False
+    assert left.to_dict()["fibrewise_reduction"] is True
 
 
 def test_incompatible_coordinates_remain_explicit_alternatives() -> None:
@@ -57,8 +68,33 @@ def test_incompatible_coordinates_remain_explicit_alternatives() -> None:
     )
 
     assert len(reduction.factors) == 2
-    assert [row.residual_type for row in reduction.residuals] == ["incompatible_alternatives"]
-    assert set(reduction.residuals[0].proposal_refs) == {driver.proposal_ref, owner.proposal_ref}
+    assert [row.residual_type for row in reduction.residuals] == [
+        "incompatible_alternatives"
+    ]
+    assert set(reduction.residuals[0].proposal_refs) == {
+        driver.proposal_ref,
+        owner.proposal_ref,
+    }
+    assert reduction.residuals[0].semantic_coordinate_ref == (
+        driver.semantic_coordinate_ref
+    )
+
+
+def test_distinct_statement_roles_do_not_compete_in_one_fibre() -> None:
+    main = _proposal(bearer="entity:driver", statement_role="main")
+    qualifier = _proposal(
+        bearer="entity:driver",
+        statement_role="qualifier",
+    )
+    reduction = reduce_factor_proposals(
+        document_ref=main.document_ref,
+        proposals=(main, qualifier),
+        known_observation_refs=("observation:must", "observation:drive"),
+    )
+
+    assert main.semantic_coordinate_ref != qualifier.semantic_coordinate_ref
+    assert len(reduction.factors) == 2
+    assert reduction.residuals == ()
 
 
 def test_missing_declared_inputs_do_not_race_into_graph() -> None:
@@ -71,6 +107,33 @@ def test_missing_declared_inputs_do_not_race_into_graph() -> None:
 
     assert reduction.factors == ()
     assert reduction.residuals[0].residual_type == "missing_reduction_input"
+    assert reduction.residuals[0].boundary_kind == "input_frontier"
+
+
+def test_integrated_producer_family_preserves_operation_contract() -> None:
+    proposal = _proposal(bearer="entity:driver")
+
+    assert proposal.producer_contract == INTEGRATED_SEMANTIC_PRODUCER_CONTRACT
+    assert proposal.operation_contract == (
+        "grammar:semantic:operator-composition:v0_1"
+    )
+
+
+def test_executor_metadata_does_not_change_semantic_identity() -> None:
+    proposal = _proposal(bearer="entity:driver")
+    python = replace(
+        proposal,
+        execution_metadata={"sub_executor_ref": "python-worklist:v1"},
+    )
+    zelph = replace(
+        proposal,
+        execution_metadata={"sub_executor_ref": "zelph:v1"},
+    )
+
+    assert python.proposal_ref == zelph.proposal_ref
+    assert python.to_dict()["execution_metadata"] != zelph.to_dict()[
+        "execution_metadata"
+    ]
 
 
 def test_build_key_targets_only_declared_inputs() -> None:

--- a/tests/pnf/test_integrated_semantic_producer.py
+++ b/tests/pnf/test_integrated_semantic_producer.py
@@ -1,13 +1,30 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from typing import Any
 
 from src.pnf.factor_proposals import (
     INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
     FactorProposal,
     reduce_factor_proposals,
 )
+from src.pnf.fibred_build_projection import project_fibred_semantic_build
 from src.pnf.integrated_semantic_producer import IntegratedSemanticProducer
+from src.storage.postgres.semantic_fibre_store import (
+    persist_semantic_fibre_artifacts,
+)
+
+
+class _Cursor:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...] | None]] = []
+
+    def execute(
+        self,
+        query: str,
+        params: tuple[Any, ...] | None = None,
+    ) -> None:
+        self.calls.append((query, params))
 
 
 def _proposal(
@@ -119,3 +136,53 @@ def test_integrated_producer_builds_fibre_ledger_and_receipt() -> None:
     assert payload["one_reduction_authority"] is True
     assert payload["identity_promoted"] is False
     assert payload["legal_truth_closed"] is False
+
+
+def test_persistence_reconstructs_exact_compiler_receipt_with_sparse_metadata() -> None:
+    proposal = replace(
+        _proposal(),
+        input_observation_refs=(),
+        execution_metadata={},
+    )
+    reduction = reduce_factor_proposals(
+        document_ref="document:1",
+        proposals=(proposal,),
+    )
+    job = {
+        "job_ref": "job:1",
+        "declaration_ref": "declaration:linking:v1",
+    }
+    solver_receipt = {
+        "receipt_ref": "solver-receipt:1",
+        "job_ref": "job:1",
+        "backend_ref": "python-closure:v1",
+        "rule_set_revision": "v1",
+        "input_refs": [],
+        "proposal_refs": [proposal.proposal_ref],
+        "assumptions": [],
+        "metrics": {},
+    }
+    streaming_build = {
+        "document_ref": "document:1",
+        "observation_deltas": [],
+        "proposals": [proposal.to_dict()],
+        "solver_jobs": [job],
+        "solver_receipts": [solver_receipt],
+        "materialized_reduction": reduction.to_dict(),
+    }
+    projected = project_fibred_semantic_build(streaming_build)
+    cursor = _Cursor()
+    persisted = persist_semantic_fibre_artifacts(
+        cursor,
+        document_ref="document:1",
+        observation_deltas=(),
+        proposals=(proposal.to_dict(),),
+        solver_jobs=(job,),
+        solver_receipts=(solver_receipt,),
+        materialized_reduction=reduction.to_dict(),
+    )
+
+    expected = projected["integrated_producer_receipt"]
+    assert persisted.fibre_ledger_ref == expected["fibre_ledger_ref"]
+    assert persisted.receipt_ref == expected["receipt_ref"]
+    assert any("semantic_fibre_derivation" in query for query, _ in cursor.calls)

--- a/tests/pnf/test_integrated_semantic_producer.py
+++ b/tests/pnf/test_integrated_semantic_producer.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from src.pnf.factor_proposals import (
+    INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
+    FactorProposal,
+    reduce_factor_proposals,
+)
+from src.pnf.integrated_semantic_producer import IntegratedSemanticProducer
+
+
+def _proposal(
+    *,
+    role: str = "main",
+    producer_scope: str = "integrated",
+    execution_metadata: dict[str, object] | None = None,
+) -> FactorProposal:
+    return FactorProposal(
+        document_ref="document:1",
+        source_revision_ref="source-revision:1",
+        factor_type_ref="semantic.entity_link",
+        source_span_refs=("span:usa",),
+        input_observation_refs=("observation:usa",),
+        dependency_factor_refs=(),
+        structural_signature="signature:entity-link:v1",
+        role_bindings={"mention": "mention:usa", "target": "wd:Q30"},
+        qualifier_state={"relation": "candidate_denotation"},
+        producer_contract="linker:wikidata:v1",
+        declaration_revision="v1",
+        candidate_payload={"target_ref": "wd:Q30"},
+        statement_role=role,
+        fibre_kind="hypothesis",
+        producer_scope=producer_scope,
+        execution_metadata=execution_metadata or {},
+    )
+
+
+def test_ordinary_proposals_share_one_integrated_producer_contract() -> None:
+    proposal = _proposal()
+
+    assert proposal.producer_contract == INTEGRATED_SEMANTIC_PRODUCER_CONTRACT
+    assert proposal.operation_contract == "linker:wikidata:v1"
+    assert proposal.producer_scope == "integrated"
+    assert proposal.semantic_coordinate_ref.startswith("semantic-coordinate:")
+
+
+def test_backend_telemetry_does_not_change_semantic_proposal_identity() -> None:
+    python = _proposal(
+        execution_metadata={"sub_executor_ref": "python-linker:v1"}
+    )
+    zelph = _proposal(
+        execution_metadata={"sub_executor_ref": "zelph-linker:v1"}
+    )
+
+    assert python.proposal_ref == zelph.proposal_ref
+    assert python.to_dict()["execution_metadata"] != zelph.to_dict()[
+        "execution_metadata"
+    ]
+
+
+def test_external_enrichment_remains_distinct_from_integrated_core() -> None:
+    proposal = _proposal(producer_scope="external")
+
+    assert proposal.producer_contract == "linker:wikidata:v1"
+    assert proposal.operation_contract == "linker:wikidata:v1"
+    assert proposal.to_dict()["authority"] == "external_candidate"
+
+
+def test_statement_roles_create_distinct_base_coordinates_and_fibres() -> None:
+    main = _proposal(role="main")
+    qualifier = _proposal(role="qualifier")
+    reduction = reduce_factor_proposals(
+        document_ref="document:1",
+        proposals=(qualifier, main),
+        known_observation_refs=("observation:usa",),
+    )
+
+    assert main.semantic_coordinate_ref != qualifier.semantic_coordinate_ref
+    assert len(reduction.factors) == 2
+    assert len(reduction.to_dict()["semantic_coordinate_refs"]) == 2
+    assert reduction.to_dict()["fibrewise_reduction"] is True
+
+
+def test_integrated_producer_builds_fibre_ledger_and_receipt() -> None:
+    producer = IntegratedSemanticProducer()
+    raw = _proposal()
+    proposal = replace(
+        raw,
+        execution_metadata={"sub_executor_ref": "python-linker:v1"},
+    )
+    sub_receipt = producer.sub_executor_receipt(
+        document_ref="document:1",
+        operation_kind="linking",
+        operation_contract=str(proposal.operation_contract),
+        sub_executor_ref="python-linker:v1",
+        declaration_ref="declaration:linking:v1",
+        rule_set_revision="v1",
+        input_refs=proposal.input_observation_refs,
+        proposals=(proposal,),
+    )
+    ledger = producer.fibre_ledger(
+        proposals=(proposal,),
+        sub_executor_receipts=(sub_receipt,),
+    )
+    receipt = producer.receipt(
+        document_ref="document:1",
+        proposals=(proposal,),
+        fibre_ledger=ledger,
+        sub_executor_receipts=(sub_receipt,),
+    )
+
+    assert ledger.fibre(str(proposal.semantic_coordinate_ref))[0].content_ref == (
+        proposal.proposal_ref
+    )
+    assert ledger.derivations[0].sub_executor_ref == "python-linker:v1"
+    payload = receipt.to_dict()
+    assert payload["one_proposal_contract"] is True
+    assert payload["one_reduction_authority"] is True
+    assert payload["identity_promoted"] is False
+    assert payload["legal_truth_closed"] is False

--- a/tests/pnf/test_semantic_fibres.py
+++ b/tests/pnf/test_semantic_fibres.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import pytest
+
+from src.pnf.semantic_fibres import (
+    AxisObligation,
+    FibreBoundaryObligation,
+    FibreElement,
+    OntologyAxis,
+    SemanticCoordinate,
+    SemanticFibreLedger,
+    SemanticTransport,
+    evaluate_fibre,
+)
+
+
+def _coordinate(*, role: str = "main") -> SemanticCoordinate:
+    return SemanticCoordinate(
+        document_ref="document:1",
+        scope_ref="sentence:1",
+        source_span_refs=("span:1",),
+        statement_role=role,
+        factor_family="semantic.causal_validation",
+    )
+
+
+def _element(
+    coordinate: SemanticCoordinate,
+    *,
+    content_ref: str,
+    role: str,
+) -> FibreElement:
+    return FibreElement(
+        document_ref=coordinate.document_ref,
+        coordinate_ref=coordinate.coordinate_ref,
+        fibre_kind="constraint",
+        content_ref=content_ref,
+        derivation_role=role,
+        producer_contract="integrated-semantic-producer:v0_1",
+        operation_contract="constraint:causal:v1",
+        source_refs=("statement:1",),
+    )
+
+
+def test_fibre_ledger_join_is_associative_commutative_and_idempotent() -> None:
+    coordinate = _coordinate()
+    support = _element(coordinate, content_ref="derivation:support", role="support")
+    contradiction = _element(
+        coordinate,
+        content_ref="derivation:contradiction",
+        role="contradict",
+    )
+    first = SemanticFibreLedger(coordinates=(coordinate,), elements=(support,))
+    second = SemanticFibreLedger(
+        coordinates=(coordinate,),
+        elements=(contradiction,),
+    )
+    third = SemanticFibreLedger(
+        coordinates=(coordinate,),
+        boundary_obligations=(
+            FibreBoundaryObligation(
+                document_ref=coordinate.document_ref,
+                coordinate_ref=coordinate.coordinate_ref,
+                scope_ref=coordinate.scope_ref,
+                boundary_kind="ontology_axis_frontier",
+                evidence_refs=(support.element_ref,),
+                frontier_refs=("class:unresolved",),
+            ),
+        ),
+    )
+
+    assert first.join(second).ledger_ref == second.join(first).ledger_ref
+    assert first.join(first).ledger_ref == first.ledger_ref
+    assert first.join(second).join(third).ledger_ref == first.join(
+        second.join(third)
+    ).ledger_ref
+    assert len(first.join(second).fibre(coordinate.coordinate_ref)) == 2
+
+
+def test_validation_is_computed_from_fibre_shape() -> None:
+    coordinate = _coordinate()
+    support = _element(coordinate, content_ref="support:1", role="support")
+    contradiction = _element(
+        coordinate,
+        content_ref="contradiction:1",
+        role="contradict",
+    )
+    unresolved = _element(
+        coordinate,
+        content_ref="frontier:1",
+        role="undetermined",
+    )
+
+    assert evaluate_fibre(
+        coordinate_ref=coordinate.coordinate_ref,
+        elements=(support,),
+    ).outcome == "satisfied"
+    assert evaluate_fibre(
+        coordinate_ref=coordinate.coordinate_ref,
+        elements=(contradiction,),
+    ).outcome == "violated"
+    assert evaluate_fibre(
+        coordinate_ref=coordinate.coordinate_ref,
+        elements=(support, contradiction),
+    ).outcome == "both"
+    assert evaluate_fibre(
+        coordinate_ref=coordinate.coordinate_ref,
+        elements=(unresolved,),
+    ).outcome == "undetermined"
+    validation = evaluate_fibre(
+        coordinate_ref=coordinate.coordinate_ref,
+        elements=(support,),
+        applicable=False,
+    )
+    assert validation.outcome == "inapplicable"
+    assert validation.to_dict()["truth_closed"] is False
+
+
+def test_discoverable_transport_cannot_silently_substitute_identity() -> None:
+    source = _coordinate()
+    target = SemanticCoordinate(
+        document_ref="document:1",
+        scope_ref="wikidata:Q30",
+        source_span_refs=(),
+        statement_role="external_target",
+        factor_family="wikidata.entity",
+        coordinate_kind="external",
+    )
+    with pytest.raises(ValueError, match="cannot permit substitution"):
+        SemanticTransport(
+            document_ref="document:1",
+            source_coordinate_ref=source.coordinate_ref,
+            target_coordinate_ref=target.coordinate_ref,
+            transport_type="rdfs:seeAlso",
+            strength="discoverable",
+            evidence_refs=("alignment:1",),
+            allowed_operations=("inspect", "substitute"),
+        )
+
+    transport = SemanticTransport(
+        document_ref="document:1",
+        source_coordinate_ref=source.coordinate_ref,
+        target_coordinate_ref=target.coordinate_ref,
+        transport_type="rdfs:seeAlso",
+        strength="discoverable",
+        evidence_refs=("alignment:1",),
+        allowed_operations=("inspect", "enrich"),
+    )
+    payload = transport.to_dict()
+    assert payload["identity_closed"] is False
+    assert payload["semantic_state_promoted"] is False
+
+
+def test_axis_obligations_and_boundaries_preserve_open_frontiers() -> None:
+    coordinate = _coordinate()
+    axis = OntologyAxis(
+        axis_ref="ontology-axis:bfo:v1",
+        label="BFO continuant/occurrent",
+        authority_ref="ontology:bfo:v1",
+        relation_refs=("wdt:P31", "wdt:P279"),
+        root_refs=("wd:Q67518978",),
+    )
+    obligation = AxisObligation(
+        document_ref="document:1",
+        coordinate_ref=coordinate.coordinate_ref,
+        axis_ref=axis.axis_ref,
+        obligation_type="requires_occurrent_classification",
+        trigger_refs=("statement:cause:1",),
+        frontier_refs=("class:historical-topic",),
+        state="undetermined",
+    )
+    boundary = FibreBoundaryObligation(
+        document_ref="document:1",
+        coordinate_ref=coordinate.coordinate_ref,
+        scope_ref=coordinate.scope_ref,
+        boundary_kind="ontology_axis_frontier",
+        evidence_refs=(obligation.obligation_ref,),
+        frontier_refs=("class:historical-topic",),
+        required_axis_refs=(axis.axis_ref,),
+        state="external",
+    )
+    ledger = SemanticFibreLedger(
+        coordinates=(coordinate,),
+        ontology_axes=(axis,),
+        axis_obligations=(obligation,),
+        boundary_obligations=(boundary,),
+    )
+
+    assert obligation.to_dict()["truth_closed"] is False
+    assert ledger.boundary_obligations[0].state == "external"
+    assert ledger.to_dict()["identity_promoted"] is False

--- a/tests/policy/test_fibred_operational_corpus_compilation.py
+++ b/tests/policy/test_fibred_operational_corpus_compilation.py
@@ -17,26 +17,9 @@ def _factor() -> dict[str, object]:
     }
 
 
-def test_fibred_wrapper_materialises_streamed_reduction(monkeypatch) -> None:
-    proposal = FactorProposal(
-        document_ref="document:1",
-        source_revision_ref="source:1",
-        factor_type_ref="semantic.normative_relation",
-        source_span_refs=("span:1",),
-        input_observation_refs=(),
-        dependency_factor_refs=(),
-        structural_signature="normative:v1",
-        role_bindings={"conduct": "eventuality:drive"},
-        qualifier_state={"modality": "obligation"},
-        producer_contract="grammar:semantic:operator-composition:v0_1",
-        declaration_revision="v1",
-        candidate_payload={
-            "source_factor_ref": "factor:source",
-            "predicate_ref": "normative.obligation",
-        },
-        scope_ref="sentence:1",
-        fibre_kind="composition",
-    )
+def _base_compilation(
+    proposal: FactorProposal,
+) -> tuple[DocumentCompilation, object]:
     reduction = reduce_factor_proposals(
         document_ref="document:1",
         proposals=(proposal,),
@@ -70,13 +53,16 @@ def test_fibred_wrapper_materialises_streamed_reduction(monkeypatch) -> None:
             "phase_boundary": {},
         },
     )
+    return base, reduction
+
+
+def _compile(monkeypatch, base: DocumentCompilation) -> DocumentCompilation:
     monkeypatch.setattr(
         module,
         "compile_document_operational",
         lambda *args, **kwargs: base,
     )
-
-    compilation = module.compile_document_fibred_operational(
+    return module.compile_document_fibred_operational(
         {
             "document_ref": "document:1",
             "content_sha256": "content:1",
@@ -86,8 +72,35 @@ def test_fibred_wrapper_materialises_streamed_reduction(monkeypatch) -> None:
         },
         default_compiler_context(),
     )
+
+
+def test_fibred_wrapper_replaces_existing_compatibility_coordinate(
+    monkeypatch,
+) -> None:
+    proposal = FactorProposal(
+        document_ref="document:1",
+        source_revision_ref="source:1",
+        factor_type_ref="semantic.normative_relation",
+        source_span_refs=("span:1",),
+        input_observation_refs=(),
+        dependency_factor_refs=(),
+        structural_signature="normative:v1",
+        role_bindings={"conduct": "eventuality:drive"},
+        qualifier_state={"modality": "obligation"},
+        producer_contract="grammar:semantic:operator-composition:v0_1",
+        declaration_revision="v1",
+        candidate_payload={
+            "source_factor_ref": "factor:source",
+            "predicate_ref": "normative.obligation",
+        },
+        scope_ref="sentence:1",
+        fibre_kind="composition",
+    )
+    base, reduction = _base_compilation(proposal)
+    compilation = _compile(monkeypatch, base)
     artifacts = compilation.artifacts
     factor = artifacts["pnf_graph"]["factors"][0]
+    receipt = artifacts["streaming_reduction_projection"]
 
     assert artifacts["pnf_graph"]["graph_ref"].startswith(
         "pnf-fibred-graph:"
@@ -96,6 +109,8 @@ def test_fibred_wrapper_materialises_streamed_reduction(monkeypatch) -> None:
     assert factor["metadata"]["fibre_summary_ref"] == (
         reduction.factors[0].factor_ref
     )
+    assert receipt["replaced_factor_count"] == 1
+    assert receipt["added_factor_count"] == 0
     assert artifacts["factor_refinements"] == []
     assert artifacts["compatibility_factor_refinements"] == [
         {"refinement_ref": "legacy:1"}
@@ -103,3 +118,38 @@ def test_fibred_wrapper_materialises_streamed_reduction(monkeypatch) -> None:
     assert artifacts["fibred_semantic_build"]["one_proposal_contract"] is True
     assert artifacts["streaming_semantic_build"]["one_reduction_authority"] is True
     assert artifacts["phase_boundary"]["fibred_semantic_state"] is True
+    assert artifacts["phase_boundary"][
+        "constraints_after_fibre_materialisation"
+    ] is True
+
+
+def test_fibred_wrapper_adds_new_higher_order_coordinate(monkeypatch) -> None:
+    proposal = FactorProposal(
+        document_ref="document:1",
+        source_revision_ref="source:1",
+        factor_type_ref="semantic.legal_exception",
+        source_span_refs=("span:unless",),
+        input_observation_refs=(),
+        dependency_factor_refs=(),
+        structural_signature="exception:v1",
+        role_bindings={"host": "factor:source"},
+        qualifier_state={"marker": "unless"},
+        producer_contract="grammar:semantic:operator-composition:v0_1",
+        declaration_revision="v1",
+        candidate_payload={"predicate_ref": "legal.exception"},
+        scope_ref="sentence:1",
+        fibre_kind="composition",
+    )
+    base, reduction = _base_compilation(proposal)
+    compilation = _compile(monkeypatch, base)
+    artifacts = compilation.artifacts
+    factors = artifacts["pnf_graph"]["factors"]
+    receipt = artifacts["streaming_reduction_projection"]
+
+    assert len(factors) == 2
+    added = next(
+        row for row in factors if row["factor_ref"] == reduction.factors[0].factor_ref
+    )
+    assert added["metadata"]["fibre_summary_ref"] == added["factor_ref"]
+    assert receipt["added_factor_count"] == 1
+    assert receipt["replaced_factor_count"] == 0

--- a/tests/policy/test_fibred_operational_corpus_compilation.py
+++ b/tests/policy/test_fibred_operational_corpus_compilation.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from src.pnf.factor_proposals import FactorProposal, reduce_factor_proposals
+from src.policy import fibred_operational_corpus_compilation as module
+from src.policy.corpus_compilation import DocumentCompilation, default_compiler_context
+
+
+def _factor() -> dict[str, object]:
+    return {
+        "factor_ref": "factor:source",
+        "factor_type": "semantic.normative_relation",
+        "alternatives": [],
+        "constraints": [],
+        "residuals": [],
+        "closure_state": "open",
+        "metadata": {},
+    }
+
+
+def test_fibred_wrapper_materialises_streamed_reduction(monkeypatch) -> None:
+    proposal = FactorProposal(
+        document_ref="document:1",
+        source_revision_ref="source:1",
+        factor_type_ref="semantic.normative_relation",
+        source_span_refs=("span:1",),
+        input_observation_refs=(),
+        dependency_factor_refs=(),
+        structural_signature="normative:v1",
+        role_bindings={"conduct": "eventuality:drive"},
+        qualifier_state={"modality": "obligation"},
+        producer_contract="grammar:semantic:operator-composition:v0_1",
+        declaration_revision="v1",
+        candidate_payload={
+            "source_factor_ref": "factor:source",
+            "predicate_ref": "normative.obligation",
+        },
+        scope_ref="sentence:1",
+        fibre_kind="composition",
+    )
+    reduction = reduce_factor_proposals(
+        document_ref="document:1",
+        proposals=(proposal,),
+    )
+    graph = {
+        "schema_version": "sl.pnf_graph.v0_1",
+        "graph_ref": "pnf-graph:before",
+        "document_ref": "document:1",
+        "factors": [_factor()],
+        "constraints": [],
+        "relation_refs": [],
+        "residuals": [],
+        "authority": "candidate_only",
+    }
+    base = DocumentCompilation(
+        document_ref="document:1",
+        content_sha256="content:1",
+        media_type="text/plain",
+        artifacts={
+            "pnf_graph": graph,
+            "refined_pnf_graph": graph,
+            "factor_refinements": [{"refinement_ref": "legacy:1"}],
+            "streaming_semantic_build": {
+                "document_ref": "document:1",
+                "observation_deltas": [],
+                "proposals": [proposal.to_dict()],
+                "solver_jobs": [],
+                "solver_receipts": [],
+                "materialized_reduction": reduction.to_dict(),
+            },
+            "phase_boundary": {},
+        },
+    )
+    monkeypatch.setattr(
+        module,
+        "compile_document_operational",
+        lambda *args, **kwargs: base,
+    )
+
+    compilation = module.compile_document_fibred_operational(
+        {
+            "document_ref": "document:1",
+            "content_sha256": "content:1",
+            "media_type": "text/plain",
+            "canonical_text": "Driver must drive.",
+            "source_ref": "source:1",
+        },
+        default_compiler_context(),
+    )
+    artifacts = compilation.artifacts
+    factor = artifacts["pnf_graph"]["factors"][0]
+
+    assert artifacts["pnf_graph"]["graph_ref"].startswith(
+        "pnf-fibred-graph:"
+    )
+    assert factor["factor_ref"] == "factor:source"
+    assert factor["metadata"]["fibre_summary_ref"] == (
+        reduction.factors[0].factor_ref
+    )
+    assert artifacts["factor_refinements"] == []
+    assert artifacts["compatibility_factor_refinements"] == [
+        {"refinement_ref": "legacy:1"}
+    ]
+    assert artifacts["fibred_semantic_build"]["one_proposal_contract"] is True
+    assert artifacts["streaming_semantic_build"]["one_reduction_authority"] is True
+    assert artifacts["phase_boundary"]["fibred_semantic_state"] is True


### PR DESCRIPTION
## Summary

Corrects the streaming semantic compiler around the updated fibred understanding rather than adding another parallel reasoning lane.

The implementation now treats the graph as the base coordinate/incidence structure and keeps provenance-bearing observations, hypotheses, composed candidates, constraints, consequences, enrichment evidence, residuals, and review evidence in fibres over those coordinates.

## Repository boundary

This belongs in SensibLaw. ITIR-suite remains the suite-level control and handoff surface; SensibLaw owns substantive deterministic semantic compilation, proposal normalisation, PNF reduction, and immutable build evidence.

## One integrated producer

Core operations now normalise under:

```text
integrated-semantic-producer:v0_1
```

while retaining their specific `operation_contract` and executor receipt. Python, Zelph, parser, ontology index, or model telemetry is excluded from semantic proposal identity, so equivalent backends can be compared by exact proposal and reduction digest without becoming competing authoritative producers.

External learned models, LLM suggestions, imported assertions, and third-party repair outputs remain distinguishable with `producer_scope=external` while using the same proposal and reduction contract.

## Fibred proposal algebra

Adds immutable carriers for:

- semantic base coordinates;
- fibre elements and ACI fibre ledgers;
- receipt-bearing derivations;
- controlled transports between local and external coordinates;
- named ontology axes/subfibrations;
- ontology-axis obligations and frontiers;
- fibre boundary obligations;
- five-way validation: satisfied, violated, both, undetermined, inapplicable.

Proposal identity now includes its semantic coordinate, statement role, fibre kind, derivation role, operation contract, axes, transports, assumptions, coverage, and support state. Executor telemetry remains outside identity.

## One deterministic reduction boundary

The PNF reducer now groups by:

```text
semantic coordinate
+ fibre kind
+ factor type
+ structural signature
```

Only proposals within the same fibre compete. Similar proposals in main-value and qualifier roles remain distinct. Incompatible contents inside one fibre remain explicit alternatives with a conflict residual.

The refined PNF projection preserves fibre coordinates, derivation roles, support states, ontology axes, controlled transports, confidence, and provenance. No parser, Python rule, Zelph rule, linker, learner, or LLM publishes a competing graph.

## Active flow

```text
canonical text
→ parser observation fibres
→ typing/linking/role hypotheses
→ early fibre reduction
→ scope and attachment morphisms
→ compatible composition fibres
→ compositional reduction
→ constraints and ontology-axis obligations
→ Python/Zelph consequence extensions
→ demand-driven external enrichment
→ affected fibre reductions
→ boundary routing
→ fixed point
→ refined PNF
→ Legal IR / PostgreSQL / SPARQL / MCP / LLM projections
```

## Persistence

Migration 021 and the active PostgreSQL build path persist:

- proposal fibre coordinates and roles;
- semantic coordinates;
- fibre elements and derivations;
- controlled transports;
- ontology axes and axis obligations;
- residual boundary obligations;
- deterministic fibre summaries;
- integrated-producer receipts.

Database guards prohibit transport-driven identity closure, semantic promotion, and legal-truth closure.

## Validation

The new hosted workflow applies all migrations, runs Ruff and focused existing/new PNF tests, verifies Python/Zelph parity compatibility, checks migration guards, and persists a concrete observation fibre plus composition fibre and deterministic summary through PostgreSQL.

## Authority boundaries

- parser observations remain evidence, not assertions;
- discoverable links cannot permit substitution;
- incomplete ontology axes remain unresolved rather than violated;
- learned/LLM outputs remain candidates;
- only deterministic PNF reduction materialises active semantic state;
- identity, applicability, breach, liability, and legal truth remain open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fibred semantic processing with coordinates, transports, ontology axes, obligations, provenance, and validation outcomes.
  * Added integrated semantic producer receipts and deterministic fibrewise reduction.
  * Persisted semantic fibre ledgers, summaries, derivations, and receipts in PostgreSQL.
  * Expanded factor proposals and reduction results with semantic metadata and execution context.
* **Documentation**
  * Added comprehensive documentation for fibred semantic compilation and fixed-point processing.
* **Tests**
  * Added coverage for fibre evaluation, ledger behavior, proposal identity, producer receipts, and PostgreSQL persistence validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->