### PR TITLE
Complete curated offline Legal IR performance and parity tranche

### DIFF
--- a/.github/workflows/curated-legal-ir-tranche.yml
+++ b/.github/workflows/curated-legal-ir-tranche.yml
@@ -1,0 +1,223 @@
+name: Curated offline Legal IR tranche
+
+on:
+  push:
+    branches:
+      - agent/complete-curated-legal-ir-tranche
+  pull_request:
+    paths:
+      - "src/sources/**"
+      - "src/pnf/factor_proposals.py"
+      - "src/pnf/legal_*.py"
+      - "src/pnf/curated_legal_ir_flow.py"
+      - "src/policy/curated_postgres_corpus_compilation.py"
+      - "src/policy/optimized_streaming_postgres_corpus_compilation.py"
+      - "src/runtime/offline_network_guard.py"
+      - "src/storage/postgres/**"
+      - "scripts/build_legal_ir_catalogue.py"
+      - "scripts/acquire_legal_source.py"
+      - "scripts/run_curated_legal_ir_parity.py"
+      - "scripts/check_curated_legal_ir_acceptance.py"
+      - "database/postgres_migrations/022_curated_legal_ir_runtime.sql"
+      - "tests/sources/**"
+      - "tests/pnf/**"
+      - "tests/policy/**"
+      - "tests/runtime/**"
+      - "docs/dev/CuratedLegalIRPerformanceParity.md"
+      - ".github/workflows/curated-legal-ir-tranche.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: sensiblaw_curated_legal_ir
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d sensiblaw_curated_legal_ir"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/sensiblaw_curated_legal_ir
+      PGHOST: localhost
+      PGPORT: "5432"
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: sensiblaw_curated_legal_ir
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install environment
+        run: |
+          python -m pip install --upgrade pip uv
+          uv sync --frozen --extra test --extra dev
+
+      - name: Apply migrations
+        run: bash scripts/apply_pg_migrations.sh
+
+      - name: Lint tranche surfaces
+        run: |
+          uv run ruff check \
+            src/sources/admission.py \
+            src/sources/catalogue_metadata.py \
+            src/sources/governed_acquisition.py \
+            src/pnf/factor_proposals.py \
+            src/pnf/legal_ir_parity.py \
+            src/pnf/legal_source_registry.py \
+            src/pnf/curated_legal_ir_flow.py \
+            src/policy/curated_postgres_corpus_compilation.py \
+            src/policy/optimized_streaming_postgres_corpus_compilation.py \
+            src/runtime/offline_network_guard.py \
+            src/storage/postgres/batched_binding_candidate_store.py \
+            src/storage/postgres/batched_compiler_store.py \
+            src/storage/postgres/batched_semantic_fibre_store.py \
+            src/storage/postgres/batched_semantic_store.py \
+            src/storage/postgres/batched_streaming_semantic_store.py \
+            src/storage/postgres/legal_source_store.py \
+            src/storage/postgres/proposal_parent_store.py \
+            src/storage/postgres/stage_timing_store.py \
+            scripts/build_legal_ir_catalogue.py \
+            scripts/acquire_legal_source.py \
+            scripts/run_curated_legal_ir_parity.py \
+            scripts/check_curated_legal_ir_acceptance.py \
+            tests/sources/test_admission.py \
+            tests/sources/test_governed_acquisition.py \
+            tests/runtime/test_offline_network_guard.py \
+            tests/pnf/test_reducer_partition_metrics.py \
+            tests/pnf/test_legal_ir_parity.py \
+            tests/pnf/test_curated_legal_ir_flow.py \
+            tests/policy/test_operational_corpus_compilation.py
+
+      - name: Run tranche tests
+        run: |
+          uv run pytest -q \
+            tests/sources/test_admission.py \
+            tests/sources/test_governed_acquisition.py \
+            tests/runtime/test_offline_network_guard.py \
+            tests/pnf/test_factor_proposals.py \
+            tests/pnf/test_reducer_partition_metrics.py \
+            tests/pnf/test_legal_ir_parity.py \
+            tests/pnf/test_curated_legal_ir_flow.py \
+            tests/pnf/test_legal_persisted_selection.py \
+            tests/policy/test_operational_corpus_compilation.py \
+            tests/policy/test_fibred_operational_corpus_compilation.py
+
+      - name: Validate curated migration guards
+        run: |
+          uv run python - <<'PY'
+          import os
+          import psycopg
+
+          required = (
+              'source_admission_receipt',
+              'legal_source_revision',
+              'legal_source_plan_receipt',
+              'governed_acquisition_receipt',
+              'execution_document_transaction_attempt',
+              'curated_legal_ir_parity_receipt',
+          )
+          with psycopg.connect(os.environ['DATABASE_URL']) as connection:
+              with connection.cursor() as cursor:
+                  for table in required:
+                      cursor.execute('SELECT to_regclass(%s)', (f'public.{table}',))
+                      assert cursor.fetchone()[0] == table
+          PY
+
+      - name: Run synthetic offline catalogue
+        run: |
+          mkdir -p build/fixture/substantive build/fixture/discovery
+          printf '%s\n' 'A driver must not drive unless licensed.' > build/fixture/substantive/hearing.txt
+          printf '%s\n' 'Search results for hearing.' > build/fixture/discovery/search.txt
+          cat > build/catalogue.json <<'JSON'
+          {
+            "catalogue_ref": "catalogue:ci-curated-legal-ir:v1",
+            "persisted_source_families": [
+              {
+                "family_ref": "hca-substantive",
+                "path": "build/fixture/substantive",
+                "source_suffixes": [".txt"],
+                "source_role": "hearing_transcript",
+                "semantic_scope": "case_material"
+              },
+              {
+                "family_ref": "hca-discovery",
+                "path": "build/fixture/discovery",
+                "source_suffixes": [".txt"],
+                "source_role": "search",
+                "semantic_scope": "discovery"
+              }
+            ]
+          }
+          JSON
+          uv run python scripts/build_legal_ir_catalogue.py \
+            --catalogue build/catalogue.json \
+            --output-root build/catalogue-output \
+            --database-url "$DATABASE_URL" \
+            --offline \
+            --compile-workers 1 \
+            --closure-workers 1 \
+            --owner-partitions 1
+          uv run python - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path('build/catalogue-output')
+          admission = json.loads((root / 'source_admission_manifest.json').read_text())
+          assert admission['counts'] == {'compile': 1, 'evidence_only': 1, 'exclude': 0}
+          network = json.loads((root / 'network_absence_receipt.json').read_text())
+          assert network['external_network_absent'] is True
+          timings = json.loads((root / 'document_compilation_timings.json').read_text())
+          stages = {
+              row['stage']
+              for document in timings['documents']
+              for row in document['stage_timings']
+          }
+          assert {
+              'postgres.token_lexeme',
+              'postgres.graph_revision',
+              'postgres.resolution_binding',
+              'postgres.fibred_ledger',
+              'postgres.receipts',
+              'postgres_persistence',
+          }.issubset(stages)
+          PY
+
+      - name: Run offline parity surface
+        run: |
+          uv run python scripts/run_curated_legal_ir_parity.py \
+            --input-directory build/catalogue-output/source_projection/canonical \
+            --source-metadata build/catalogue-output/source_metadata.json \
+            --output-dir build/parity-output \
+            --database-url "$DATABASE_URL" \
+            --closure-workers 1 \
+            --owner-partitions 1
+          uv run python - <<'PY'
+          import json
+          from pathlib import Path
+
+          root = Path('build/parity-output')
+          receipt = json.loads((root / 'parity_receipt.json').read_text())
+          network = json.loads((root / 'network_absence_receipt.json').read_text())
+          assert receipt['network_attempt_count'] == 0
+          assert receipt['semantic_state_promoted'] is False
+          assert receipt['applicability_closed'] is False
+          assert receipt['legal_truth_closed'] is False
+          assert network['external_network_absent'] is True
+          PY
+
+      - name: Check worktree patch formatting
+        run: git diff --check HEAD^

--- a/database/postgres_migrations/022_curated_legal_ir_runtime.sql
+++ b/database/postgres_migrations/022_curated_legal_ir_runtime.sql
@@ -1,0 +1,149 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS source_admission_receipt (
+    receipt_ref TEXT PRIMARY KEY,
+    corpus_ref TEXT,
+    source_revision_ref TEXT NOT NULL,
+    source_role TEXT NOT NULL,
+    semantic_scope TEXT NOT NULL,
+    admission_state TEXT NOT NULL CHECK (
+        admission_state IN ('compile', 'evidence_only', 'exclude')
+    ),
+    exclusion_reason TEXT,
+    profile_ref TEXT NOT NULL,
+    contract_ref TEXT NOT NULL,
+    semantic_state_promoted BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (semantic_state_promoted = FALSE),
+    legal_truth_closed BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (legal_truth_closed = FALSE),
+    receipt_sha256 BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (source_revision_ref, profile_ref)
+);
+
+CREATE INDEX IF NOT EXISTS source_admission_profile_state_idx
+    ON source_admission_receipt (profile_ref, admission_state, source_role);
+
+CREATE TABLE IF NOT EXISTS legal_source_revision (
+    source_revision_ref TEXT PRIMARY KEY,
+    document_ref TEXT NOT NULL,
+    admission_receipt_ref TEXT NOT NULL
+        REFERENCES source_admission_receipt(receipt_ref),
+    acquisition_receipt_ref TEXT,
+    jurisdiction_ref TEXT NOT NULL,
+    source_role TEXT NOT NULL,
+    authority_level TEXT NOT NULL,
+    temporal_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    provider_profile_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    media_type TEXT NOT NULL,
+    canonical_text_sha256 TEXT NOT NULL,
+    compile_eligible BOOLEAN NOT NULL DEFAULT TRUE
+        CHECK (compile_eligible = TRUE),
+    identity_promoted BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (identity_promoted = FALSE),
+    applicability_closed BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (applicability_closed = FALSE),
+    legal_truth_closed BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (legal_truth_closed = FALSE),
+    revision_sha256 BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS legal_source_revision_selection_idx
+    ON legal_source_revision
+    (jurisdiction_ref, source_role, authority_level, compile_eligible);
+
+CREATE TABLE IF NOT EXISTS legal_source_plan_receipt (
+    plan_ref TEXT PRIMARY KEY,
+    demand_ref TEXT NOT NULL,
+    plan_key TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (
+        state IN ('ready_persisted', 'blocked_missing_context',
+                  'blocked_acquisition_required')
+    ),
+    selected_source_revision_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    blocked_reasons JSONB NOT NULL DEFAULT '[]'::jsonb,
+    authority TEXT NOT NULL DEFAULT 'acquisition_plan_only'
+        CHECK (authority = 'acquisition_plan_only'),
+    applicability_closed BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (applicability_closed = FALSE),
+    plan_sha256 BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS governed_acquisition_receipt (
+    receipt_ref TEXT PRIMARY KEY,
+    request_ref TEXT NOT NULL,
+    operator_authorization_ref TEXT NOT NULL,
+    provider_profile_ref TEXT NOT NULL,
+    requested_url TEXT NOT NULL,
+    final_url TEXT,
+    source_revision_ref TEXT,
+    content_sha256 TEXT,
+    media_type TEXT,
+    byte_count BIGINT NOT NULL DEFAULT 0,
+    state TEXT NOT NULL CHECK (
+        state IN ('persisted', 'reused', 'rejected', 'failed')
+    ),
+    failure_reason TEXT,
+    network_operation_explicit BOOLEAN NOT NULL DEFAULT TRUE
+        CHECK (network_operation_explicit = TRUE),
+    semantic_state_promoted BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (semantic_state_promoted = FALSE),
+    legal_truth_closed BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (legal_truth_closed = FALSE),
+    receipt_sha256 BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (request_ref, content_sha256)
+);
+
+ALTER TABLE legal_source_revision
+    ADD CONSTRAINT legal_source_revision_acquisition_fk
+    FOREIGN KEY (acquisition_receipt_ref)
+    REFERENCES governed_acquisition_receipt(receipt_ref)
+    DEFERRABLE INITIALLY DEFERRED;
+
+CREATE TABLE IF NOT EXISTS execution_document_transaction_attempt (
+    attempt_ref TEXT PRIMARY KEY,
+    document_ref TEXT NOT NULL,
+    build_key_sha256 TEXT NOT NULL,
+    attempt_no INTEGER NOT NULL CHECK (attempt_no >= 1),
+    state TEXT NOT NULL CHECK (state IN ('succeeded', 'retryable_failure', 'failed')),
+    sqlstate TEXT,
+    retry_delay_ms INTEGER NOT NULL DEFAULT 0 CHECK (retry_delay_ms >= 0),
+    worker_ref TEXT,
+    telemetry_sha256 BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (document_ref, build_key_sha256, attempt_no)
+);
+
+CREATE TABLE IF NOT EXISTS curated_legal_ir_parity_receipt (
+    receipt_ref TEXT PRIMARY KEY,
+    corpus_ref TEXT NOT NULL,
+    admission_profile_ref TEXT NOT NULL,
+    compiler_contract_ref TEXT NOT NULL,
+    source_revision_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ordinary_graph_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    legal_graph_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    demand_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    plan_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    legal_ir_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    typed_meet_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    legacy_witness_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    identity_snapshot JSONB NOT NULL,
+    control_snapshot JSONB,
+    identity_parity BOOLEAN,
+    network_attempt_count INTEGER NOT NULL DEFAULT 0
+        CHECK (network_attempt_count = 0),
+    unexpected_failure_refs JSONB NOT NULL DEFAULT '[]'::jsonb,
+    semantic_state_promoted BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (semantic_state_promoted = FALSE),
+    applicability_closed BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (applicability_closed = FALSE),
+    legal_truth_closed BOOLEAN NOT NULL DEFAULT FALSE
+        CHECK (legal_truth_closed = FALSE),
+    receipt_sha256 BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMIT;

--- a/docs/dev/CuratedLegalIRPerformanceParity.md
+++ b/docs/dev/CuratedLegalIRPerformanceParity.md
@@ -1,0 +1,213 @@
+# Curated Legal-IR Performance and Parity
+
+## Status
+
+This document describes the implemented offline product path. It is not a
+second legal parser or semantic compiler. All substantive documents use the
+existing fibred PNF compiler and its single deterministic reduction boundary.
+
+```text
+persisted source catalogue
+→ immutable source-admission receipt
+→ canonical/fibred PNF compilation
+→ explicit normative interaction demand
+→ compatible persisted legal-source selection
+→ legal-source fibred PNF
+→ Legal IR projection
+→ candidate-only typed meet
+→ legacy diagnostic differential
+→ parity and network-absence receipts
+```
+
+## Source admission
+
+Admission occurs before parser submission and has three states:
+
+```text
+compile        substantive source; may enter canonical parsing
+
+evidence_only discovery/transport evidence; retained but never parsed
+
+exclude        duplicate, unrelated, unknown, or otherwise ineligible artefact
+```
+
+Every inventoried revision receives an immutable receipt containing its source
+role, semantic scope, profile revision, state, and reason. Unknown roles fail
+closed. The HCA regression profile admits substantive transcripts, judgments,
+submissions, chronologies, appeal/reply/outline documents, and genuine
+transcript media. Search, navigation, database, landing, OEmbed, and recording
+pages are evidence-only. Duplicate captions and unrelated support material are
+excluded.
+
+The catalogue command has no acquisition capability. `--force-refetch` is
+rejected. It copies only declared persisted source families and writes:
+
+- `source_admission_manifest.json`;
+- `network_absence_receipt.json`;
+- `document_compilation_timings.json`;
+- `catalogue_build_manifest.json`.
+
+## Governed acquisition
+
+Network acquisition is a separate operator effect:
+
+```text
+scripts/acquire_legal_source.py
+```
+
+It requires:
+
+- an operator authorization reference;
+- a provider profile;
+- an allow-listed host;
+- a byte bound;
+- permitted media types;
+- declared jurisdiction, source role, and authority level.
+
+The result is content-addressed, admitted under the primary-law profile, and
+registered as a persisted legal-source revision. Acquisition receipts retain
+network and provider provenance but cannot promote identity, applicability, or
+legal truth.
+
+A normal semantic build can only emit a blocked acquisition requirement. It
+cannot call the acquisition operation.
+
+## Persisted legal-source planning
+
+`NormativeInteractionDemand` is projected only from explicit legal PNF pressure
+or an explicit operator request. The durable registry is queried by:
+
+- jurisdiction;
+- source role;
+- authority level;
+- provider profile where requested;
+- temporal compatibility where represented;
+- compile eligibility.
+
+A `LegalSourcePlan` is either:
+
+```text
+ready_persisted
+blocked_missing_context
+blocked_acquisition_required
+```
+
+`ready_persisted` means retrieval-compatible input is available. It does not
+mean the source is applicable, controlling, correctly interpreted, or legally
+true.
+
+## Persistence execution
+
+The immutable document transaction is split into measured groups:
+
+```text
+postgres.token_lexeme
+postgres.graph_revision
+postgres.resolution_binding
+postgres.fibred_ledger
+postgres.receipts
+postgres_persistence
+```
+
+The implementation batches:
+
+- unique lexeme insertion and one stable key-to-ID lookup;
+- codec symbols and annotation nodes/relations;
+- factors, revisions, graph membership, alternatives, and residuals;
+- evidence, demands/facets, meets, and refinement transitions;
+- binding anchors, morphology, candidate sets, members, exclusions, and links;
+- observation deltas, proposals, jobs, receipts, state deltas, and boundaries;
+- fibre coordinates, elements, derivations, transports, ontology axes,
+  obligations, summaries, and producer receipts.
+
+Foreign-key order remains deterministic. The persisted integrated-producer
+receipt must reproduce the compiler's in-memory fibre-ledger and receipt
+identities before the completed-build receipt is committed.
+
+Deadlock (`40P01`) and serialization (`40001`) failures retry the whole immutable
+document attempt with bounded deterministic delay. Attempt number, SQLSTATE,
+worker, and delay are execution telemetry and do not enter semantic or build
+identity.
+
+## Fibre-local proposal reduction
+
+Exact proposals are deduplicated and then partitioned by:
+
+```text
+semantic coordinate
++ fibre kind
++ factor type
++ structural signature
+```
+
+Compatibility grouping occurs only within a bucket. The graph and factor
+identity formulas are unchanged. Execution-only metrics include:
+
+- bucket count and largest bucket;
+- actual and potential candidate comparisons;
+- comparisons avoided and avoidance ratio;
+- duplicates collapsed;
+- alternatives retained;
+- factor count and reduction ratio.
+
+Metrics are excluded from graph identity.
+
+## Offline parity proof
+
+```text
+scripts/run_curated_legal_ir_parity.py
+```
+
+The parity runner:
+
+1. admits and compiles ordinary HCA/case sources through fibred PNF;
+2. projects explicit legal demands;
+3. queries the persisted legal-source registry;
+4. preserves missing sources as blocked acquisition requirements;
+5. compiles selected legal sources through the same fibred compiler;
+6. projects Legal IR;
+7. constructs candidate-only typed meets;
+8. runs the existing legacy obligation extractor only as a diagnostic witness;
+9. retains comparison and PNF coverage ledgers;
+10. records semantic identity and optional control-run parity;
+11. rejects external network attempts.
+
+The semantic identity snapshot contains proposal, factor, graph, fibre-ledger,
+residual, demand, Legal IR, typed-meet, and legacy-witness references. Timing,
+retry, worker, and SQL execution receipts are intentionally absent.
+
+A zero-Legal-IR result or blocked source plan is an empirical coverage result.
+The parity runner never invents applicability to make the scorecard non-zero.
+
+## Acceptance evidence
+
+The curated run should retain:
+
+- exact source and profile revisions;
+- admission manifest;
+- fixed-point certificates;
+- nested stage timings;
+- reducer bucket/comparison metrics;
+- transaction-attempt receipts;
+- ordinary and legal graph identities;
+- blocked acquisition requirements and selected-source plans;
+- Legal IR, typed meets, and legacy comparison ledgers;
+- identity parity result;
+- external-network-absence receipt.
+
+Performance thresholds are evaluated on a fixed small/medium admitted source
+set with compiler, profile, worker, PostgreSQL, and cache conditions recorded.
+No threshold permits semantic identity drift.
+
+## Authority boundary
+
+```text
+admission receipt       catalogue policy only
+source selection plan   retrieval compatibility only
+Legal IR                deterministic PNF projection only
+typed meet              structural comparison only
+legacy witness          diagnostic evidence only
+parity receipt          audit evidence only
+```
+
+None closes identity, applicability, breach, liability, or legal truth.

--- a/docs/planning/curated_legal_ir_performance_parity_20260724.md
+++ b/docs/planning/curated_legal_ir_performance_parity_20260724.md
@@ -1,0 +1,28 @@
+# Curated Legal-IR performance and parity tranche
+
+The offline catalogue boundary is explicit:
+
+```text
+persisted source catalogue -> admission receipt -> canonical/PNF compilation
+ordinary PNF -> explicit legal demand -> persisted authority selection
+-> legal PNF / Legal IR -> typed meet and legacy diagnostic ledger
+```
+
+`src.sources.admission` is generic profile data, not legal parser logic.  Its
+immutable receipts record source role, semantic scope, compile eligibility and
+an exclusion reason.  The offline HCA regression profile admits substantive
+transcripts, judgments and case documents while excluding navigation, search,
+landing, OEmbed, recording-page, duplicate-caption and support artefacts.
+
+Normal catalogue compilation never discovers or fetches legal materials.
+`plan_legal_sources` selects only `PersistedLegalSource` revisions matching
+the explicit PNF jurisdiction, source role, authority, provider and time
+coordinates.  If no compatible revision exists it emits a blocked acquisition
+requirement.  A separately operator-authorised acquisition operation may use
+the legacy bounded follow backend to seed persisted revisions; it is not part
+of a parity build.  Repositories and aggregators remain transport evidence,
+not authority shortcuts.
+
+Blocked demands and residuals are retained as results.  Legal IR and typed
+meets are candidate-only projections; legacy comparison results are diagnostic
+witnesses and cannot promote PNF facts.

--- a/scripts/acquire_legal_source.py
+++ b/scripts/acquire_legal_source.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Explicitly acquire and register one bounded legal source revision.
+
+This command is intentionally separate from catalogue compilation. It requires
+an operator authorization reference and never asserts applicability or truth.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import sys
+from urllib.request import Request, urlopen
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.pnf.legal_source_registry import RegisteredLegalSource  # noqa: E402
+from src.policy.corpus_compilation import default_compiler_context  # noqa: E402
+from src.policy.postgres_corpus_compilation import (  # noqa: E402
+    _canonical_source_coordinates,
+    _operational_document_ref,
+)
+from src.sources.admission import (  # noqa: E402
+    AU_PRIMARY_LEGAL_SOURCE_PROFILE,
+    admit_source,
+)
+from src.sources.governed_acquisition import (  # noqa: E402
+    AcquisitionPolicy,
+    AcquisitionRequest,
+    FetchedSource,
+    acquire_legal_source,
+)
+from src.storage.postgres.batched_compiler_store import (  # noqa: E402
+    BatchedPostgresCompilerStore,
+)
+from src.storage.postgres.legal_source_store import (  # noqa: E402
+    persist_governed_acquisition_receipt,
+    persist_legal_source_revision,
+    persist_source_admission_receipts,
+)
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("url")
+    parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
+    parser.add_argument("--operator-authorization-ref", required=True)
+    parser.add_argument("--provider-profile-ref", required=True)
+    parser.add_argument("--allowed-host", action="append", required=True)
+    parser.add_argument("--maximum-bytes", type=int, default=5_000_000)
+    parser.add_argument("--jurisdiction-ref", required=True)
+    parser.add_argument("--source-role", required=True)
+    parser.add_argument("--authority-level", required=True)
+    parser.add_argument("--temporal-ref", action="append", default=[])
+    args = parser.parse_args()
+    if not args.database_url:
+        parser.error("--database-url or DATABASE_URL is required")
+    return args
+
+
+def _fetch(url: str, maximum_bytes: int) -> FetchedSource:
+    request = Request(
+        url,
+        headers={"User-Agent": "SensibLaw governed acquisition/0.1"},
+    )
+    with urlopen(request, timeout=30) as response:  # noqa: S310 - explicit CLI boundary
+        media_type = response.headers.get_content_type()
+        raw = response.read(maximum_bytes + 1)
+        final_url = response.geturl()
+    if len(raw) > maximum_bytes:
+        raise ValueError("response exceeds configured byte limit")
+    if media_type not in {"text/plain", "text/html", "application/xhtml+xml"}:
+        raise ValueError("this acquisition CLI accepts text and HTML only")
+    decoded = raw.decode("utf-8")
+    canonical_text, _, _ = _canonical_source_coordinates(
+        media_type=media_type,
+        source_text=decoded,
+        source_ref=f"governed-fetch:{hashlib.sha256(raw).hexdigest()}",
+    )
+    return FetchedSource(
+        final_url=final_url,
+        media_type=media_type,
+        raw_bytes=raw,
+        canonical_text=canonical_text,
+    )
+
+
+def main() -> int:
+    args = _args()
+    request = AcquisitionRequest(
+        requested_url=args.url,
+        operator_authorization_ref=args.operator_authorization_ref,
+        provider_profile_ref=args.provider_profile_ref,
+        source_role=args.source_role,
+        jurisdiction_ref=args.jurisdiction_ref,
+        authority_level=args.authority_level,
+        temporal_refs=tuple(sorted(set(args.temporal_ref))),
+    )
+    policy = AcquisitionPolicy(
+        provider_profile_ref=args.provider_profile_ref,
+        allowed_hosts=tuple(sorted(set(args.allowed_host))),
+        maximum_bytes=args.maximum_bytes,
+        allowed_media_types=("text/plain", "text/html", "application/xhtml+xml"),
+    )
+    receipt, payload = acquire_legal_source(request, policy=policy, fetch=_fetch)
+    store = BatchedPostgresCompilerStore.connect(args.database_url)
+    try:
+        with store.transaction() as cursor:
+            persist_governed_acquisition_receipt(cursor, receipt.to_dict())
+            if payload is None:
+                print(receipt.to_dict())
+                return 1
+            context = default_compiler_context()
+            document_ref = _operational_document_ref(
+                source_content_sha256=str(receipt.content_sha256),
+                canonical_text_sha256=str(payload["canonical_text_sha256"]),
+                media_type=str(payload["media_type"]),
+                media_adapter_ref=context.media_normalization_ref,
+                context=context,
+            )
+            admission = admit_source(
+                {
+                    "source_revision_ref": payload["source_revision_ref"],
+                    "source_role": args.source_role,
+                    "semantic_scope": "primary_legal_source",
+                },
+                profile=AU_PRIMARY_LEGAL_SOURCE_PROFILE,
+            )
+            if not admission.compile_eligible:
+                raise ValueError("acquired source role is not admitted as primary law")
+            store.persist_context(cursor, context.to_dict())
+            store.persist_source_document(
+                cursor,
+                document_ref=document_ref,
+                media_type=str(payload["media_type"]),
+                content_sha256=str(receipt.content_sha256),
+                source_bytes=bytes(payload["raw_bytes"]),
+                canonical_text=str(payload["canonical_text"]),
+                adapter_ref=context.media_normalization_ref,
+                adapter_version=context.media_normalization_ref,
+                compiler_context_ref=context.context_ref,
+                normalization_ref=context.media_normalization_ref,
+            )
+            persist_source_admission_receipts(
+                cursor,
+                corpus_ref="corpus:governed-legal-sources",
+                receipts=(admission,),
+            )
+            registered = RegisteredLegalSource(
+                source_revision_ref=str(payload["source_revision_ref"]),
+                document_ref=document_ref,
+                admission_receipt_ref=admission.receipt_ref,
+                acquisition_receipt_ref=receipt.receipt_ref,
+                jurisdiction_ref=args.jurisdiction_ref,
+                source_role=args.source_role,
+                authority_level=args.authority_level,
+                canonical_text_sha256=str(payload["canonical_text_sha256"]),
+                media_type=str(payload["media_type"]),
+                temporal_refs=tuple(sorted(set(args.temporal_ref))),
+                provider_profile_refs=(args.provider_profile_ref,),
+            )
+            persist_legal_source_revision(cursor, registered)
+        print({"acquisition": receipt.to_dict(), "registered": registered.to_dict()})
+        return 0
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/acquire_legal_source.py
+++ b/scripts/acquire_legal_source.py
@@ -115,11 +115,20 @@ def main() -> int:
                 print(receipt.to_dict())
                 return 1
             context = default_compiler_context()
+            canonical_text, canonical_sha256_hex, adapter_ref = (
+                _canonical_source_coordinates(
+                    media_type=str(payload["media_type"]),
+                    source_text=str(payload["canonical_text"]),
+                    source_ref=str(payload["source_revision_ref"]),
+                )
+            )
+            if canonical_sha256_hex != str(payload["canonical_text_sha256"]):
+                raise ValueError("acquisition canonical text digest is not reproducible")
             document_ref = _operational_document_ref(
                 source_content_sha256=str(receipt.content_sha256),
-                canonical_text_sha256=str(payload["canonical_text_sha256"]),
+                canonical_text_sha256=canonical_sha256_hex,
                 media_type=str(payload["media_type"]),
-                media_adapter_ref=context.media_normalization_ref,
+                media_adapter_ref=adapter_ref,
                 context=context,
             )
             admission = admit_source(
@@ -139,8 +148,8 @@ def main() -> int:
                 media_type=str(payload["media_type"]),
                 content_sha256=str(receipt.content_sha256),
                 source_bytes=bytes(payload["raw_bytes"]),
-                canonical_text=str(payload["canonical_text"]),
-                adapter_ref=context.media_normalization_ref,
+                canonical_text=canonical_text,
+                adapter_ref=adapter_ref,
                 adapter_version=context.media_normalization_ref,
                 compiler_context_ref=context.context_ref,
                 normalization_ref=context.media_normalization_ref,
@@ -158,7 +167,7 @@ def main() -> int:
                 jurisdiction_ref=args.jurisdiction_ref,
                 source_role=args.source_role,
                 authority_level=args.authority_level,
-                canonical_text_sha256=str(payload["canonical_text_sha256"]),
+                canonical_text_sha256=canonical_sha256_hex,
                 media_type=str(payload["media_type"]),
                 temporal_refs=tuple(sorted(set(args.temporal_ref))),
                 provider_profile_refs=(args.provider_profile_ref,),

--- a/scripts/build_legal_ir_catalogue.py
+++ b/scripts/build_legal_ir_catalogue.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
-"""Build or refresh a checked-in legal catalogue and persistent PNF database."""
+"""Build a deterministic offline Legal IR catalogue from persisted sources.
+
+This command has no acquisition capability. Use ``acquire_legal_source.py`` for
+an explicit operator-authorised bounded fetch, then rerun this catalogue build.
+"""
 
 from __future__ import annotations
 
 import argparse
 import atexit
 from concurrent.futures import ThreadPoolExecutor
-import hashlib
 import json
 import os
 from pathlib import Path
 import shutil
-import subprocess
 import sys
-from urllib.parse import quote_plus
-
+from urllib.parse import urlparse
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -22,52 +23,35 @@ if str(ROOT) not in sys.path:
 
 from src.ingestion.corpus_source_projection import project_source_families  # noqa: E402
 from src.policy.corpus_compilation import default_compiler_context  # noqa: E402
-from src.policy.parallel_postgres_corpus_compilation import (  # noqa: E402
-    compile_directory_postgres_parallel,
+from src.policy.curated_postgres_corpus_compilation import (  # noqa: E402
+    compile_curated_directory_postgres,
 )
+from src.runtime.offline_network_guard import OfflineNetworkGuard  # noqa: E402
 from src.runtime.progress import PhaseRecorder  # noqa: E402
-from src.runtime.request_governor import RequestGovernor, RequestGovernorPolicy  # noqa: E402
-from src.sources.legal_follow import follow_legal_sources  # noqa: E402
+from src.sources.admission import OFFLINE_HCA_REGRESSION_PROFILE  # noqa: E402
+from src.sources.catalogue_metadata import source_metadata_from_rules  # noqa: E402
 
 
 def _args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--catalogue", type=Path, required=True)
     parser.add_argument("--output-root", type=Path, required=True)
-    parser.add_argument(
-        "--database-url",
-        default=os.environ.get("DATABASE_URL"),
-    )
-    parser.add_argument("--offline", action="store_true")
-    parser.add_argument("--force-refetch", action="store_true")
-    parser.add_argument(
-        "--compile-workers",
-        type=int,
-        default=max(1, min(4, (os.cpu_count() or 2) // 2)),
-        help="Document parser/persistence processes (1-32)",
-    )
-    parser.add_argument(
-        "--closure-workers",
-        type=int,
-        default=2,
-        help="Pure closure executors inside each active document (1-32)",
-    )
-    parser.add_argument(
-        "--owner-partitions",
-        type=int,
-        default=4,
-        help="Logical keyed owner partitions inside each document (1-128)",
-    )
-    parser.add_argument(
-        "--copy-workers",
-        type=int,
-        default=4,
-        help="Bounded source-family copy workers",
-    )
+    parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
+    parser.add_argument("--offline", action="store_true", help="Retained for compatibility; builds are always offline")
+    parser.add_argument("--force-refetch", action="store_true", help="Rejected; acquisition is a separate command")
+    parser.add_argument("--compile-workers", type=int, default=4)
+    parser.add_argument("--closure-workers", type=int, default=4)
+    parser.add_argument("--owner-partitions", type=int, default=8)
+    parser.add_argument("--copy-workers", type=int, default=4)
+    parser.add_argument("--transaction-attempts", type=int, default=3)
+    parser.add_argument("--max-files", type=int, default=500)
+    parser.add_argument("--max-file-bytes", type=int, default=10_000_000)
     parser.add_argument("--progress-jsonl", action="store_true")
     args = parser.parse_args()
     if not args.database_url:
         parser.error("--database-url or DATABASE_URL is required")
+    if args.force_refetch:
+        parser.error("--force-refetch is unavailable; use scripts/acquire_legal_source.py")
     if not 1 <= args.compile_workers <= 32:
         parser.error("--compile-workers must be between 1 and 32")
     if not 1 <= args.closure_workers <= 32:
@@ -82,34 +66,34 @@ def _args() -> argparse.Namespace:
 def _write_json(path: Path, value: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        json.dumps(value, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+        json.dumps(value, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
     )
 
 
-def _safe_name(index: int, url: str, suffix: str) -> str:
-    digest = hashlib.sha256(url.encode()).hexdigest()[:16]
-    return f"{index:04d}_{digest}{suffix}"
-
-
-def _source_file_plan(
-    source: Path,
-    target: Path,
-    *,
-    max_file_bytes: int | None = None,
-    source_suffixes: tuple[str, ...] = (),
-) -> tuple[tuple[Path, Path], ...]:
-    if not source.exists():
-        return ()
-    return tuple(
-        (path, target / path.relative_to(source))
-        for path in sorted(source.rglob("*"))
-        if path.is_file()
-        and (not source_suffixes or path.suffix.lower() in source_suffixes)
-        and (
-            max_file_bytes is None
-            or path.stat().st_size <= max_file_bytes
-        )
-    )
+def _copy_plan(catalogue: dict[str, object], target_root: Path) -> tuple[tuple[Path, Path], ...]:
+    rows: list[tuple[Path, Path]] = []
+    for raw_family in catalogue.get("persisted_source_families", []):
+        family = dict(raw_family)
+        source = (ROOT / str(family["path"])).resolve()
+        family_ref = str(family["family_ref"]).replace(":", "_")
+        target = target_root / family_ref
+        suffixes = {str(value).lower() for value in family.get("source_suffixes", ())}
+        maximum = family.get("max_file_bytes")
+        if source.is_file():
+            candidates = (source,)
+        elif source.exists():
+            candidates = tuple(path for path in sorted(source.rglob("*")) if path.is_file())
+        else:
+            candidates = ()
+        for path in candidates:
+            if suffixes and path.suffix.lower() not in suffixes:
+                continue
+            if maximum is not None and path.stat().st_size > int(maximum):
+                continue
+            relative = path.name if source.is_file() else str(path.relative_to(source))
+            rows.append((path, target / relative))
+    return tuple(rows)
 
 
 def _copy_one(pair: tuple[Path, Path]) -> str:
@@ -119,14 +103,33 @@ def _copy_one(pair: tuple[Path, Path]) -> str:
     return str(destination)
 
 
-def _aggregate_stage_timings(outcomes: tuple[object, ...]) -> dict[str, object]:
+def _admission_rules(catalogue: dict[str, object]) -> tuple[dict[str, object], ...]:
+    explicit = tuple(dict(row) for row in catalogue.get("source_admission_rules", []))
+    if explicit:
+        return explicit
+    derived = []
+    for raw_family in catalogue.get("persisted_source_families", []):
+        family = dict(raw_family)
+        family_ref = str(family["family_ref"]).replace(":", "_")
+        derived.append(
+            {
+                "glob": f"{family_ref}/**",
+                "source_role": str(family.get("source_role") or "unclassified"),
+                "semantic_scope": str(family.get("semantic_scope") or "source_material"),
+                "jurisdiction_ref": str(family.get("jurisdiction_ref") or ""),
+                "authority_level": str(family.get("authority_level") or ""),
+                "provider_profile_refs": family.get("provider_profile_refs") or (),
+                "temporal_refs": family.get("temporal_refs") or (),
+            }
+        )
+    return tuple(derived)
+
+
+def _aggregate_timings(outcomes: tuple[object, ...]) -> dict[str, object]:
     totals: dict[str, int] = {}
     counts: dict[str, int] = {}
     slowest: list[dict[str, object]] = []
-    fixed_points = 0
     for outcome in outcomes:
-        if getattr(outcome, "local_fixed_point", None) == "reached":
-            fixed_points += 1
         for row in getattr(outcome, "stage_timings", ()):
             stage = str(row["stage"])
             elapsed = int(row["elapsed_ms"])
@@ -138,26 +141,27 @@ def _aggregate_stage_timings(outcomes: tuple[object, ...]) -> dict[str, object]:
                     "relative_path": getattr(outcome, "relative_path"),
                     "stage": stage,
                     "elapsed_ms": elapsed,
-                    "backend_ref": row.get("backend_ref"),
                 }
             )
     return {
-        "stage_totals_ms": {
-            key: totals[key] for key in sorted(totals)
-        },
+        "stage_totals_ms": {key: totals[key] for key in sorted(totals)},
         "stage_means_ms": {
             key: totals[key] / counts[key] for key in sorted(totals)
         },
         "slowest_stage_instances": sorted(
             slowest,
-            key=lambda row: (
-                -int(row["elapsed_ms"]),
-                str(row["document_ref"]),
-                str(row["stage"]),
-            ),
+            key=lambda row: (-int(row["elapsed_ms"]), str(row["document_ref"])),
         )[:30],
-        "local_fixed_point_count": fixed_points,
     }
+
+
+def _allowed_database_hosts(database_url: str) -> tuple[str, ...]:
+    parsed = urlparse(database_url)
+    host = parsed.hostname
+    local = {"localhost", "127.0.0.1", "::1"}
+    if host and host not in local:
+        raise ValueError("offline catalogue requires a local PostgreSQL endpoint")
+    return tuple(sorted(local | ({host} if host else set())))
 
 
 def main() -> int:
@@ -170,258 +174,118 @@ def main() -> int:
     atexit.register(recorder.write_json, phase_ledger_path)
 
     source_root = output_root / "source_catalogue"
-    existing_root = source_root / "existing_au_tranche"
-    driving_root = source_root / "austlii_driving"
-    raw_root = driving_root / "raw"
-    canonical_root = driving_root / "canonical"
-    raw_root.mkdir(parents=True, exist_ok=True)
-    canonical_root.mkdir(parents=True, exist_ok=True)
-
-    copy_plan: list[tuple[Path, Path]] = []
-    for family in catalogue.get("persisted_source_families", []):
-        max_file_bytes = family.get("max_file_bytes")
-        source_suffixes = tuple(
-            str(value).lower()
-            for value in family.get("source_suffixes", ())
-        )
-        copy_plan.extend(
-            _source_file_plan(
-                ROOT / family["path"],
-                existing_root / family["family_ref"].replace(":", "_"),
-                max_file_bytes=(
-                    int(max_file_bytes)
-                    if max_file_bytes is not None
-                    else None
-                ),
-                source_suffixes=source_suffixes,
-            )
-        )
+    source_root.mkdir(parents=True, exist_ok=True)
+    copy_plan = _copy_plan(catalogue, source_root)
     with recorder.phase(
         "copy_persisted_sources",
         total=len(copy_plan),
-        details={"workers": args.copy_workers},
+        details={"workers": args.copy_workers, "network": "forbidden"},
     ) as phase:
-        with ThreadPoolExecutor(
-            max_workers=args.copy_workers,
-            thread_name_prefix="source-copy",
-        ) as executor:
+        with ThreadPoolExecutor(max_workers=args.copy_workers) as executor:
             for copied_path in executor.map(_copy_one, copy_plan):
                 phase.advance(subject_ref=copied_path)
-    copied = len(copy_plan)
 
-    policy_data = catalogue["request_policy"]
-    governor = RequestGovernor(
-        RequestGovernorPolicy(
-            minimum_interval_seconds=float(
-                policy_data["minimum_interval_seconds"]
-            ),
-            maximum_attempts=int(policy_data["maximum_attempts"]),
-            backoff_seconds=float(policy_data["backoff_seconds"]),
-            request_budget=int(policy_data["request_budget"]),
-        )
-    )
-    provider = catalogue["provider"]
-    fetched_documents: list[dict[str, object]] = []
-    terms = tuple(catalogue.get("search_terms", []))
-    with recorder.phase(
-        "acquire_sources",
-        total=0 if args.offline else len(terms),
-        message=(
-            "offline reuse"
-            if args.offline
-            else "bounded AustLII discovery"
-        ),
-        details={"provider": provider["endpoint_ref"], "governed": True},
-    ) as phase:
-        if not args.offline:
-            for term in terms:
-                search_url = provider["search_url_template"].format(
-                    query=quote_plus(term["query"])
-                )
-                result = governor.call(
-                    search_url,
-                    lambda url=search_url: follow_legal_sources(
-                        "AU",
-                        seed_urls=(url,),
-                        max_depth=int(policy_data["max_depth"]),
-                        max_documents=max(
-                            1,
-                            int(policy_data["max_documents"])
-                            // max(1, len(terms)),
-                        ),
-                    ),
-                )
-                term_count = 0
-                for followed in result.documents:
-                    document = followed.document
-                    final_url = (
-                        document.final_url or document.requested_url
-                    )
-                    suffix = (
-                        ".html"
-                        if document.media_type
-                        in {"text/html", "application/xhtml+xml"}
-                        else ".txt"
-                    )
-                    name = _safe_name(
-                        len(fetched_documents) + 1,
-                        final_url,
-                        suffix,
-                    )
-                    raw_path = raw_root / name
-                    canonical_path = canonical_root / (
-                        Path(name).stem + ".txt"
-                    )
-                    reused = raw_path.exists() and not args.force_refetch
-                    if not reused:
-                        raw_path.write_bytes(document.raw_bytes)
-                        canonical_path.write_text(
-                            document.canonical_text,
-                            encoding="utf-8",
-                        )
-                    fetched_documents.append(
-                        {
-                            "jurisdiction": term["jurisdiction"],
-                            "search_term": term["query"],
-                            "search_url": search_url,
-                            "requested_url": document.requested_url,
-                            "final_url": document.final_url,
-                            "raw_path": str(
-                                raw_path.relative_to(output_root)
-                            ),
-                            "canonical_path": str(
-                                canonical_path.relative_to(output_root)
-                            ),
-                            "reused": reused,
-                            "receipt": document.receipt.to_dict(),
-                        }
-                    )
-                    term_count += 1
-                phase.advance(
-                    subject_ref=term["query"],
-                    message=f"{term_count} documents",
-                    details={
-                        "jurisdiction": term["jurisdiction"],
-                        "document_count": term_count,
-                    },
-                )
-
+    projection_root = output_root / "source_projection"
     with recorder.phase("project_canonical_sources", total=1) as phase:
         projection = project_source_families(
-            [existing_root, raw_root],
-            output_dir=output_root / "source_projection",
-            max_files=500,
-            max_file_bytes=10_000_000,
+            [source_root],
+            output_dir=projection_root,
+            max_files=args.max_files,
+            max_file_bytes=args.max_file_bytes,
         )
-        _write_json(
-            output_root / "source_projection" / "manifest.json",
-            projection.to_dict(),
-        )
+        _write_json(projection_root / "manifest.json", projection.to_dict())
         phase.advance(
-            subject_ref=str(
-                output_root / "source_projection" / "manifest.json"
-            ),
-            details={"source_family_count": 2},
+            subject_ref=str(projection_root / "manifest.json"),
+            details={"document_count": len(projection.documents)},
         )
 
-    outcomes: tuple[object, ...]
+    original_relative_paths = []
+    for row in projection.documents:
+        original_relative_paths.append(
+            Path(row.source_path).resolve().relative_to(source_root).as_posix()
+        )
+    original_metadata = source_metadata_from_rules(
+        original_relative_paths,
+        rules=_admission_rules(catalogue),
+    )
+    source_metadata: dict[str, dict[str, object]] = {}
+    for row, original_path in zip(
+        projection.documents,
+        original_relative_paths,
+        strict=True,
+    ):
+        canonical_relative = Path(row.canonical_path).relative_to("canonical").as_posix()
+        source_metadata[canonical_relative] = {
+            **original_metadata[original_path],
+            "source_revision_ref": row.source_ref,
+            "source_projection_ref": row.source_ref,
+            "source_anchor_state": row.anchor_state,
+        }
+    _write_json(output_root / "source_metadata.json", source_metadata)
+
     runtime = {
         "parser_document_processes": args.compile_workers,
         "owner_partitions_per_document": args.owner_partitions,
         "closure_executors_per_document": args.closure_workers,
+        "maximum_transaction_attempts": args.transaction_attempts,
     }
-    with recorder.phase(
-        "compile_pnf",
-        details={
-            **runtime,
-            "parallel_boundary": "document_and_revision_bound_jobs",
-        },
-    ) as phase:
-        compilation, outcomes = compile_directory_postgres_parallel(
-            output_root / "source_projection" / "canonical",
-            context=default_compiler_context(),
-            database_url=args.database_url,
-            workers=args.compile_workers,
-            closure_workers_per_document=args.closure_workers,
-            owner_partitions_per_document=args.owner_partitions,
-            execution_phase="demand_planning",
-            progress=phase,
-        )
-    aggregate_timings = _aggregate_stage_timings(outcomes)
+    guard = OfflineNetworkGuard(
+        allowed_hosts=_allowed_database_hosts(args.database_url)
+    )
+    with guard:
+        with recorder.phase(
+            "compile_curated_pnf",
+            details={**runtime, "offline": True, "admission_enforced": True},
+        ) as phase:
+            result = compile_curated_directory_postgres(
+                projection_root / "canonical",
+                context=default_compiler_context(),
+                database_url=args.database_url,
+                admission_profile=OFFLINE_HCA_REGRESSION_PROFILE,
+                source_metadata=source_metadata,
+                workers=args.compile_workers,
+                closure_workers_per_document=args.closure_workers,
+                owner_partitions_per_document=args.owner_partitions,
+                maximum_transaction_attempts=args.transaction_attempts,
+                progress=phase,
+            )
+    network_receipt = guard.receipt.to_dict()
+    if not network_receipt["external_network_absent"]:
+        raise RuntimeError("offline catalogue recorded external network attempts")
+
+    aggregate = _aggregate_timings(result.outcomes)
+    _write_json(output_root / "source_admission_manifest.json", result.admission)
+    _write_json(output_root / "network_absence_receipt.json", network_receipt)
     _write_json(
         output_root / "document_compilation_timings.json",
         {
-            "schema_version": "sl.document_compilation_timings.v0_2",
+            "schema_version": "sl.document_compilation_timings.v0_3",
             "runtime": runtime,
-            "aggregate": aggregate_timings,
-            "documents": [row.to_dict() for row in outcomes],
+            "aggregate": aggregate,
+            "documents": [row.to_dict() for row in result.outcomes],
         },
     )
-
-    probe_dir = output_root / "legal_pnf_probe"
-    with recorder.phase(
-        "project_legal_ir",
-        total=len(compilation.document_refs),
-        message="document-local PNF/Legal IR/legacy differential probe",
-    ) as phase:
-        subprocess.run(
-            [
-                sys.executable,
-                str(ROOT / "scripts" / "run_legal_pnf_probe.py"),
-                "--input-directory",
-                str(source_root),
-                "--output-dir",
-                str(probe_dir),
-                "--compare-legacy",
-                "--max-files",
-                "500",
-                "--closure-workers",
-                str(args.closure_workers),
-                "--owner-partitions",
-                str(args.owner_partitions),
-            ],
-            check=True,
-        )
-        phase.completed = len(compilation.document_refs)
-
-    recorder.write_json(phase_ledger_path)
     manifest = {
-        "schema_version": "sl.persisted_legal_catalogue_build.v0_3",
+        "schema_version": "sl.persisted_legal_catalogue_build.v0_4",
         "catalogue_ref": catalogue["catalogue_ref"],
-        "provider": provider,
-        "existing_tranche_file_count": copied,
-        "fetched_document_count": len(fetched_documents),
-        "fetched_documents": fetched_documents,
-        "request_governor": governor.summary(),
-        "corpus_ref": compilation.corpus_ref,
-        "document_refs": list(compilation.document_refs),
-        "demand_refs": list(compilation.demand_refs),
-        "failure_refs": list(compilation.failure_refs),
+        "corpus_ref": result.persisted.corpus_ref,
+        "document_refs": list(result.persisted.document_refs),
+        "demand_refs": list(result.persisted.demand_refs),
+        "failure_refs": list(result.persisted.failure_refs),
+        "source_admission_manifest": "source_admission_manifest.json",
+        "network_absence_receipt": "network_absence_receipt.json",
+        "document_compilation_timings": "document_compilation_timings.json",
+        "aggregate_stage_timings": aggregate,
         "runtime": runtime,
-        "document_compilation_timings": (
-            "document_compilation_timings.json"
-        ),
-        "aggregate_stage_timings": aggregate_timings,
-        "phase_ledger": str(phase_ledger_path.relative_to(output_root)),
-        "phase_summary": recorder.to_dict()["phase_summary"],
-        "legal_pnf_probe_root": str(probe_dir.relative_to(output_root)),
-        "parallelism_boundary": (
-            "immutable_document_and_revision_bound_semantic_jobs"
-        ),
-        "logical_owner_granularity": (
-            "document_scope_factor_family"
-        ),
-        "streaming_bidirectional": True,
-        "eventual_consistency": "convergent_append_only",
-        "request_governor_serialized": True,
-        "final_manifest_reduction_serialized": True,
+        "acquisition_supported": False,
+        "governed_acquisition_command": "scripts/acquire_legal_source.py",
         "identity_promoted": False,
         "legal_truth_closed": False,
         "authority": "candidate_catalogue_build_only",
     }
     _write_json(output_root / "catalogue_build_manifest.json", manifest)
     print(json.dumps(manifest, indent=2, sort_keys=True))
-    return 0
+    return 1 if result.persisted.failure_refs else 0
 
 
 if __name__ == "__main__":

--- a/scripts/check_curated_legal_ir_acceptance.py
+++ b/scripts/check_curated_legal_ir_acceptance.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Evaluate curated Legal IR correctness, offline, parity, and p50 thresholds."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from statistics import median
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-root", type=Path, required=True)
+    parser.add_argument("--parity-root", type=Path, required=True)
+    parser.add_argument("--maximum-p50-postgres-seconds", type=float, default=1.85)
+    parser.add_argument("--maximum-p50-base-reduction-seconds", type=float, default=0.69)
+    parser.add_argument("--require-control-parity", action="store_true")
+    return parser.parse_args()
+
+
+def _load(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _stage_values(timing: dict[str, object], stage: str) -> list[float]:
+    values = []
+    for document in timing.get("documents", []):
+        for row in document.get("stage_timings", []):
+            if str(row.get("stage")) == stage:
+                values.append(float(row.get("elapsed_ms") or 0) / 1000.0)
+    return values
+
+
+def main() -> int:
+    args = _args()
+    build = args.build_root.resolve()
+    parity = args.parity_root.resolve()
+    catalogue = _load(build / "catalogue_build_manifest.json")
+    admission = _load(build / "source_admission_manifest.json")
+    network = _load(build / "network_absence_receipt.json")
+    timing = _load(build / "document_compilation_timings.json")
+    parity_receipt = _load(parity / "parity_receipt.json")
+    parity_network = _load(parity / "network_absence_receipt.json")
+
+    failures: list[str] = []
+    if catalogue.get("failure_refs"):
+        failures.append("unexpected_compiler_failures")
+    if not network.get("external_network_absent"):
+        failures.append("catalogue_external_network_attempt")
+    if not parity_network.get("external_network_absent"):
+        failures.append("parity_external_network_attempt")
+    if int(parity_receipt.get("network_attempt_count") or 0) != 0:
+        failures.append("parity_receipt_network_attempt")
+    if parity_receipt.get("unexpected_failure_refs"):
+        failures.append("parity_unexpected_failures")
+    if args.require_control_parity and parity_receipt.get("identity_parity") is not True:
+        failures.append("semantic_identity_drift_or_control_absent")
+    if admission.get("counts", {}).get("compile", 0) < 1:
+        failures.append("no_compile_eligible_source")
+
+    postgres_values = _stage_values(timing, "postgres_persistence")
+    base_values = _stage_values(timing, "base_proposal_reduction")
+    p50_postgres = median(postgres_values) if postgres_values else None
+    p50_base = median(base_values) if base_values else None
+    if p50_postgres is None:
+        failures.append("postgres_timing_absent")
+    elif p50_postgres > args.maximum_p50_postgres_seconds:
+        failures.append("postgres_p50_threshold_failed")
+    if p50_base is None:
+        failures.append("base_reduction_timing_absent")
+    elif p50_base > args.maximum_p50_base_reduction_seconds:
+        failures.append("base_reduction_p50_threshold_failed")
+
+    result = {
+        "schema_version": "sl.curated_legal_ir_acceptance.v0_1",
+        "accepted": not failures,
+        "failures": failures,
+        "thresholds": {
+            "maximum_p50_postgres_seconds": args.maximum_p50_postgres_seconds,
+            "maximum_p50_base_reduction_seconds": args.maximum_p50_base_reduction_seconds,
+        },
+        "observed": {
+            "p50_postgres_seconds": p50_postgres,
+            "p50_base_reduction_seconds": p50_base,
+            "document_count": len(timing.get("documents", [])),
+            "admission_counts": admission.get("counts", {}),
+            "identity_parity": parity_receipt.get("identity_parity"),
+        },
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if result["accepted"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_curated_legal_ir_parity.py
+++ b/scripts/run_curated_legal_ir_parity.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Run the curated offline PNF → persisted law → Legal IR parity proof."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+from urllib.parse import urlparse
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.obligations import extract_obligations_from_text, obligation_to_dict  # noqa: E402
+from src.pnf.curated_legal_ir_flow import run_curated_legal_ir_flow  # noqa: E402
+from src.pnf.legal_ir_parity import SemanticIdentitySnapshot  # noqa: E402
+from src.pnf.legal_semantic_build import (  # noqa: E402
+    build_legal_semantic_build,
+    normalize_legacy_witnesses,
+)
+from src.policy.carriers.canonical import canonical_sha256  # noqa: E402
+from src.policy.corpus_compilation import default_compiler_context  # noqa: E402
+from src.policy.fibred_operational_corpus_compilation import (  # noqa: E402
+    FIBRED_OPERATIONAL_COMPILER_CONTRACT,
+    compile_document_fibred_operational,
+)
+from src.runtime.offline_network_guard import OfflineNetworkGuard  # noqa: E402
+from src.sources.admission import OFFLINE_HCA_REGRESSION_PROFILE, admit_source  # noqa: E402
+from src.storage.postgres.batched_compiler_store import (  # noqa: E402
+    BatchedPostgresCompilerStore,
+)
+from src.storage.postgres.legal_source_store import (  # noqa: E402
+    load_compatible_legal_sources,
+    load_legal_source_payload,
+    persist_legal_source_plans,
+    persist_parity_receipt,
+)
+
+
+def _args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-directory", type=Path, required=True)
+    parser.add_argument("--source-metadata", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
+    parser.add_argument("--control-snapshot", type=Path)
+    parser.add_argument("--closure-workers", type=int, default=4)
+    parser.add_argument("--owner-partitions", type=int, default=8)
+    args = parser.parse_args()
+    if not args.database_url:
+        parser.error("--database-url or DATABASE_URL is required")
+    return args
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _snapshot(path: Path | None) -> SemanticIdentitySnapshot | None:
+    if path is None:
+        return None
+    row = json.loads(path.read_text(encoding="utf-8"))
+    return SemanticIdentitySnapshot(
+        proposal_refs=tuple(row.get("proposal_refs") or ()),
+        factor_refs=tuple(row.get("factor_refs") or ()),
+        graph_refs=tuple(row.get("graph_refs") or ()),
+        fibre_ledger_refs=tuple(row.get("fibre_ledger_refs") or ()),
+        residual_refs=tuple(row.get("residual_refs") or ()),
+        demand_refs=tuple(row.get("demand_refs") or ()),
+        legal_ir_refs=tuple(row.get("legal_ir_refs") or ()),
+        typed_meet_refs=tuple(row.get("typed_meet_refs") or ()),
+        legacy_witness_refs=tuple(row.get("legacy_witness_refs") or ()),
+    )
+
+
+def _allowed_hosts(database_url: str) -> tuple[str, ...]:
+    host = urlparse(database_url).hostname
+    local = {"localhost", "127.0.0.1", "::1"}
+    if host and host not in local:
+        raise ValueError("offline parity requires a local PostgreSQL endpoint")
+    return tuple(sorted(local | ({host} if host else set())))
+
+
+def _compile(
+    *,
+    document_ref: str,
+    source_ref: str,
+    canonical_text: str,
+    closure_workers: int,
+    owner_partitions: int,
+) -> dict[str, object]:
+    digest = hashlib.sha256(canonical_text.encode("utf-8")).hexdigest()
+    compilation = compile_document_fibred_operational(
+        {
+            "document_ref": document_ref,
+            "source_ref": source_ref,
+            "media_type": "text/plain",
+            "content_sha256": digest,
+            "canonical_text": canonical_text,
+        },
+        default_compiler_context(),
+        closure_workers=closure_workers,
+        owner_partitions=owner_partitions,
+    )
+    return compilation.to_dict()
+
+
+def main() -> int:
+    args = _args()
+    root = args.input_directory.resolve()
+    metadata = json.loads(args.source_metadata.read_text(encoding="utf-8"))
+    output = args.output_dir.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    ordinary: list[dict[str, object]] = []
+    legacy_builds: list[dict[str, object]] = []
+    witness_refs: list[str] = []
+
+    store = BatchedPostgresCompilerStore.connect(args.database_url)
+    guard = OfflineNetworkGuard(allowed_hosts=_allowed_hosts(args.database_url))
+    try:
+        with guard:
+            for path in sorted(value for value in root.rglob("*") if value.is_file()):
+                relative_path = path.relative_to(root).as_posix()
+                source_row = dict(metadata.get(relative_path) or {})
+                digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                source_row.setdefault("source_revision_ref", f"source-revision:{digest}")
+                receipt = admit_source(
+                    source_row,
+                    profile=OFFLINE_HCA_REGRESSION_PROFILE,
+                )
+                if not receipt.compile_eligible:
+                    continue
+                text = path.read_text(encoding="utf-8")
+                document_ref = "document:curated-parity:" + canonical_sha256(
+                    {
+                        "source_revision_ref": receipt.source_revision_ref,
+                        "content_sha256": digest,
+                    }
+                )
+                compilation = _compile(
+                    document_ref=document_ref,
+                    source_ref=receipt.source_revision_ref,
+                    canonical_text=text,
+                    closure_workers=args.closure_workers,
+                    owner_partitions=args.owner_partitions,
+                )
+                ordinary.append(compilation)
+                legacy_rows = [
+                    obligation_to_dict(row)
+                    for row in extract_obligations_from_text(
+                        text,
+                        references=[],
+                        source_id=receipt.source_revision_ref,
+                    )
+                ]
+                witnesses = normalize_legacy_witnesses(
+                    legacy_rows,
+                    document_ref=document_ref,
+                )
+                witness_refs.extend(row.witness_ref for row in witnesses)
+                semantic_build = build_legal_semantic_build(
+                    compilation=compilation,
+                    legal_ir=(),
+                    legacy_rows=legacy_rows,
+                    declaration_revision_refs=(FIBRED_OPERATIONAL_COMPILER_CONTRACT,),
+                )
+                legacy_builds.append(
+                    {
+                        "document_ref": document_ref,
+                        "legacy_witnesses": [row.to_dict() for row in witnesses],
+                        "comparison_ledger": semantic_build["comparison_ledger"],
+                        "coverage_demands": semantic_build["coverage_demands"],
+                    }
+                )
+
+            def source_lookup(demand):
+                with store.transaction() as cursor:
+                    return load_compatible_legal_sources(cursor, demand)
+
+            def payload_lookup(source_revision_ref: str):
+                with store.transaction() as cursor:
+                    return load_legal_source_payload(
+                        cursor,
+                        source_revision_ref=source_revision_ref,
+                    )
+
+            def compile_legal_source(payload):
+                return _compile(
+                    document_ref=str(payload["document_ref"]),
+                    source_ref=str(payload["source_revision_ref"]),
+                    canonical_text=str(payload["canonical_text"]),
+                    closure_workers=args.closure_workers,
+                    owner_partitions=args.owner_partitions,
+                )
+
+            result = run_curated_legal_ir_flow(
+                corpus_ref="corpus:curated-legal-ir-parity",
+                admission_profile_ref=OFFLINE_HCA_REGRESSION_PROFILE.profile_ref,
+                compiler_contract_ref=FIBRED_OPERATIONAL_COMPILER_CONTRACT,
+                ordinary_compilations=ordinary,
+                source_lookup=source_lookup,
+                payload_lookup=payload_lookup,
+                compile_legal_source=compile_legal_source,
+                legacy_witness_refs=witness_refs,
+                control_snapshot=_snapshot(args.control_snapshot),
+                network_attempt_count=0,
+            )
+        network_receipt = guard.receipt.to_dict()
+        if not network_receipt["external_network_absent"]:
+            raise RuntimeError("parity run attempted external network access")
+        with store.transaction() as cursor:
+            persist_legal_source_plans(cursor, result.plans)
+            persist_parity_receipt(cursor, result.parity_receipt.to_dict())
+
+        _write_json(output / "ordinary_compilations.json", ordinary)
+        _write_json(output / "legacy_differential.json", legacy_builds)
+        _write_json(output / "legal_ir_flow.json", result.to_dict())
+        _write_json(output / "identity_snapshot.json", result.identity_snapshot.to_dict())
+        _write_json(output / "parity_receipt.json", result.parity_receipt.to_dict())
+        _write_json(output / "network_absence_receipt.json", network_receipt)
+        print(json.dumps(result.parity_receipt.to_dict(), indent=2, sort_keys=True))
+        if result.parity_receipt.unexpected_failure_refs:
+            return 1
+        if (
+            result.parity_receipt.identity_parity is False
+            and args.control_snapshot is not None
+        ):
+            return 1
+        return 0
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pnf/curated_legal_ir_flow.py
+++ b/src/pnf/curated_legal_ir_flow.py
@@ -1,0 +1,264 @@
+"""Pure orchestration for the curated ordinary-PNF to Legal-IR proof.
+
+The caller supplies already-compiled ordinary documents, persisted legal-source
+lookups, and the same fibred compiler for selected legal sources. Missing source
+coordinates remain blocked acquisition requirements; no network operation is
+available in this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from src.pnf.legal_adjunct import (
+    AcquisitionRequirement,
+    LegalIRObservation,
+    LegalSourcePlan,
+    LegalTypedMeet,
+    NormativeInteractionDemand,
+    plan_legal_sources,
+    project_acquisition_requirements,
+    project_legal_ir,
+    project_normative_interaction_demands,
+    typed_legal_meet,
+)
+from src.pnf.legal_ir_parity import (
+    CuratedLegalIRParityReceipt,
+    SemanticIdentitySnapshot,
+    compare_identity_snapshots,
+    snapshot_from_build_artifacts,
+)
+from src.pnf.legal_source_registry import RegisteredLegalSource
+from src.policy.carriers.canonical import canonical_sha256
+
+SourceLookup = Callable[[NormativeInteractionDemand], Sequence[RegisteredLegalSource]]
+PayloadLookup = Callable[[str], Mapping[str, Any] | None]
+LegalCompiler = Callable[[Mapping[str, Any]], Mapping[str, Any]]
+
+
+def _artifacts(compilation: Mapping[str, Any]) -> Mapping[str, Any]:
+    return compilation.get("artifacts") or compilation
+
+
+def _factor_projection_rows(artifact: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
+    graph = artifact.get("refined_pnf_graph") or artifact.get("pnf_graph") or {}
+    rows = []
+    for factor in graph.get("factors") or ():
+        metadata = dict(factor.get("metadata") or {})
+        revision_ref = str(
+            metadata.get("factor_revision_ref")
+            or "factor-revision:"
+            + canonical_sha256(
+                {
+                    "factor_ref": factor.get("factor_ref"),
+                    "closure_state": factor.get("closure_state"),
+                    "alternatives": factor.get("alternatives") or (),
+                    "residuals": factor.get("residuals") or (),
+                }
+            )
+        )
+        signature_ref = str(
+            metadata.get("structural_signature_ref")
+            or metadata.get("signature_ref")
+            or factor.get("factor_type")
+            or ""
+        )
+        rows.append(
+            {
+                **dict(factor),
+                "factor_type_ref": str(factor.get("factor_type") or ""),
+                "factor_revision_ref": revision_ref,
+                "structural_signature_ref": signature_ref,
+                "role_bindings": dict(metadata.get("role_bindings") or {}),
+                "qualifier_state": dict(metadata.get("qualifier_state") or {}),
+                "wrapper_state": dict(metadata.get("wrapper_state") or {}),
+                "provenance_refs": tuple(metadata.get("provenance_refs") or ()),
+                "residual_refs": tuple(factor.get("residuals") or ()),
+                "legal_coordinates": dict(metadata.get("legal_coordinates") or {}),
+            }
+        )
+    return tuple(rows)
+
+
+@dataclass(frozen=True)
+class CuratedLegalIRFlowResult:
+    demands: tuple[NormativeInteractionDemand, ...]
+    plans: tuple[LegalSourcePlan, ...]
+    acquisition_requirements: tuple[AcquisitionRequirement, ...]
+    legal_compilations: tuple[Mapping[str, Any], ...]
+    legal_ir: tuple[LegalIRObservation, ...]
+    typed_meets: tuple[LegalTypedMeet, ...]
+    identity_snapshot: SemanticIdentitySnapshot
+    parity_receipt: CuratedLegalIRParityReceipt
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "demands": [row.to_dict() for row in self.demands],
+            "plans": [row.to_dict() for row in self.plans],
+            "acquisition_requirements": [
+                {
+                    **row.__dict__,
+                    "requirement_ref": "acquisition-requirement:"
+                    + canonical_sha256(row.__dict__),
+                    "network_operation_performed": False,
+                }
+                for row in self.acquisition_requirements
+            ],
+            "legal_compilations": [dict(row) for row in self.legal_compilations],
+            "legal_ir": [row.to_dict() for row in self.legal_ir],
+            "typed_meets": [row.to_dict() for row in self.typed_meets],
+            "identity_snapshot": self.identity_snapshot.to_dict(),
+            "parity_receipt": self.parity_receipt.to_dict(),
+        }
+
+
+def run_curated_legal_ir_flow(
+    *,
+    corpus_ref: str,
+    admission_profile_ref: str,
+    compiler_contract_ref: str,
+    ordinary_compilations: Iterable[Mapping[str, Any]],
+    source_lookup: SourceLookup,
+    payload_lookup: PayloadLookup,
+    compile_legal_source: LegalCompiler,
+    legacy_witness_refs: Iterable[str] = (),
+    control_snapshot: SemanticIdentitySnapshot | None = None,
+    network_attempt_count: int = 0,
+    unexpected_failure_refs: Iterable[str] = (),
+) -> CuratedLegalIRFlowResult:
+    """Run the offline parity flow over persisted inputs only."""
+
+    if network_attempt_count != 0:
+        raise ValueError("curated Legal IR parity requires zero network attempts")
+    ordinary = tuple(dict(row) for row in ordinary_compilations)
+    demands = project_normative_interaction_demands(
+        row
+        for compilation in ordinary
+        for row in _artifacts(compilation).get("resolution_demands") or ()
+    )
+    plans: list[LegalSourcePlan] = []
+    selected_sources: dict[str, RegisteredLegalSource] = {}
+    for demand in demands:
+        sources = tuple(source_lookup(demand))
+        selected_sources.update({row.source_revision_ref: row for row in sources})
+        plans.extend(
+            plan_legal_sources(
+                (demand,),
+                persisted_sources=(row.planning_row() for row in sources),
+            )
+        )
+    ordered_plans = tuple(sorted(plans, key=lambda row: (row.demand_ref, row.plan_key)))
+    requirements = project_acquisition_requirements(ordered_plans)
+
+    selected_refs = tuple(
+        sorted(
+            {
+                ref
+                for plan in ordered_plans
+                if plan.state == "ready_persisted"
+                for ref in plan.selected_source_revision_refs
+            }
+        )
+    )
+    legal_compilations: list[Mapping[str, Any]] = []
+    for source_ref in selected_refs:
+        payload = payload_lookup(source_ref)
+        if payload is None:
+            raise ValueError(f"selected persisted legal source is unavailable: {source_ref}")
+        compilation = compile_legal_source(payload)
+        artifacts = _artifacts(compilation)
+        streaming = artifacts.get("streaming_semantic_build") or {}
+        if (streaming.get("fixed_point_certificate") or {}).get("local_fixed_point") != "reached":
+            raise ValueError("selected legal source did not reach local fixed point")
+        legal_compilations.append(dict(compilation))
+
+    legal_projection_rows = tuple(
+        row
+        for compilation in legal_compilations
+        for row in _factor_projection_rows(_artifacts(compilation))
+    )
+    legal_ir = project_legal_ir(legal_projection_rows)
+    ordinary_factor_rows = tuple(
+        row
+        for compilation in ordinary
+        for row in _factor_projection_rows(_artifacts(compilation))
+    )
+    typed_meets = tuple(
+        sorted(
+            (
+                typed_legal_meet(world_row, observation)
+                for world_row in ordinary_factor_rows
+                for observation in legal_ir
+                if world_row["structural_signature_ref"]
+                == observation.structural_signature_ref
+            ),
+            key=lambda row: (row.world_pnf_ref, row.legal_ir_ref),
+        )
+    )
+    witness_refs = tuple(sorted(set(str(value) for value in legacy_witness_refs)))
+    all_artifacts = tuple(_artifacts(row) for row in (*ordinary, *legal_compilations))
+    snapshot = snapshot_from_build_artifacts(
+        all_artifacts,
+        legal_ir_refs=(row.observation_ref for row in legal_ir),
+        typed_meet_refs=(
+            "legal-typed-meet:" + canonical_sha256(row.to_dict()) for row in typed_meets
+        ),
+        legacy_witness_refs=witness_refs,
+    )
+    parity = (
+        compare_identity_snapshots(control_snapshot, snapshot)
+        if control_snapshot is not None
+        else None
+    )
+    receipt = CuratedLegalIRParityReceipt(
+        corpus_ref=corpus_ref,
+        admission_profile_ref=admission_profile_ref,
+        compiler_contract_ref=compiler_contract_ref,
+        source_revision_refs=selected_refs,
+        ordinary_graph_refs=tuple(
+            sorted(
+                str((_artifacts(row).get("pnf_graph") or {}).get("graph_ref") or "")
+                for row in ordinary
+                if (_artifacts(row).get("pnf_graph") or {}).get("graph_ref")
+            )
+        ),
+        legal_graph_refs=tuple(
+            sorted(
+                str((_artifacts(row).get("pnf_graph") or {}).get("graph_ref") or "")
+                for row in legal_compilations
+                if (_artifacts(row).get("pnf_graph") or {}).get("graph_ref")
+            )
+        ),
+        demand_refs=tuple(row.demand_ref for row in demands),
+        plan_refs=tuple(
+            "legal-source-plan:" + canonical_sha256(row.to_dict())
+            for row in ordered_plans
+        ),
+        legal_ir_refs=tuple(row.observation_ref for row in legal_ir),
+        typed_meet_refs=tuple(
+            "legal-typed-meet:" + canonical_sha256(row.to_dict()) for row in typed_meets
+        ),
+        legacy_witness_refs=witness_refs,
+        identity_snapshot=snapshot.to_dict(),
+        control_snapshot=(control_snapshot.to_dict() if control_snapshot else None),
+        identity_parity=parity.identical if parity else None,
+        network_attempt_count=network_attempt_count,
+        unexpected_failure_refs=tuple(sorted(set(unexpected_failure_refs))),
+    )
+    return CuratedLegalIRFlowResult(
+        demands=demands,
+        plans=ordered_plans,
+        acquisition_requirements=requirements,
+        legal_compilations=tuple(legal_compilations),
+        legal_ir=legal_ir,
+        typed_meets=typed_meets,
+        identity_snapshot=snapshot,
+        parity_receipt=receipt,
+    )
+
+
+__all__ = [
+    "CuratedLegalIRFlowResult",
+    "run_curated_legal_ir_flow",
+]

--- a/src/pnf/factor_proposals.py
+++ b/src/pnf/factor_proposals.py
@@ -1,25 +1,23 @@
 """Immutable fibred PNF proposals and deterministic reduction.
 
 Ordinary compiler operations are normalised under one integrated semantic
-producer family.  Their particular typing, linking, composition, constraint,
-closure, or enrichment operation remains explicit, while executor details stay
-outside semantic identity.  Workers may populate fibres concurrently; one
-fibrewise reducer materialises the active PNF view and retains incompatible
-alternatives and residual boundary data.
+producer family. Executor details stay outside semantic identity. Proposals are
+partitioned by their complete fibre signature before compatibility grouping, so
+unrelated fibres never enter the comparison loop.
 """
 
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
+from math import comb
 from typing import Any, Iterable, Mapping, Sequence
 
 from src.pnf.semantic_fibres import SemanticCoordinate
 from src.policy.carriers.canonical import canonical_sha256
 
-
 INTEGRATED_SEMANTIC_PRODUCER_CONTRACT = "integrated-semantic-producer:v0_1"
 FACTOR_PROPOSAL_SCHEMA_VERSION = "sl.pnf.factor_proposal.v0_2"
-PROPOSAL_REDUCTION_SCHEMA_VERSION = "sl.pnf.proposal_reduction.v0_2"
+PROPOSAL_REDUCTION_SCHEMA_VERSION = "sl.pnf.proposal_reduction.v0_3"
 CROSS_DOCUMENT_RELATION_SCHEMA_VERSION = "sl.pnf.cross_document_relation.v0_1"
 
 _FIBRE_KINDS = {
@@ -139,18 +137,12 @@ class FactorProposal:
         object.__setattr__(self, "assumptions", assumptions)
         object.__setattr__(self, "coverage_requirements", coverage)
 
-        resolved_scope = self.scope_ref or (
-            min(spans) if spans else "document-global"
-        )
+        resolved_scope = self.scope_ref or (min(spans) if spans else "document-global")
         object.__setattr__(self, "scope_ref", resolved_scope)
-
-        operation_contract = self.operation_contract
+        operation_contract = self.operation_contract or self.producer_contract
         producer_contract = self.producer_contract
         if self.producer_scope == "integrated":
-            operation_contract = operation_contract or producer_contract
             producer_contract = INTEGRATED_SEMANTIC_PRODUCER_CONTRACT
-        else:
-            operation_contract = operation_contract or producer_contract
         object.__setattr__(self, "operation_contract", operation_contract)
         object.__setattr__(self, "producer_contract", producer_contract)
 
@@ -162,8 +154,11 @@ class FactorProposal:
             factor_family=self.factor_type_ref,
             coordinate_kind=self.coordinate_kind,
         )
-        coordinate_ref = self.semantic_coordinate_ref or coordinate.coordinate_ref
-        object.__setattr__(self, "semantic_coordinate_ref", coordinate_ref)
+        object.__setattr__(
+            self,
+            "semantic_coordinate_ref",
+            self.semantic_coordinate_ref or coordinate.coordinate_ref,
+        )
 
     @property
     def proposal_digest(self) -> str:
@@ -174,8 +169,6 @@ class FactorProposal:
         return "factor-proposal:" + self.proposal_digest
 
     def identity_payload(self) -> dict[str, Any]:
-        """Return semantic identity without executor-specific telemetry."""
-
         return {
             "document_ref": self.document_ref,
             "source_revision_ref": self.source_revision_ref,
@@ -270,9 +263,7 @@ class ReducedFactor:
             "ontology_axis_refs": list(self.ontology_axis_refs),
             "transport_refs": list(self.transport_refs),
             "support_states": list(self.support_states),
-            "closure_state": (
-                "requires_review" if self.residuals else "locally_closed"
-            ),
+            "closure_state": "requires_review" if self.residuals else "locally_closed",
         }
 
 
@@ -283,6 +274,7 @@ class ProposalReduction:
     residuals: tuple[ReductionResidual, ...]
     proposal_count: int
     deduplicated_count: int
+    metrics: Mapping[str, Any] = field(default_factory=dict)
 
     @property
     def graph_ref(self) -> str:
@@ -307,10 +299,9 @@ class ProposalReduction:
             ),
             "factors": [row.to_dict() for row in self.factors],
             "residuals": [row.to_dict() for row in self.residuals],
+            "metrics": dict(self.metrics),
             "reduction_contract": "deterministic-fibrewise-pnf:v0_1",
-            "integrated_producer_contract": (
-                INTEGRATED_SEMANTIC_PRODUCER_CONTRACT
-            ),
+            "integrated_producer_contract": INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
             "fibrewise_reduction": True,
             "identity_promoted": False,
             "legal_truth_closed": False,
@@ -330,9 +321,7 @@ class CrossDocumentRelation:
 
     @property
     def relation_ref(self) -> str:
-        return "cross-document-relation:" + canonical_sha256(
-            self.identity_payload()
-        )
+        return "cross-document-relation:" + canonical_sha256(self.identity_payload())
 
     def identity_payload(self) -> dict[str, Any]:
         return {
@@ -369,29 +358,28 @@ def proposal_build_key(
             "canonical_text_digest": canonical_text_digest,
             "producer_contract": producer_contract,
             "declaration_revision": declaration_revision,
-            "input_observation_digests": sorted(
-                set(input_observation_digests)
-            ),
-            "dependency_factor_digests": sorted(
-                set(dependency_factor_digests)
-            ),
+            "input_observation_digests": sorted(set(input_observation_digests)),
+            "dependency_factor_digests": sorted(set(dependency_factor_digests)),
         }
     )
 
 
+def _signature_key(proposal: FactorProposal) -> tuple[str, str, str, str]:
+    return (
+        str(proposal.semantic_coordinate_ref),
+        proposal.fibre_kind,
+        proposal.factor_type_ref,
+        proposal.structural_signature,
+    )
+
+
 def _compatible(left: FactorProposal, right: FactorProposal) -> bool:
-    if left.semantic_coordinate_ref != right.semantic_coordinate_ref:
+    if _signature_key(left) != _signature_key(right):
         return False
-    if left.fibre_kind != right.fibre_kind:
-        return False
-    if left.factor_type_ref != right.factor_type_ref:
-        return False
-    if left.structural_signature != right.structural_signature:
-        return False
-    for role in set(left.role_bindings) & set(right.role_bindings):
-        if left.role_bindings[role] != right.role_bindings[role]:
-            return False
-    return True
+    return all(
+        left.role_bindings[role] == right.role_bindings[role]
+        for role in set(left.role_bindings) & set(right.role_bindings)
+    )
 
 
 def reduce_factor_proposals(
@@ -406,9 +394,7 @@ def reduce_factor_proposals(
     ordered = sorted(proposals, key=lambda row: row.proposal_ref)
     for proposal in ordered:
         if proposal.document_ref != document_ref:
-            raise ValueError(
-                "cross-document proposal supplied to document-local reducer"
-            )
+            raise ValueError("cross-document proposal supplied to document-local reducer")
 
     observation_refs = set(known_observation_refs)
     dependency_refs = set(known_dependency_refs)
@@ -429,9 +415,7 @@ def reduce_factor_proposals(
             residual_ref = "reduction-residual:" + canonical_sha256(
                 {
                     "proposal_ref": proposal.proposal_ref,
-                    "semantic_coordinate_ref": (
-                        proposal.semantic_coordinate_ref
-                    ),
+                    "semantic_coordinate_ref": proposal.semantic_coordinate_ref,
                     "missing_observations": missing_observations,
                     "missing_dependencies": missing_dependencies,
                 }
@@ -443,12 +427,10 @@ def reduce_factor_proposals(
                     residual_type="missing_reduction_input",
                     proposal_refs=(proposal.proposal_ref,),
                     message=(
-                        "proposal retained outside reduction because declared "
-                        "inputs are unavailable"
+                        "proposal retained outside reduction because declared inputs "
+                        "are unavailable"
                     ),
-                    semantic_coordinate_ref=(
-                        proposal.semantic_coordinate_ref
-                    ),
+                    semantic_coordinate_ref=proposal.semantic_coordinate_ref,
                     boundary_kind="input_frontier",
                 )
             )
@@ -457,37 +439,32 @@ def reduce_factor_proposals(
 
     unique = {row.proposal_ref: row for row in valid}
     deduplicated = sorted(unique.values(), key=lambda row: row.proposal_ref)
-    groups: list[list[FactorProposal]] = []
+    buckets: dict[tuple[str, str, str, str], list[FactorProposal]] = {}
     for proposal in deduplicated:
-        matched = next(
-            (
-                group
-                for group in groups
-                if all(_compatible(proposal, item) for item in group)
-            ),
-            None,
-        )
-        if matched is None:
-            groups.append([proposal])
-        else:
-            matched.append(proposal)
+        buckets.setdefault(_signature_key(proposal), []).append(proposal)
+
+    candidate_comparisons = 0
+    grouped_by_signature: dict[
+        tuple[str, str, str, str], list[list[FactorProposal]]
+    ] = {}
+    for key, bucket in sorted(buckets.items()):
+        groups: list[list[FactorProposal]] = []
+        for proposal in bucket:
+            matched: list[FactorProposal] | None = None
+            for group in groups:
+                candidate_comparisons += 1
+                if all(_compatible(proposal, item) for item in group):
+                    matched = group
+                    break
+            if matched is None:
+                groups.append([proposal])
+            else:
+                matched.append(proposal)
+        grouped_by_signature[key] = groups
 
     factors: list[ReducedFactor] = []
     incompatibility_residuals: list[ReductionResidual] = []
-    signature_groups: dict[
-        tuple[str, str, str, str],
-        list[list[FactorProposal]],
-    ] = {}
-    for group in groups:
-        key = (
-            str(group[0].semantic_coordinate_ref),
-            group[0].fibre_kind,
-            group[0].factor_type_ref,
-            group[0].structural_signature,
-        )
-        signature_groups.setdefault(key, []).append(group)
-
-    for key, compatible_groups in sorted(signature_groups.items()):
+    for key, compatible_groups in sorted(grouped_by_signature.items()):
         if len(compatible_groups) > 1:
             refs = tuple(
                 sorted(
@@ -510,17 +487,15 @@ def reduce_factor_proposals(
                     residual_type="incompatible_alternatives",
                     proposal_refs=refs,
                     message=(
-                        "proposals in one semantic fibre disagree on one or "
-                        "more occupied coordinates"
+                        "proposals in one semantic fibre disagree on one or more "
+                        "occupied coordinates"
                     ),
                     semantic_coordinate_ref=key[0],
                     boundary_kind="conflicted_fibre",
                 )
             )
         for group in compatible_groups:
-            proposal_refs = tuple(
-                sorted(row.proposal_ref for row in group)
-            )
+            proposal_refs = tuple(sorted(row.proposal_ref for row in group))
             roles: dict[str, str] = {}
             qualifiers: dict[str, Any] = {}
             residuals: set[str] = set()
@@ -576,6 +551,26 @@ def reduce_factor_proposals(
                 )
             )
 
+    possible_comparisons = comb(len(deduplicated), 2) if len(deduplicated) > 1 else 0
+    avoided = max(0, possible_comparisons - candidate_comparisons)
+    metrics = {
+        "bucket_count": len(buckets),
+        "largest_bucket": max((len(value) for value in buckets.values()), default=0),
+        "candidate_comparisons": candidate_comparisons,
+        "potential_candidate_comparisons": possible_comparisons,
+        "comparisons_avoided": avoided,
+        "comparison_avoidance_ratio": (
+            avoided / possible_comparisons if possible_comparisons else 1.0
+        ),
+        "duplicates_collapsed": len(valid) - len(deduplicated),
+        "alternatives_retained": sum(
+            len(group) for groups in grouped_by_signature.values() for group in groups
+        ),
+        "factor_count": len(factors),
+        "reduction_ratio": (
+            len(factors) / len(deduplicated) if deduplicated else 0.0
+        ),
+    }
     return ProposalReduction(
         document_ref=document_ref,
         factors=tuple(sorted(factors, key=lambda row: row.factor_ref)),
@@ -587,6 +582,7 @@ def reduce_factor_proposals(
         ),
         proposal_count=len(ordered),
         deduplicated_count=len(valid) - len(deduplicated),
+        metrics=metrics,
     )
 
 

--- a/src/pnf/legal_adjunct.py
+++ b/src/pnf/legal_adjunct.py
@@ -112,9 +112,31 @@ class LegalSourcePlan:
     temporal_refs: tuple[str, ...]
     state: str
     blocked_reasons: tuple[str, ...]
+    selected_source_revision_refs: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         return {**asdict(self), "authority": "acquisition_plan_only"}
+
+
+@dataclass(frozen=True)
+class PersistedLegalSource:
+    """A revision already acquired under an operator-governed process."""
+
+    source_revision_ref: str
+    jurisdiction_ref: str
+    source_role: str
+    authority_level: str
+    temporal_refs: tuple[str, ...] = ()
+    provider_profile_refs: tuple[str, ...] = ()
+    compile_eligible: bool = True
+
+
+@dataclass(frozen=True)
+class AcquisitionRequirement:
+    demand_ref: str
+    plan_key: str
+    state: str = "blocked_acquisition_required"
+    reason: str = "compatible_persisted_legal_source_absent"
 
 
 @dataclass(frozen=True)
@@ -185,7 +207,9 @@ def project_normative_interaction_demands(
 
     projected: dict[tuple[str, str], NormativeInteractionDemand] = {}
     for row in rows:
-        facets = tuple(sorted({str(value) for value in row.get("requested_facets") or ()}))
+        facets = tuple(
+            sorted({str(value) for value in row.get("requested_facets") or ()})
+        )
         explicit = bool(row.get("explicit_legal_request"))
         if not explicit and not _LEGAL_TRIGGER_FACETS.intersection(facets):
             continue
@@ -251,28 +275,104 @@ def project_normative_interaction_demands(
 
 def plan_legal_sources(
     demands: Iterable[NormativeInteractionDemand],
+    persisted_sources: Iterable[PersistedLegalSource | Mapping[str, Any]] = (),
 ) -> tuple[LegalSourcePlan, ...]:
+    sources = tuple(_coerce_persisted_source(source) for source in persisted_sources)
     plans: list[LegalSourcePlan] = []
     for demand in demands:
         blocked = demand.open_slots
+        selected = () if blocked else _select_persisted_sources(demand, sources)
+        if not blocked and not selected:
+            blocked = ("compatible_persisted_legal_source_absent",)
         plans.append(
             LegalSourcePlan(
                 demand_ref=demand.demand_ref,
                 plan_key=demand.plan_key,
-                jurisdiction_ref=demand.jurisdiction_refs[0] if demand.jurisdiction_refs else "",
+                jurisdiction_ref=demand.jurisdiction_refs[0]
+                if demand.jurisdiction_refs
+                else "",
                 source_role_refs=demand.source_role_refs,
                 authority_level_refs=demand.authority_level_refs,
                 provider_profile_refs=demand.provider_profile_refs,
                 requested_legal_facets=demand.requested_legal_facets,
                 temporal_refs=demand.temporal_refs,
-                state="ready" if demand.acquisition_ready else "blocked_missing_context",
+                state=(
+                    "ready_persisted"
+                    if demand.acquisition_ready and selected
+                    else "blocked_missing_context"
+                    if demand.open_slots
+                    else "blocked_acquisition_required"
+                ),
                 blocked_reasons=blocked,
+                selected_source_revision_refs=selected,
             )
         )
     return tuple(plans)
 
 
-def project_legal_ir(rows: Iterable[Mapping[str, Any]]) -> tuple[LegalIRObservation, ...]:
+def _coerce_persisted_source(
+    value: PersistedLegalSource | Mapping[str, Any],
+) -> PersistedLegalSource:
+    if isinstance(value, PersistedLegalSource):
+        return value
+    return PersistedLegalSource(
+        source_revision_ref=str(value["source_revision_ref"]),
+        jurisdiction_ref=str(value["jurisdiction_ref"]),
+        source_role=str(value["source_role"]),
+        authority_level=str(value["authority_level"]),
+        temporal_refs=tuple(
+            sorted(str(item) for item in value.get("temporal_refs") or ())
+        ),
+        provider_profile_refs=tuple(
+            sorted(str(item) for item in value.get("provider_profile_refs") or ())
+        ),
+        compile_eligible=bool(value.get("compile_eligible", True)),
+    )
+
+
+def _select_persisted_sources(
+    demand: NormativeInteractionDemand, sources: Sequence[PersistedLegalSource]
+) -> tuple[str, ...]:
+    """Select only already-persisted compatible revisions; never acquire here."""
+    selected = []
+    for source in sources:
+        if (
+            not source.compile_eligible
+            or source.jurisdiction_ref not in demand.jurisdiction_refs
+        ):
+            continue
+        if (
+            source.source_role not in demand.source_role_refs
+            or source.authority_level not in demand.authority_level_refs
+        ):
+            continue
+        if demand.provider_profile_refs and not set(
+            demand.provider_profile_refs
+        ).intersection(source.provider_profile_refs):
+            continue
+        if (
+            demand.temporal_refs
+            and source.temporal_refs
+            and not set(demand.temporal_refs).intersection(source.temporal_refs)
+        ):
+            continue
+        selected.append(source.source_revision_ref)
+    return tuple(sorted(set(selected)))
+
+
+def project_acquisition_requirements(
+    plans: Iterable[LegalSourcePlan],
+) -> tuple[AcquisitionRequirement, ...]:
+    return tuple(
+        AcquisitionRequirement(plan.demand_ref, plan.plan_key)
+        for plan in plans
+        if plan.state == "blocked_acquisition_required"
+    )
+
+
+def project_legal_ir(
+    rows: Iterable[Mapping[str, Any]],
+) -> tuple[LegalIRObservation, ...]:
     """Project Legal IR from already-constructed PNF rows.
 
     Rows without a legal PNF factor type are ignored. This deliberately refuses
@@ -282,7 +382,9 @@ def project_legal_ir(rows: Iterable[Mapping[str, Any]]) -> tuple[LegalIRObservat
     projected: dict[str, LegalIRObservation] = {}
     for row in rows:
         factor_type = str(row.get("factor_type_ref") or "")
-        if factor_type not in _LEGAL_PNF_TYPES and not factor_type.startswith("semantic.legal."):
+        if factor_type not in _LEGAL_PNF_TYPES and not factor_type.startswith(
+            "semantic.legal."
+        ):
             continue
         factor_ref = str(row.get("factor_ref") or "")
         revision_ref = str(row.get("factor_revision_ref") or "")
@@ -306,8 +408,12 @@ def project_legal_ir(rows: Iterable[Mapping[str, Any]]) -> tuple[LegalIRObservat
             role_bindings=dict(row.get("role_bindings") or {}),
             qualifier_state=dict(row.get("qualifier_state") or {}),
             wrapper_state=dict(row.get("wrapper_state") or {}),
-            provenance_refs=tuple(sorted(str(value) for value in row.get("provenance_refs") or ())),
-            residual_refs=tuple(sorted(str(value) for value in row.get("residual_refs") or ())),
+            provenance_refs=tuple(
+                sorted(str(value) for value in row.get("provenance_refs") or ())
+            ),
+            residual_refs=tuple(
+                sorted(str(value) for value in row.get("residual_refs") or ())
+            ),
         )
     return tuple(sorted(projected.values(), key=lambda item: item.observation_ref))
 
@@ -317,9 +423,16 @@ def typed_legal_meet(
     legal_observation: LegalIRObservation,
 ) -> LegalTypedMeet:
     world_signature = str(world_row.get("structural_signature_ref") or "")
-    if not world_signature or world_signature != legal_observation.structural_signature_ref:
+    if (
+        not world_signature
+        or world_signature != legal_observation.structural_signature_ref
+    ):
         return LegalTypedMeet(
-            world_pnf_ref=str(world_row.get("factor_revision_ref") or world_row.get("factor_ref") or ""),
+            world_pnf_ref=str(
+                world_row.get("factor_revision_ref")
+                or world_row.get("factor_ref")
+                or ""
+            ),
             legal_ir_ref=legal_observation.observation_ref,
             structural_state="NO_TYPED_MEET",
             jurisdiction_state="not_evaluated",
@@ -334,7 +447,9 @@ def typed_legal_meet(
         )
     coordinates = dict(world_row.get("legal_coordinates") or {})
     return LegalTypedMeet(
-        world_pnf_ref=str(world_row.get("factor_revision_ref") or world_row.get("factor_ref") or ""),
+        world_pnf_ref=str(
+            world_row.get("factor_revision_ref") or world_row.get("factor_ref") or ""
+        ),
         legal_ir_ref=legal_observation.observation_ref,
         structural_state="same_fibre_candidate",
         jurisdiction_state=str(coordinates.get("jurisdiction_state") or "unresolved"),
@@ -361,10 +476,13 @@ __all__ = [
     "LEGAL_ADJUNCT_CONTRACT",
     "LEGAL_IR_PROJECTION_CONTRACT",
     "LegalIRObservation",
+    "PersistedLegalSource",
+    "AcquisitionRequirement",
     "LegalSourcePlan",
     "LegalTypedMeet",
     "NormativeInteractionDemand",
     "plan_legal_sources",
+    "project_acquisition_requirements",
     "project_legal_ir",
     "project_normative_interaction_demands",
     "typed_legal_meet",

--- a/src/pnf/legal_ir_parity.py
+++ b/src/pnf/legal_ir_parity.py
@@ -1,0 +1,180 @@
+"""Deterministic identity and non-promotion certificates for Legal IR parity."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Mapping
+
+from src.policy.carriers.canonical import canonical_sha256
+
+LEGAL_IR_PARITY_CONTRACT = "curated-legal-ir-parity:v0_1"
+
+
+def _refs(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(sorted({str(value) for value in values if str(value)}))
+
+
+@dataclass(frozen=True)
+class SemanticIdentitySnapshot:
+    proposal_refs: tuple[str, ...] = ()
+    factor_refs: tuple[str, ...] = ()
+    graph_refs: tuple[str, ...] = ()
+    fibre_ledger_refs: tuple[str, ...] = ()
+    residual_refs: tuple[str, ...] = ()
+    demand_refs: tuple[str, ...] = ()
+    legal_ir_refs: tuple[str, ...] = ()
+    typed_meet_refs: tuple[str, ...] = ()
+    legacy_witness_refs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        for field_name in self.__dataclass_fields__:
+            object.__setattr__(self, field_name, _refs(getattr(self, field_name)))
+
+    @property
+    def snapshot_ref(self) -> str:
+        return "semantic-identity-snapshot:" + canonical_sha256(asdict(self))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"snapshot_ref": self.snapshot_ref, **asdict(self)}
+
+
+@dataclass(frozen=True)
+class IdentityParityResult:
+    control_snapshot_ref: str
+    candidate_snapshot_ref: str
+    identical: bool
+    added_refs: Mapping[str, tuple[str, ...]]
+    removed_refs: Mapping[str, tuple[str, ...]]
+
+    @property
+    def result_ref(self) -> str:
+        return "semantic-identity-parity:" + canonical_sha256(self.to_dict(include_ref=False))
+
+    def to_dict(self, *, include_ref: bool = True) -> dict[str, Any]:
+        payload = {
+            "control_snapshot_ref": self.control_snapshot_ref,
+            "candidate_snapshot_ref": self.candidate_snapshot_ref,
+            "identical": self.identical,
+            "added_refs": {key: list(value) for key, value in sorted(self.added_refs.items())},
+            "removed_refs": {key: list(value) for key, value in sorted(self.removed_refs.items())},
+        }
+        return {"result_ref": self.result_ref, **payload} if include_ref else payload
+
+
+def compare_identity_snapshots(
+    control: SemanticIdentitySnapshot,
+    candidate: SemanticIdentitySnapshot,
+) -> IdentityParityResult:
+    added: dict[str, tuple[str, ...]] = {}
+    removed: dict[str, tuple[str, ...]] = {}
+    for field_name in control.__dataclass_fields__:
+        before = set(getattr(control, field_name))
+        after = set(getattr(candidate, field_name))
+        if after - before:
+            added[field_name] = tuple(sorted(after - before))
+        if before - after:
+            removed[field_name] = tuple(sorted(before - after))
+    return IdentityParityResult(
+        control_snapshot_ref=control.snapshot_ref,
+        candidate_snapshot_ref=candidate.snapshot_ref,
+        identical=not added and not removed,
+        added_refs=added,
+        removed_refs=removed,
+    )
+
+
+def snapshot_from_build_artifacts(
+    artifacts: Iterable[Mapping[str, Any]],
+    *,
+    legal_ir_refs: Iterable[str] = (),
+    typed_meet_refs: Iterable[str] = (),
+    legacy_witness_refs: Iterable[str] = (),
+) -> SemanticIdentitySnapshot:
+    proposal_refs: list[str] = []
+    factor_refs: list[str] = []
+    graph_refs: list[str] = []
+    fibre_ledger_refs: list[str] = []
+    residual_refs: list[str] = []
+    demand_refs: list[str] = []
+    for artifact in artifacts:
+        graph = artifact.get("pnf_graph") or {}
+        if graph.get("graph_ref"):
+            graph_refs.append(str(graph["graph_ref"]))
+        for factor in graph.get("factors") or ():
+            if factor.get("factor_ref"):
+                factor_refs.append(str(factor["factor_ref"]))
+            residual_refs.extend(str(value) for value in factor.get("residuals") or ())
+        streaming = artifact.get("streaming_semantic_build") or {}
+        proposal_refs.extend(
+            str(row["proposal_ref"])
+            for row in streaming.get("proposals") or ()
+            if isinstance(row, Mapping) and row.get("proposal_ref")
+        )
+        if streaming.get("fibre_ledger_ref"):
+            fibre_ledger_refs.append(str(streaming["fibre_ledger_ref"]))
+        materialized = streaming.get("materialized_reduction") or {}
+        residual_refs.extend(
+            str(row["residual_ref"])
+            for row in materialized.get("residuals") or ()
+            if isinstance(row, Mapping) and row.get("residual_ref")
+        )
+        demand_refs.extend(
+            str(row["demand_ref"])
+            for row in artifact.get("resolution_demands") or ()
+            if isinstance(row, Mapping) and row.get("demand_ref")
+        )
+    return SemanticIdentitySnapshot(
+        proposal_refs=tuple(proposal_refs),
+        factor_refs=tuple(factor_refs),
+        graph_refs=tuple(graph_refs),
+        fibre_ledger_refs=tuple(fibre_ledger_refs),
+        residual_refs=tuple(residual_refs),
+        demand_refs=tuple(demand_refs),
+        legal_ir_refs=tuple(legal_ir_refs),
+        typed_meet_refs=tuple(typed_meet_refs),
+        legacy_witness_refs=tuple(legacy_witness_refs),
+    )
+
+
+@dataclass(frozen=True)
+class CuratedLegalIRParityReceipt:
+    corpus_ref: str
+    admission_profile_ref: str
+    compiler_contract_ref: str
+    source_revision_refs: tuple[str, ...]
+    ordinary_graph_refs: tuple[str, ...]
+    legal_graph_refs: tuple[str, ...]
+    demand_refs: tuple[str, ...]
+    plan_refs: tuple[str, ...]
+    legal_ir_refs: tuple[str, ...]
+    typed_meet_refs: tuple[str, ...]
+    legacy_witness_refs: tuple[str, ...]
+    identity_snapshot: Mapping[str, Any]
+    control_snapshot: Mapping[str, Any] | None
+    identity_parity: bool | None
+    network_attempt_count: int
+    unexpected_failure_refs: tuple[str, ...] = ()
+
+    @property
+    def receipt_ref(self) -> str:
+        return "curated-legal-ir-parity-receipt:" + canonical_sha256(asdict(self))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "receipt_ref": self.receipt_ref,
+            **asdict(self),
+            "contract_ref": LEGAL_IR_PARITY_CONTRACT,
+            "semantic_state_promoted": False,
+            "applicability_closed": False,
+            "legal_truth_closed": False,
+        }
+
+
+__all__ = [
+    "LEGAL_IR_PARITY_CONTRACT",
+    "CuratedLegalIRParityReceipt",
+    "IdentityParityResult",
+    "SemanticIdentitySnapshot",
+    "compare_identity_snapshots",
+    "snapshot_from_build_artifacts",
+]

--- a/src/pnf/legal_source_registry.py
+++ b/src/pnf/legal_source_registry.py
@@ -1,0 +1,58 @@
+"""Durable registry coordinates for already-persisted legal sources.
+
+These rows prove acquisition/admission provenance and retrieval compatibility.
+They never close applicability or legal truth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from src.policy.carriers.canonical import canonical_sha256
+
+
+@dataclass(frozen=True)
+class RegisteredLegalSource:
+    source_revision_ref: str
+    document_ref: str
+    admission_receipt_ref: str
+    jurisdiction_ref: str
+    source_role: str
+    authority_level: str
+    canonical_text_sha256: str
+    media_type: str = "text/plain"
+    acquisition_receipt_ref: str | None = None
+    temporal_refs: tuple[str, ...] = ()
+    provider_profile_refs: tuple[str, ...] = ()
+    compile_eligible: bool = True
+
+    @property
+    def registry_ref(self) -> str:
+        return "legal-source-registry:" + canonical_sha256(asdict(self))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "registry_ref": self.registry_ref,
+            **asdict(self),
+            "authority": "persisted_source_revision_only",
+            "identity_promoted": False,
+            "applicability_closed": False,
+            "legal_truth_closed": False,
+        }
+
+    def planning_row(self) -> dict[str, Any]:
+        """Return the narrower carrier accepted by plan_legal_sources."""
+
+        return {
+            "source_revision_ref": self.source_revision_ref,
+            "jurisdiction_ref": self.jurisdiction_ref,
+            "source_role": self.source_role,
+            "authority_level": self.authority_level,
+            "temporal_refs": self.temporal_refs,
+            "provider_profile_refs": self.provider_profile_refs,
+            "compile_eligible": self.compile_eligible,
+        }
+
+
+__all__ = ["RegisteredLegalSource"]

--- a/src/pnf/streaming_reduction_projection.py
+++ b/src/pnf/streaming_reduction_projection.py
@@ -11,12 +11,14 @@ replacement-only API.
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any, Mapping
 
 from src.language.operator_composition import OPERATOR_COMPOSITION_CONTRACT
 from src.pnf.factor_proposals import INTEGRATED_SEMANTIC_PRODUCER_CONTRACT
 from src.pnf.graph import PNFGraph
 from src.policy.algebra import Factor, TypedAlternative
+from src.policy.algebra.revision_identity import factor_revision_ref
 from src.policy.carriers.canonical import canonical_sha256
 
 
@@ -113,19 +115,7 @@ def _factor_from_reduction(
     role_bindings = dict(reduced.get("role_bindings") or {})
     qualifier_state = dict(reduced.get("qualifier_state") or {})
     fibre_summary_ref = str(reduced["factor_ref"])
-    factor_revision_ref = str(
-        reduced.get("factor_revision_ref")
-        or "factor-revision:"
-        + canonical_sha256(
-            {
-                "factor_ref": factor_ref,
-                "fibre_summary_ref": fibre_summary_ref,
-                "proposal_refs": proposal_refs,
-                "residuals": residuals,
-            }
-        )
-    )
-    return Factor(
+    projected = Factor(
         factor_ref=factor_ref,
         factor_type=str(reduced["factor_type_ref"]),
         alternatives=alternatives,
@@ -134,7 +124,6 @@ def _factor_from_reduction(
             "requires_external_resolution" if residuals else "locally_closed"
         ),
         metadata={
-            "factor_revision_ref": factor_revision_ref,
             "fibre_summary_ref": fibre_summary_ref,
             "semantic_coordinate_ref": str(
                 reduced.get("semantic_coordinate_ref") or ""
@@ -161,6 +150,16 @@ def _factor_from_reduction(
                 INTEGRATED_SEMANTIC_PRODUCER_CONTRACT
             ),
             "authority": "candidate_pnf_only",
+        },
+    )
+    # A fibre summary is evidence for the projected factor, not its revision
+    # identity.  The latter is defined by the complete materialised factor
+    # payload so that persistence can verify it without a special case.
+    return replace(
+        projected,
+        metadata={
+            **projected.metadata,
+            "factor_revision_ref": factor_revision_ref(projected.to_dict()),
         },
     )
 

--- a/src/policy/curated_postgres_corpus_compilation.py
+++ b/src/policy/curated_postgres_corpus_compilation.py
@@ -1,0 +1,421 @@
+"""Curated offline corpus compilation with admission and bounded retry.
+
+The parser pool sees only revisions carrying an immutable ``compile`` admission
+receipt. Evidence-only and excluded artefacts remain in the admission manifest
+and never enter canonical parsing or PNF construction.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import Future, ProcessPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from time import monotonic_ns, sleep
+from typing import Any, Callable, Mapping, Sequence
+
+from psycopg import Error as PostgresError
+
+from src.policy.corpus_compilation import CompilerContext, build_corpus_manifest
+from src.policy.fibred_operational_corpus_compilation import (
+    FIBRED_OPERATIONAL_COMPILER_CONTRACT,
+)
+from src.policy.optimized_streaming_postgres_corpus_compilation import (
+    persist_optimized_streaming_document_compilation,
+)
+from src.policy.postgres_corpus_compilation import (
+    _operational_build_key,
+    _prepare_operational_manifest,
+)
+from src.runtime.progress import PhaseHandle
+from src.sensiblaw.interfaces import tokenize_canonical_with_spans
+from src.sources.admission import (
+    SourceAdmissionProfile,
+    SourceAdmissionReceipt,
+    admission_manifest,
+    admit_source,
+)
+from src.storage.postgres import PersistedCompilation
+from src.storage.postgres.batched_compiler_store import BatchedPostgresCompilerStore
+from src.storage.postgres.legal_source_store import (
+    persist_source_admission_receipts,
+    persist_transaction_attempt,
+)
+from src.storage.postgres.operational_build_store import (
+    load_completed_operational_build,
+)
+from src.storage.postgres.streaming_semantic_store import load_stage_timings
+
+_RETRYABLE_SQLSTATES = {"40001", "40P01"}
+CURATED_COMPILATION_SCHEMA_VERSION = "sl.curated_postgres_compilation.v0_1"
+
+
+@dataclass(frozen=True)
+class CuratedDocumentOutcome:
+    document_ref: str
+    relative_path: str
+    state: str
+    admission_receipt_ref: str
+    demand_refs: tuple[str, ...] = ()
+    failure_ref: str | None = None
+    elapsed_ms: int = 0
+    canonical_token_count: int = 0
+    worker: str = ""
+    stage_timings: tuple[Mapping[str, Any], ...] = ()
+    retry_count: int = 0
+    transaction_attempt_refs: tuple[str, ...] = ()
+    closure_workers: int = 1
+    owner_partitions: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": CURATED_COMPILATION_SCHEMA_VERSION,
+            **asdict(self),
+            "demand_refs": list(self.demand_refs),
+            "stage_timings": [dict(row) for row in self.stage_timings],
+            "transaction_attempt_refs": list(self.transaction_attempt_refs),
+        }
+
+
+@dataclass(frozen=True)
+class CuratedCompilationResult:
+    persisted: PersistedCompilation
+    outcomes: tuple[CuratedDocumentOutcome, ...]
+    admission: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": CURATED_COMPILATION_SCHEMA_VERSION,
+            "persisted": asdict(self.persisted),
+            "outcomes": [row.to_dict() for row in self.outcomes],
+            "admission": dict(self.admission),
+        }
+
+
+def _build_key(entry: Mapping[str, Any], context: CompilerContext) -> str:
+    return _operational_build_key(
+        document_ref=str(entry["document_ref"]),
+        content_sha256=str(entry["content_sha256"]),
+        canonical_text_sha256=str(entry["canonical_text_sha256"]),
+        media_adapter_ref=str(entry["media_adapter_ref"]),
+        context=context,
+    )
+
+
+def _retry_delay_ms(document_ref: str, attempt_no: int) -> int:
+    from src.policy.carriers.canonical import canonical_sha256
+
+    jitter = int(canonical_sha256({"document_ref": document_ref, "attempt": attempt_no})[:4], 16) % 37
+    return min(1000, 50 * attempt_no + jitter)
+
+
+def _persist_attempt(
+    store: BatchedPostgresCompilerStore,
+    *,
+    document_ref: str,
+    build_key_sha256: str,
+    attempt_no: int,
+    state: str,
+    sqlstate: str | None,
+    retry_delay_ms: int,
+    worker_ref: str,
+) -> str:
+    with store.transaction() as cursor:
+        return persist_transaction_attempt(
+            cursor,
+            document_ref=document_ref,
+            build_key_sha256=build_key_sha256,
+            attempt_no=attempt_no,
+            state=state,
+            sqlstate=sqlstate,
+            retry_delay_ms=retry_delay_ms,
+            worker_ref=worker_ref,
+        )
+
+
+def _compile_one(
+    *,
+    database_url: str,
+    corpus_ref: str,
+    root: Path,
+    entry: Mapping[str, Any],
+    prepared_source: tuple[bytes, str] | None,
+    context: CompilerContext,
+    worker: str,
+    admission_receipt_ref: str,
+    closure_workers: int,
+    owner_partitions: int,
+    maximum_transaction_attempts: int,
+) -> CuratedDocumentOutcome:
+    started = monotonic_ns()
+    document_ref = str(entry["document_ref"])
+    relative_path = str(entry["relative_path"])
+    build_key = _build_key(entry, context)
+    store = BatchedPostgresCompilerStore.connect(database_url)
+    attempt_refs: list[str] = []
+    try:
+        with store.transaction() as cursor:
+            cached = load_completed_operational_build(
+                cursor,
+                document_ref=document_ref,
+                compiler_contract_ref=FIBRED_OPERATIONAL_COMPILER_CONTRACT,
+                build_key_sha256=build_key,
+            )
+        if prepared_source is None:
+            source_bytes = (root / relative_path).read_bytes()
+            source_text = source_bytes.decode("utf-8")
+        else:
+            source_bytes, source_text = prepared_source
+
+        demand_refs: tuple[str, ...] = ()
+        for attempt_no in range(1, maximum_transaction_attempts + 1):
+            try:
+                demand_refs = persist_optimized_streaming_document_compilation(
+                    store=store,
+                    corpus_ref=corpus_ref,
+                    relative_path=relative_path,
+                    entry=entry,
+                    source_bytes=source_bytes,
+                    source_text=source_text,
+                    context=context,
+                    closure_workers=closure_workers,
+                    owner_partitions=owner_partitions,
+                )
+                attempt_refs.append(
+                    _persist_attempt(
+                        store,
+                        document_ref=document_ref,
+                        build_key_sha256=build_key,
+                        attempt_no=attempt_no,
+                        state="succeeded",
+                        sqlstate=None,
+                        retry_delay_ms=0,
+                        worker_ref=worker,
+                    )
+                )
+                break
+            except PostgresError as error:
+                sqlstate = getattr(error, "sqlstate", None)
+                retryable = sqlstate in _RETRYABLE_SQLSTATES
+                final_attempt = attempt_no >= maximum_transaction_attempts
+                delay_ms = 0 if final_attempt or not retryable else _retry_delay_ms(document_ref, attempt_no)
+                attempt_refs.append(
+                    _persist_attempt(
+                        store,
+                        document_ref=document_ref,
+                        build_key_sha256=build_key,
+                        attempt_no=attempt_no,
+                        state=(
+                            "retryable_failure"
+                            if retryable and not final_attempt
+                            else "failed"
+                        ),
+                        sqlstate=sqlstate,
+                        retry_delay_ms=delay_ms,
+                        worker_ref=worker,
+                    )
+                )
+                if not retryable or final_attempt:
+                    raise
+                sleep(delay_ms / 1000.0)
+        with store.transaction() as cursor:
+            canonical_token_count = store.count_persisted_tokens(
+                cursor,
+                document_ref=document_ref,
+            )
+            stage_timings = load_stage_timings(cursor, document_ref=document_ref)
+        return CuratedDocumentOutcome(
+            document_ref=document_ref,
+            relative_path=relative_path,
+            state="reused" if cached is not None else "compiled",
+            admission_receipt_ref=admission_receipt_ref,
+            demand_refs=tuple(sorted(set(demand_refs))),
+            elapsed_ms=max(0, (monotonic_ns() - started) // 1_000_000),
+            canonical_token_count=canonical_token_count,
+            worker=worker,
+            stage_timings=stage_timings,
+            retry_count=max(0, len(attempt_refs) - 1),
+            transaction_attempt_refs=tuple(attempt_refs),
+            closure_workers=closure_workers,
+            owner_partitions=owner_partitions,
+        )
+    except (OSError, UnicodeDecodeError, ValueError, RuntimeError, PostgresError) as error:
+        with store.transaction() as cursor:
+            failure_ref = store.persist_failure(
+                cursor,
+                target_ref=document_ref,
+                phase_ref="curated_local_compile",
+                error=error,
+            )
+        return CuratedDocumentOutcome(
+            document_ref=document_ref,
+            relative_path=relative_path,
+            state="failed",
+            admission_receipt_ref=admission_receipt_ref,
+            failure_ref=failure_ref,
+            elapsed_ms=max(0, (monotonic_ns() - started) // 1_000_000),
+            worker=worker,
+            retry_count=max(0, len(attempt_refs) - 1),
+            transaction_attempt_refs=tuple(attempt_refs),
+            closure_workers=closure_workers,
+            owner_partitions=owner_partitions,
+        )
+    finally:
+        store.close()
+
+
+def compile_curated_directory_postgres(
+    input_dir: str | Path,
+    *,
+    context: CompilerContext,
+    database_url: str,
+    admission_profile: SourceAdmissionProfile,
+    source_metadata: Mapping[str, Mapping[str, Any]],
+    workers: int = 4,
+    closure_workers_per_document: int = 4,
+    owner_partitions_per_document: int = 8,
+    maximum_transaction_attempts: int = 3,
+    recursive: bool = True,
+    include_globs: Sequence[str] = (),
+    exclude_globs: Sequence[str] = (),
+    max_files: int | None = None,
+    max_file_bytes: int | None = None,
+    max_total_bytes: int | None = None,
+    progress: PhaseHandle | None = None,
+    outcome_sink: Callable[[CuratedDocumentOutcome], None] | None = None,
+) -> CuratedCompilationResult:
+    """Compile only source revisions admitted by the supplied profile."""
+
+    if not 1 <= workers <= 32:
+        raise ValueError("workers must be between 1 and 32")
+    if not 1 <= closure_workers_per_document <= 32:
+        raise ValueError("closure workers must be between 1 and 32")
+    if not 1 <= owner_partitions_per_document <= 128:
+        raise ValueError("owner partitions must be between 1 and 128")
+    if not 1 <= maximum_transaction_attempts <= 8:
+        raise ValueError("transaction attempts must be between 1 and 8")
+
+    root = Path(input_dir).resolve()
+    manifest = build_corpus_manifest(
+        root,
+        context=context,
+        recursive=recursive,
+        include_globs=include_globs,
+        exclude_globs=exclude_globs,
+        max_files=max_files,
+        max_file_bytes=max_file_bytes,
+        max_total_bytes=max_total_bytes,
+    )
+    manifest_row, prepared_sources = _prepare_operational_manifest(
+        root=root,
+        manifest=manifest.to_dict(),
+        context=context,
+    )
+    corpus_ref = str(manifest_row["corpus_ref"])
+    receipts: list[SourceAdmissionReceipt] = []
+    admitted: list[tuple[Mapping[str, Any], SourceAdmissionReceipt]] = []
+    seen_documents: set[str] = set()
+    for entry in manifest_row["ordered_documents"]:
+        if entry["status"] != "inventoried":
+            continue
+        relative_path = str(entry["relative_path"])
+        metadata = dict(source_metadata.get(relative_path) or {})
+        metadata.update(
+            {
+                "document_ref": entry["document_ref"],
+                "source_revision_ref": (
+                    metadata.get("source_revision_ref")
+                    or f"source-revision:{entry['content_sha256']}"
+                ),
+            }
+        )
+        receipt = admit_source(metadata, profile=admission_profile)
+        receipts.append(receipt)
+        if not receipt.compile_eligible:
+            continue
+        document_ref = str(entry["document_ref"])
+        if document_ref in seen_documents:
+            continue
+        seen_documents.add(document_ref)
+        admitted.append((entry, receipt))
+
+    admission_store = BatchedPostgresCompilerStore.connect(database_url)
+    try:
+        with admission_store.transaction() as cursor:
+            admission_store.persist_context(cursor, context.to_dict())
+            admission_store.persist_manifest(cursor, manifest_row)
+            persist_source_admission_receipts(
+                cursor,
+                corpus_ref=corpus_ref,
+                receipts=receipts,
+            )
+    finally:
+        admission_store.close()
+
+    if progress is not None:
+        progress.total = len(admitted)
+        progress.total_tokens = sum(
+            len(tokenize_canonical_with_spans(prepared_sources[str(entry["relative_path"])][1]))
+            for entry, _ in admitted
+        )
+
+    outcomes: list[CuratedDocumentOutcome] = []
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        futures: dict[Future[CuratedDocumentOutcome], str] = {}
+        for index, (entry, receipt) in enumerate(admitted):
+            relative_path = str(entry["relative_path"])
+            future = executor.submit(
+                _compile_one,
+                database_url=database_url,
+                corpus_ref=corpus_ref,
+                root=root,
+                entry=entry,
+                prepared_source=prepared_sources.get(relative_path),
+                context=context,
+                worker=f"document-{(index % workers) + 1}",
+                admission_receipt_ref=receipt.receipt_ref,
+                closure_workers=closure_workers_per_document,
+                owner_partitions=owner_partitions_per_document,
+                maximum_transaction_attempts=maximum_transaction_attempts,
+            )
+            futures[future] = str(entry["document_ref"])
+        for future in as_completed(futures):
+            outcome = future.result()
+            outcomes.append(outcome)
+            if outcome_sink is not None:
+                outcome_sink(outcome)
+            if progress is not None:
+                progress.advance(
+                    subject_ref=outcome.document_ref,
+                    message=outcome.state,
+                    reused=outcome.state == "reused",
+                    processed_tokens=outcome.canonical_token_count,
+                    details={
+                        "relative_path": outcome.relative_path,
+                        "worker": outcome.worker,
+                        "retry_count": outcome.retry_count,
+                        "failure_ref": outcome.failure_ref,
+                    },
+                )
+
+    ordered = tuple(sorted(outcomes, key=lambda row: (row.document_ref, row.relative_path)))
+    persisted = PersistedCompilation(
+        corpus_ref=corpus_ref,
+        document_refs=tuple(sorted(row.document_ref for row in ordered if row.state != "failed")),
+        demand_refs=tuple(sorted({ref for row in ordered for ref in row.demand_refs})),
+        failure_refs=tuple(
+            sorted(row.failure_ref for row in ordered if row.failure_ref is not None)
+        ),
+    )
+    return CuratedCompilationResult(
+        persisted=persisted,
+        outcomes=ordered,
+        admission=admission_manifest(receipts),
+    )
+
+
+__all__ = [
+    "CURATED_COMPILATION_SCHEMA_VERSION",
+    "CuratedCompilationResult",
+    "CuratedDocumentOutcome",
+    "compile_curated_directory_postgres",
+]

--- a/src/policy/entity_resolution.py
+++ b/src/policy/entity_resolution.py
@@ -2741,9 +2741,30 @@ def build_local_typing_carrier(
                 ).to_dict()
             )
 
-    alternative_rows.sort(key=lambda alternative: alternative["type_ref"])
-    if len({row["type_ref"] for row in alternative_rows}) != len(alternative_rows):
-        raise ValueError("local typing emitted duplicate alternative references")
+    # Multiple generic form/structural paths may witness the identical
+    # content-addressed alternative.  They are not competing alternatives;
+    # retain one canonical row and merge its provenance before indexing.
+    deduplicated_alternatives: dict[str, dict[str, Any]] = {}
+    for alternative in alternative_rows:
+        type_ref = str(alternative["type_ref"])
+        prior = deduplicated_alternatives.get(type_ref)
+        if prior is None:
+            deduplicated_alternatives[type_ref] = alternative
+            continue
+        if prior["mention_ref"] != alternative["mention_ref"]:
+            raise ValueError(
+                "local typing duplicate alternative crosses mention identity"
+            )
+        prior["evidence_refs"] = tuple(
+            sorted(
+                set(prior.get("evidence_refs") or ())
+                | set(alternative.get("evidence_refs") or ())
+            )
+        )
+    alternative_rows = sorted(
+        deduplicated_alternatives.values(),
+        key=lambda alternative: alternative["type_ref"],
+    )
     alternatives_by_mention: dict[str, list[str]] = {
         mention_ref: [] for mention_ref in mention_by_ref
     }
@@ -3829,16 +3850,35 @@ def build_mention_licensing_carrier(
                 )
             )
 
-    mention_rows: list[dict[str, Any]] = []
-    license_rows: list[dict[str, Any]] = []
+    normalized_proposed: dict[
+        tuple[int, int], list[tuple[str, tuple[str, ...], tuple[str, ...]]]
+    ] = {}
     for start_char, end_char in sorted(proposed):
         interval = _canonical_token_interval(tokens, start_char, end_char)
         if interval is None:
             continue
         start_token, end_token = interval
+        normalized_interval = (tokens[start_token][1], tokens[end_token - 1][2])
+        normalized_proposed.setdefault(normalized_interval, []).extend(
+            proposed[(start_char, end_char)]
+        )
+
+    mention_rows: list[dict[str, Any]] = []
+    license_rows: list[dict[str, Any]] = []
+    for start_char, end_char in sorted(normalized_proposed):
+        interval = _canonical_token_interval(tokens, start_char, end_char)
+        if interval is None:
+            continue
+        start_token, end_token = interval
+        # Persisted mention coordinates are one canonical token interval.  A
+        # parser phrase can overlap a token boundary; normalize its material
+        # span to that interval instead of emitting internally contradictory
+        # character and token ranges.
+        start_char = tokens[start_token][1]
+        end_char = tokens[end_token - 1][2]
         mention_ref = f"mention:{document}:{start_char}:{end_char}"
         specifications = sorted(
-            proposed[(start_char, end_char)],
+            set(normalized_proposed[(start_char, end_char)]),
             key=lambda specification: _LICENSE_PRIORITY[specification[0]],
         )
         primary_kind = specifications[0][0]

--- a/src/policy/fibred_operational_corpus_compilation.py
+++ b/src/policy/fibred_operational_corpus_compilation.py
@@ -18,7 +18,12 @@ from src.pnf.constraint_worklist import evaluate_constraint_worklist
 from src.pnf.fibred_build_projection import project_fibred_semantic_build
 from src.pnf.streaming_reduction_projection import project_streaming_reduction
 from src.policy import corpus_compilation as legacy
-from src.policy.algebra import Factor, FactorConstraint, TypedAlternative
+from src.policy.algebra import (
+    Factor,
+    FactorConstraint,
+    TypedAlternative,
+    canonicalize_factor_revision,
+)
 from src.policy.carriers.canonical import canonical_sha256
 from src.policy.operational_corpus_compilation import (
     OPERATIONAL_COMPILER_CONTRACT,
@@ -118,6 +123,18 @@ def _reidentify_graph(graph: PNFGraph) -> PNFGraph:
     return replace(graph, graph_ref=graph_ref)
 
 
+def _canonicalize_factor_revisions(graph: PNFGraph) -> PNFGraph:
+    """Refresh derived revision metadata after fibred materialisation."""
+
+    return replace(
+        graph,
+        factors=tuple(
+            _factor(canonicalize_factor_revision(factor.to_dict()))
+            for factor in graph.factors
+        ),
+    )
+
+
 def compile_document_fibred_operational(
     document_input: Mapping[str, Any],
     compiler_context: legacy.CompilerContext,
@@ -145,7 +162,7 @@ def compile_document_fibred_operational(
         graph=source_graph,
         streaming_build=streaming_build,
     )
-    fibred_graph = _reidentify_graph(fibred_graph)
+    fibred_graph = _canonicalize_factor_revisions(_reidentify_graph(fibred_graph))
     changed_factor_refs = tuple(
         str(ref) for ref in projection_receipt.get("factor_refs") or ()
     )

--- a/src/policy/fibred_operational_corpus_compilation.py
+++ b/src/policy/fibred_operational_corpus_compilation.py
@@ -204,7 +204,11 @@ def compile_document_fibred_operational(
             "fibred_constraint_worklist": constraint_worklist.to_dict(),
             "pnf_graph": fibred_graph.to_dict(),
             "refined_pnf_graph": fibred_graph.to_dict(),
-            "resolution_demands": [row.to_dict() for row in demands],
+            # ``derive_resolution_demands`` deliberately returns canonical
+            # mapping payloads.  Keep that backend-free contract intact at
+            # the fibred boundary rather than treating demand rows as carrier
+            # instances.
+            "resolution_demands": [legacy.canonical_json(row) for row in demands],
             "streaming_semantic_build": streaming_build,
             "fibred_semantic_build": fibred_build,
             "streaming_reduction_projection": projection_receipt,

--- a/src/policy/optimized_streaming_postgres_corpus_compilation.py
+++ b/src/policy/optimized_streaming_postgres_corpus_compilation.py
@@ -1,0 +1,459 @@
+"""Timed, batched PostgreSQL persistence for one immutable fibred document.
+
+This module preserves the existing compiler and semantic identities. It changes
+only execution: parent-before-child batching, nested persistence timings, and a
+single document transaction suitable for whole-attempt retry by the caller.
+"""
+
+from __future__ import annotations
+
+from time import monotonic_ns
+from typing import Any, Mapping
+
+from src.policy.corpus_compilation import CompilerContext
+from src.policy.fibred_operational_corpus_compilation import (
+    FIBRED_OPERATIONAL_COMPILER_CONTRACT,
+    compile_document_fibred_operational,
+)
+from src.policy.postgres_corpus_compilation import (
+    _canonical_source_coordinates,
+    _operational_build_key,
+    _operational_document_ref,
+    _prepare_meets_for_relational_persistence,
+    _validated_canonical_tokens,
+)
+from src.runtime.stage_timing import StageTiming
+from src.storage.postgres.batched_compiler_store import BatchedPostgresCompilerStore
+from src.storage.postgres.batched_semantic_fibre_store import (
+    persist_semantic_fibre_artifacts_batched,
+)
+from src.storage.postgres.batched_semantic_store import (
+    persist_pnf_graph_batched,
+    persist_resolution_artifacts_batched,
+)
+from src.storage.postgres.batched_streaming_semantic_store import (
+    persist_streaming_semantic_artifacts_batched,
+)
+from src.storage.postgres.binding_candidate_store import (
+    persist_binding_candidate_sets,
+)
+from src.storage.postgres.factor_revision_store import persist_factor_revision
+from src.storage.postgres.operational_build_store import (
+    load_completed_operational_build,
+    persist_completed_operational_build,
+)
+from src.storage.postgres.proposal_parent_store import (
+    persist_factor_proposal_parents,
+)
+from src.storage.postgres.span_store import persist_licensed_spans
+from src.storage.postgres.stage_timing_store import persist_stage_timings
+
+
+def _elapsed_ms(started_ns: int) -> int:
+    return max(0, (monotonic_ns() - started_ns) // 1_000_000)
+
+
+def _append_timing(
+    ledger: dict[str, Any],
+    *,
+    document_ref: str,
+    stage: str,
+    elapsed_ms: int,
+    details: Mapping[str, Any],
+    input_nodes: int | None = None,
+    output_nodes: int | None = None,
+) -> dict[str, Any]:
+    timings = [dict(row) for row in ledger.get("timings") or ()]
+    row = StageTiming(
+        document_ref=document_ref,
+        stage=stage,
+        ordinal=len(timings),
+        elapsed_ms=elapsed_ms,
+        backend_ref="postgresql",
+        input_nodes=input_nodes,
+        output_nodes=output_nodes,
+        details=dict(details),
+    ).to_dict()
+    timings.append(row)
+    totals = {
+        str(key): int(value)
+        for key, value in (ledger.get("stage_totals_ms") or {}).items()
+    }
+    totals[stage] = totals.get(stage, 0) + elapsed_ms
+    return {
+        **ledger,
+        "timings": timings,
+        "stage_totals_ms": {key: totals[key] for key in sorted(totals)},
+    }
+
+
+def persist_optimized_streaming_document_compilation(
+    *,
+    store: BatchedPostgresCompilerStore,
+    corpus_ref: str,
+    relative_path: str,
+    entry: Mapping[str, Any],
+    source_bytes: bytes,
+    source_text: str,
+    context: CompilerContext,
+    closure_workers: int = 2,
+    owner_partitions: int = 2,
+) -> tuple[str, ...]:
+    """Compile and persist one document in one immutable transaction."""
+
+    document_ref = str(entry["document_ref"])
+    content_sha256 = str(entry["content_sha256"])
+    source_ref = f"document-source:{document_ref}"
+    canonical_text, canonical_text_sha256, media_adapter_ref = (
+        _canonical_source_coordinates(
+            media_type=str(entry["media_type"]),
+            source_text=source_text,
+            source_ref=source_ref,
+        )
+    )
+    expected_document_ref = _operational_document_ref(
+        source_content_sha256=content_sha256,
+        canonical_text_sha256=canonical_text_sha256,
+        media_type=str(entry["media_type"]),
+        media_adapter_ref=media_adapter_ref,
+        context=context,
+    )
+    if document_ref != expected_document_ref:
+        raise ValueError("operational document identity disagrees with canonical text")
+    if str(entry.get("canonical_text_sha256") or "") != canonical_text_sha256:
+        raise ValueError("manifest canonical text hash disagrees with compilation")
+    if str(entry.get("media_adapter_ref") or "") != media_adapter_ref:
+        raise ValueError("manifest media adapter disagrees with compilation")
+    if str(entry.get("adapter_capability_ref") or "") != media_adapter_ref:
+        raise ValueError("declared media capability disagrees with selected adapter")
+
+    build_key_sha256 = _operational_build_key(
+        document_ref=document_ref,
+        content_sha256=content_sha256,
+        canonical_text_sha256=canonical_text_sha256,
+        media_adapter_ref=media_adapter_ref,
+        context=context,
+    )
+    with store.transaction() as cursor:
+        cached = load_completed_operational_build(
+            cursor,
+            document_ref=document_ref,
+            compiler_contract_ref=FIBRED_OPERATIONAL_COMPILER_CONTRACT,
+            build_key_sha256=build_key_sha256,
+        )
+        if cached is not None:
+            store.persist_occurrence(
+                cursor,
+                corpus_ref=corpus_ref,
+                relative_path=relative_path,
+                document_ref=document_ref,
+                state="reused_compilation",
+            )
+            return cached
+
+    compilation = compile_document_fibred_operational(
+        {
+            "document_ref": document_ref,
+            "content_sha256": content_sha256,
+            "media_type": entry["media_type"],
+            "canonical_text": source_text,
+            "source_ref": source_ref,
+        },
+        context,
+        closure_workers=closure_workers,
+        owner_partitions=owner_partitions,
+    )
+    artifacts = compilation.artifacts
+    if str(artifacts.get("build_key_sha256") or "") != build_key_sha256:
+        raise ValueError("operational compiler build key disagrees with persistence")
+    if artifacts.get("operational_compiler_contract") != (
+        FIBRED_OPERATIONAL_COMPILER_CONTRACT
+    ):
+        raise ValueError("catalogue persistence requires the fibred compiler")
+    source_normalisation = artifacts.get("source_normalisation") or {}
+    if str(source_normalisation.get("adapter_ref") or "") != media_adapter_ref:
+        raise ValueError("operational compiler media adapter disagrees with persistence")
+
+    canonical_tokens = _validated_canonical_tokens(
+        artifacts=artifacts,
+        expected_text=canonical_text,
+        expected_sha256=canonical_text_sha256,
+    )
+    refinements = tuple(artifacts.get("factor_refinements") or ())
+    candidate_sets = tuple(artifacts.get("binding_candidate_sets") or ())
+    factor_anchors = tuple(artifacts.get("factor_anchors") or ())
+    candidate_set_builds = tuple(
+        artifacts.get("binding_candidate_set_builds") or ()
+    )
+    demands = tuple(artifacts.get("resolution_demands") or ())
+    meets = _prepare_meets_for_relational_persistence(
+        artifacts.get("typed_meets") or ()
+    )
+    streaming_build = artifacts.get("streaming_semantic_build") or {}
+    stage_ledger = dict(artifacts.get("semantic_stage_timing") or {})
+    certificate = streaming_build.get("fixed_point_certificate") or {}
+    if certificate.get("local_fixed_point") != "reached":
+        raise ValueError("only locally fixed-point streaming builds may be persisted")
+    if not streaming_build.get("one_reduction_authority"):
+        raise ValueError("fibred build requires one reduction authority")
+    expected_producer_receipt = (
+        streaming_build.get("integrated_producer_receipt") or {}
+    )
+    proposals = tuple(
+        row
+        for row in streaming_build.get("proposals") or ()
+        if isinstance(row, Mapping)
+    )
+
+    persistence_started = monotonic_ns()
+    with store.savepoint() as cursor:
+        stage_started = monotonic_ns()
+        store.persist_source_document(
+            cursor,
+            document_ref=compilation.document_ref,
+            media_type=compilation.media_type,
+            content_sha256=compilation.content_sha256,
+            source_bytes=source_bytes,
+            canonical_text=canonical_text,
+            adapter_ref=media_adapter_ref,
+            adapter_version=context.media_normalization_ref,
+            compiler_context_ref=context.context_ref,
+            normalization_ref=context.media_normalization_ref,
+        )
+        store.persist_occurrence(
+            cursor,
+            corpus_ref=corpus_ref,
+            relative_path=relative_path,
+            document_ref=compilation.document_ref,
+            state="compiled",
+        )
+        persist_licensed_spans(
+            cursor,
+            document_ref=compilation.document_ref,
+            mentions=artifacts["licensing"].get("mentions") or (),
+        )
+        store.persist_tokens(
+            cursor,
+            document_ref=compilation.document_ref,
+            tokenizer_ref=context.annotation_backend_ref,
+            tokenizer_version=context.compiler_version,
+            tokens=canonical_tokens,
+        )
+        store.persist_annotation_layer(
+            cursor,
+            document_ref=compilation.document_ref,
+            layer=artifacts["annotation_layer"],
+        )
+        stage_ledger = _append_timing(
+            stage_ledger,
+            document_ref=document_ref,
+            stage="postgres.token_lexeme",
+            elapsed_ms=_elapsed_ms(stage_started),
+            input_nodes=len(canonical_tokens),
+            output_nodes=len(canonical_tokens),
+            details={
+                "token_count": len(canonical_tokens),
+                "mention_count": len(artifacts["licensing"].get("mentions") or ()),
+                "batched": True,
+                "canonical_lock_order": "lexeme_key_then_document_children",
+            },
+        )
+
+        stage_started = monotonic_ns()
+        base_factor_revisions = persist_pnf_graph_batched(
+            cursor,
+            document_ref=compilation.document_ref,
+            graph=artifacts["pnf_graph"],
+        )
+        resulting_factor_revisions = dict(base_factor_revisions)
+        for refinement in refinements:
+            resulting = refinement.get("resulting_factor")
+            if isinstance(resulting, Mapping):
+                revision_ref = persist_factor_revision(
+                    cursor,
+                    document_ref=compilation.document_ref,
+                    factor=resulting,
+                )
+                resulting_factor_revisions[str(resulting["factor_ref"])] = revision_ref
+        stage_ledger = _append_timing(
+            stage_ledger,
+            document_ref=document_ref,
+            stage="postgres.graph_revision",
+            elapsed_ms=_elapsed_ms(stage_started),
+            input_nodes=len(artifacts["pnf_graph"].get("factors") or ()),
+            output_nodes=len(base_factor_revisions),
+            details={"batched": True, "refinement_count": len(refinements)},
+        )
+
+        stage_started = monotonic_ns()
+        demand_refs = persist_resolution_artifacts_batched(
+            cursor,
+            factor_revisions=resulting_factor_revisions,
+            demands=demands,
+            evidence=tuple(artifacts.get("local_evidence") or ()),
+            meets=meets,
+            refinements=refinements,
+        )
+        persist_binding_candidate_sets(
+            cursor,
+            candidate_sets=candidate_sets,
+            refinements=refinements,
+            factor_revisions=base_factor_revisions,
+            factor_anchors=factor_anchors,
+            builds=candidate_set_builds,
+            meets=meets,
+            demands=demands,
+            validate_indexed_query=True,
+        )
+        stage_ledger = _append_timing(
+            stage_ledger,
+            document_ref=document_ref,
+            stage="postgres.resolution_binding",
+            elapsed_ms=_elapsed_ms(stage_started),
+            input_nodes=len(demands) + len(candidate_sets) + len(meets),
+            output_nodes=len(demand_refs),
+            details={
+                "demand_count": len(demands),
+                "candidate_set_count": len(candidate_sets),
+                "typed_meet_count": len(meets),
+                "resolution_children_batched": True,
+            },
+        )
+
+        stage_started = monotonic_ns()
+        persist_factor_proposal_parents(cursor, proposals)
+        persisted_producer_receipt = persist_semantic_fibre_artifacts_batched(
+            cursor,
+            document_ref=compilation.document_ref,
+            observation_deltas=tuple(
+                row
+                for row in streaming_build.get("observation_deltas") or ()
+                if isinstance(row, Mapping)
+            ),
+            proposals=proposals,
+            solver_jobs=tuple(
+                row
+                for row in streaming_build.get("solver_jobs") or ()
+                if isinstance(row, Mapping)
+            ),
+            solver_receipts=tuple(
+                row
+                for row in streaming_build.get("solver_receipts") or ()
+                if isinstance(row, Mapping)
+            ),
+            materialized_reduction=(
+                streaming_build.get("materialized_reduction") or {}
+            ),
+            transports=tuple(
+                row
+                for row in streaming_build.get("semantic_transports") or ()
+                if isinstance(row, Mapping)
+            ),
+            ontology_axes=tuple(
+                row
+                for row in streaming_build.get("ontology_axes") or ()
+                if isinstance(row, Mapping)
+            ),
+            axis_obligations=tuple(
+                row
+                for row in streaming_build.get("axis_obligations") or ()
+                if isinstance(row, Mapping)
+            ),
+            boundary_obligations=tuple(
+                row
+                for row in streaming_build.get("fibre_boundary_obligations") or ()
+                if isinstance(row, Mapping)
+            ),
+        )
+        if expected_producer_receipt:
+            if persisted_producer_receipt.fibre_ledger_ref != str(
+                expected_producer_receipt.get("fibre_ledger_ref") or ""
+            ):
+                raise ValueError("persisted fibre ledger disagrees with compiler receipt")
+            if persisted_producer_receipt.receipt_ref != str(
+                expected_producer_receipt.get("receipt_ref") or ""
+            ):
+                raise ValueError("persisted producer receipt disagrees with compiler receipt")
+        stage_ledger = _append_timing(
+            stage_ledger,
+            document_ref=document_ref,
+            stage="postgres.fibred_ledger",
+            elapsed_ms=_elapsed_ms(stage_started),
+            input_nodes=len(proposals),
+            output_nodes=len(
+                (streaming_build.get("materialized_reduction") or {}).get("factors")
+                or ()
+            ),
+            details={
+                "proposal_count": len(proposals),
+                "coordinate_count": len(
+                    (streaming_build.get("fibred_semantic_build") or {}).get(
+                        "semantic_coordinates"
+                    )
+                    or ()
+                ),
+                "batched": True,
+            },
+        )
+
+        stage_started = monotonic_ns()
+        persist_streaming_semantic_artifacts_batched(
+            cursor,
+            document_ref=compilation.document_ref,
+            streaming_build=streaming_build,
+            stage_timing_ledger=stage_ledger,
+        )
+        receipt_elapsed_ms = _elapsed_ms(stage_started)
+        stage_ledger = _append_timing(
+            stage_ledger,
+            document_ref=document_ref,
+            stage="postgres.receipts",
+            elapsed_ms=receipt_elapsed_ms,
+            input_nodes=len(streaming_build.get("solver_receipts") or ()),
+            output_nodes=len(streaming_build.get("solver_receipts") or ()),
+            details={
+                "solver_receipt_count": len(
+                    streaming_build.get("solver_receipts") or ()
+                ),
+                "state_delta_count": len(streaming_build.get("state_deltas") or ()),
+                "batched": True,
+            },
+        )
+        total_elapsed_ms = _elapsed_ms(persistence_started)
+        stage_ledger = _append_timing(
+            stage_ledger,
+            document_ref=document_ref,
+            stage="postgres_persistence",
+            elapsed_ms=total_elapsed_ms,
+            details={
+                "transaction_scope": "document_immutable_fibred_build",
+                "nested_stage_refs": [
+                    row["timing_ref"]
+                    for row in stage_ledger.get("timings") or ()
+                    if str(row.get("stage") or "").startswith("postgres.")
+                ],
+                "batched": True,
+            },
+        )
+        persist_stage_timings(
+            cursor,
+            document_ref=document_ref,
+            timings=(
+                row
+                for row in stage_ledger.get("timings") or ()
+                if str(row.get("stage") or "")
+                in {"postgres.receipts", "postgres_persistence"}
+            ),
+        )
+        persist_completed_operational_build(
+            cursor,
+            document_ref=compilation.document_ref,
+            compiler_contract_ref=FIBRED_OPERATIONAL_COMPILER_CONTRACT,
+            build_key_sha256=build_key_sha256,
+            graph_ref=str(artifacts["pnf_graph"]["graph_ref"]),
+            demand_refs=demand_refs,
+        )
+        return demand_refs
+
+
+__all__ = ["persist_optimized_streaming_document_compilation"]

--- a/src/policy/parallel_postgres_corpus_compilation.py
+++ b/src/policy/parallel_postgres_corpus_compilation.py
@@ -15,7 +15,9 @@ from time import monotonic_ns
 from typing import Any, Callable, Mapping, Sequence
 
 from src.policy.corpus_compilation import CompilerContext, build_corpus_manifest
-from src.policy.operational_corpus_compilation import OPERATIONAL_COMPILER_CONTRACT
+from src.policy.fibred_operational_corpus_compilation import (
+    FIBRED_OPERATIONAL_COMPILER_CONTRACT,
+)
 from src.policy.postgres_corpus_compilation import (
     _operational_build_key,
     _prepare_operational_manifest,
@@ -131,7 +133,7 @@ def _compile_one(
             cached = load_completed_operational_build(
                 cursor,
                 document_ref=document_ref,
-                compiler_contract_ref=OPERATIONAL_COMPILER_CONTRACT,
+                compiler_contract_ref=FIBRED_OPERATIONAL_COMPILER_CONTRACT,
                 build_key_sha256=build_key,
             )
         if prepared_source is None:

--- a/src/policy/parallel_postgres_corpus_compilation.py
+++ b/src/policy/parallel_postgres_corpus_compilation.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from time import monotonic_ns
 from typing import Any, Callable, Mapping, Sequence
 
+from psycopg import Error as PostgresError
+
 from src.policy.corpus_compilation import CompilerContext, build_corpus_manifest
 from src.policy.fibred_operational_corpus_compilation import (
     FIBRED_OPERATIONAL_COMPILER_CONTRACT,
@@ -182,7 +184,13 @@ def _compile_one(
             closure_workers=closure_workers,
             owner_partitions=owner_partitions,
         )
-    except (OSError, UnicodeDecodeError, ValueError, RuntimeError) as error:
+    except (
+        OSError,
+        UnicodeDecodeError,
+        ValueError,
+        RuntimeError,
+        PostgresError,
+    ) as error:
         with store.transaction() as cursor:
             failure_ref = store.persist_failure(
                 cursor,

--- a/src/policy/postgres_corpus_compilation.py
+++ b/src/policy/postgres_corpus_compilation.py
@@ -166,6 +166,8 @@ def _operational_build_key(
             "media_adapter_ref": media_adapter_ref,
             "context": context.to_dict(),
             "compiler_contract": OPERATIONAL_COMPILER_CONTRACT,
+            "closure_workers_semantic_effect": "none",
+            "owner_partitions_semantic_effect": "none",
         }
     )
 

--- a/src/policy/streaming_postgres_corpus_compilation.py
+++ b/src/policy/streaming_postgres_corpus_compilation.py
@@ -177,9 +177,6 @@ def persist_streaming_document_compilation(
         expected_sha256=canonical_text_sha256,
     )
     refinements = tuple(artifacts.get("factor_refinements") or ())
-    compatibility_refinements = tuple(
-        artifacts.get("compatibility_factor_refinements") or refinements
-    )
     candidate_sets = tuple(artifacts.get("binding_candidate_sets") or ())
     factor_anchors = tuple(artifacts.get("factor_anchors") or ())
     candidate_set_builds = tuple(
@@ -268,7 +265,10 @@ def persist_streaming_document_compilation(
         persist_binding_candidate_sets(
             cursor,
             candidate_sets=candidate_sets,
-            refinements=compatibility_refinements,
+            # The fibred graph is the persisted semantic state.  Legacy
+            # refinements remain compatibility evidence only, so they cannot
+            # create foreign-keyed refinement links in the active build.
+            refinements=refinements,
             factor_revisions=base_factor_revisions,
             factor_anchors=factor_anchors,
             builds=candidate_set_builds,

--- a/src/runtime/offline_network_guard.py
+++ b/src/runtime/offline_network_guard.py
@@ -1,4 +1,4 @@
-"""Process-local guard proving that an offline build attempted no sockets."""
+"""Process-local guard proving that an offline build attempted no external network."""
 
 from __future__ import annotations
 
@@ -18,7 +18,8 @@ class OfflineNetworkViolation(RuntimeError):
 @dataclass(frozen=True)
 class NetworkAbsenceReceipt:
     guard_ref: str
-    attempted_connections: tuple[str, ...]
+    allowed_connections: tuple[str, ...]
+    blocked_connections: tuple[str, ...]
 
     @property
     def receipt_ref(self) -> str:
@@ -28,33 +29,52 @@ class NetworkAbsenceReceipt:
         return {
             "receipt_ref": self.receipt_ref,
             **asdict(self),
-            "network_attempt_count": len(self.attempted_connections),
-            "network_absent": not self.attempted_connections,
+            "network_attempt_count": len(self.blocked_connections),
+            "external_network_absent": not self.blocked_connections,
+            "allowed_local_connection_count": len(self.allowed_connections),
         }
 
 
 class OfflineNetworkGuard(AbstractContextManager["OfflineNetworkGuard"]):
-    """Reject socket creation during deterministic catalogue/parity execution."""
+    """Reject external sockets while allowing explicitly declared local services."""
 
-    def __init__(self, *, guard_ref: str = "offline-curated-legal-ir:v0_1") -> None:
+    def __init__(
+        self,
+        *,
+        guard_ref: str = "offline-curated-legal-ir:v0_2",
+        allowed_hosts: tuple[str, ...] = ("localhost", "127.0.0.1", "::1"),
+    ) -> None:
         self.guard_ref = guard_ref
-        self._attempts: list[str] = []
+        self.allowed_hosts = frozenset(allowed_hosts)
+        self._allowed: list[str] = []
+        self._blocked: list[str] = []
         self._original_create_connection = socket.create_connection
         self._original_connect = socket.socket.connect
 
-    def _block_create_connection(self, address: Any, *args: Any, **kwargs: Any) -> Any:
-        del args, kwargs
-        self._attempts.append(repr(address))
-        raise OfflineNetworkViolation(f"offline build attempted network access: {address!r}")
+    def _is_allowed(self, address: Any) -> bool:
+        if isinstance(address, str):
+            return address.startswith("/")
+        if isinstance(address, tuple) and address:
+            return str(address[0]) in self.allowed_hosts
+        return False
 
-    def _block_connect(self, instance: socket.socket, address: Any) -> Any:
-        del instance
-        self._attempts.append(repr(address))
-        raise OfflineNetworkViolation(f"offline build attempted network access: {address!r}")
+    def _guard_create_connection(self, address: Any, *args: Any, **kwargs: Any) -> Any:
+        if self._is_allowed(address):
+            self._allowed.append(repr(address))
+            return self._original_create_connection(address, *args, **kwargs)
+        self._blocked.append(repr(address))
+        raise OfflineNetworkViolation(f"offline build attempted external access: {address!r}")
+
+    def _guard_connect(self, instance: socket.socket, address: Any) -> Any:
+        if self._is_allowed(address):
+            self._allowed.append(repr(address))
+            return self._original_connect(instance, address)
+        self._blocked.append(repr(address))
+        raise OfflineNetworkViolation(f"offline build attempted external access: {address!r}")
 
     def __enter__(self) -> "OfflineNetworkGuard":
-        socket.create_connection = self._block_create_connection  # type: ignore[assignment]
-        socket.socket.connect = self._block_connect  # type: ignore[method-assign]
+        socket.create_connection = self._guard_create_connection  # type: ignore[assignment]
+        socket.socket.connect = self._guard_connect  # type: ignore[method-assign]
         return self
 
     def __exit__(
@@ -72,7 +92,8 @@ class OfflineNetworkGuard(AbstractContextManager["OfflineNetworkGuard"]):
     def receipt(self) -> NetworkAbsenceReceipt:
         return NetworkAbsenceReceipt(
             guard_ref=self.guard_ref,
-            attempted_connections=tuple(self._attempts),
+            allowed_connections=tuple(self._allowed),
+            blocked_connections=tuple(self._blocked),
         )
 
 

--- a/src/runtime/offline_network_guard.py
+++ b/src/runtime/offline_network_guard.py
@@ -1,0 +1,83 @@
+"""Process-local guard proving that an offline build attempted no sockets."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from dataclasses import asdict, dataclass
+import socket
+from types import TracebackType
+from typing import Any
+
+from src.policy.carriers.canonical import canonical_sha256
+
+
+class OfflineNetworkViolation(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class NetworkAbsenceReceipt:
+    guard_ref: str
+    attempted_connections: tuple[str, ...]
+
+    @property
+    def receipt_ref(self) -> str:
+        return "network-absence-receipt:" + canonical_sha256(asdict(self))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "receipt_ref": self.receipt_ref,
+            **asdict(self),
+            "network_attempt_count": len(self.attempted_connections),
+            "network_absent": not self.attempted_connections,
+        }
+
+
+class OfflineNetworkGuard(AbstractContextManager["OfflineNetworkGuard"]):
+    """Reject socket creation during deterministic catalogue/parity execution."""
+
+    def __init__(self, *, guard_ref: str = "offline-curated-legal-ir:v0_1") -> None:
+        self.guard_ref = guard_ref
+        self._attempts: list[str] = []
+        self._original_create_connection = socket.create_connection
+        self._original_connect = socket.socket.connect
+
+    def _block_create_connection(self, address: Any, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        self._attempts.append(repr(address))
+        raise OfflineNetworkViolation(f"offline build attempted network access: {address!r}")
+
+    def _block_connect(self, instance: socket.socket, address: Any) -> Any:
+        del instance
+        self._attempts.append(repr(address))
+        raise OfflineNetworkViolation(f"offline build attempted network access: {address!r}")
+
+    def __enter__(self) -> "OfflineNetworkGuard":
+        socket.create_connection = self._block_create_connection  # type: ignore[assignment]
+        socket.socket.connect = self._block_connect  # type: ignore[method-assign]
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        del exc_type, exc_value, traceback
+        socket.create_connection = self._original_create_connection
+        socket.socket.connect = self._original_connect  # type: ignore[method-assign]
+        return None
+
+    @property
+    def receipt(self) -> NetworkAbsenceReceipt:
+        return NetworkAbsenceReceipt(
+            guard_ref=self.guard_ref,
+            attempted_connections=tuple(self._attempts),
+        )
+
+
+__all__ = [
+    "NetworkAbsenceReceipt",
+    "OfflineNetworkGuard",
+    "OfflineNetworkViolation",
+]

--- a/src/sources/admission.py
+++ b/src/sources/admission.py
@@ -1,0 +1,122 @@
+"""Deterministic source admission before canonical parsing.
+
+Admission is a generic catalogue concern: it records what an operator supplied
+and whether that revision may enter compilation.  It never interprets content
+or turns a repository/aggregator into a legal authority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Mapping
+
+from src.ontology.external_enrichment import canonical_sha256
+
+SOURCE_ADMISSION_CONTRACT = "source-admission:v0_1"
+
+
+@dataclass(frozen=True)
+class SourceAdmissionProfile:
+    profile_ref: str
+    admitted_roles: tuple[str, ...]
+    excluded_roles: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class SourceAdmissionReceipt:
+    receipt_ref: str
+    source_revision_ref: str
+    source_role: str
+    semantic_scope: str
+    compile_eligible: bool
+    exclusion_reason: str | None
+    profile_ref: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "contract_ref": SOURCE_ADMISSION_CONTRACT,
+            "authority": "catalogue_admission_only",
+            "immutable": True,
+        }
+
+
+def admit_source(
+    source: Mapping[str, Any], *, profile: SourceAdmissionProfile
+) -> SourceAdmissionReceipt:
+    """Create an immutable receipt; unknown roles fail closed."""
+    role = str(source.get("source_role") or "unclassified")
+    revision = str(
+        source.get("source_revision_ref") or source.get("document_ref") or ""
+    )
+    if not revision:
+        raise ValueError("source admission requires a source revision reference")
+    eligible = role in set(profile.admitted_roles)
+    reason = (
+        None
+        if eligible
+        else str(profile.excluded_roles.get(role) or "role_not_compile_eligible")
+    )
+    identity = {
+        "contract": SOURCE_ADMISSION_CONTRACT,
+        "profile": profile.profile_ref,
+        "revision": revision,
+        "role": role,
+        "eligible": eligible,
+        "reason": reason,
+    }
+    return SourceAdmissionReceipt(
+        receipt_ref="source-admission:" + canonical_sha256(identity),
+        source_revision_ref=revision,
+        source_role=role,
+        semantic_scope=str(source.get("semantic_scope") or "source_material"),
+        compile_eligible=eligible,
+        exclusion_reason=reason,
+        profile_ref=profile.profile_ref,
+    )
+
+
+def classify_catalogue(
+    sources: Iterable[Mapping[str, Any]], *, profile: SourceAdmissionProfile
+) -> tuple[SourceAdmissionReceipt, ...]:
+    return tuple(
+        sorted(
+            (admit_source(row, profile=profile) for row in sources),
+            key=lambda row: (row.source_revision_ref, row.receipt_ref),
+        )
+    )
+
+
+OFFLINE_HCA_REGRESSION_PROFILE = SourceAdmissionProfile(
+    profile_ref="profile:offline-hca-regression:v0_1",
+    admitted_roles=(
+        "hearing_transcript",
+        "judgment",
+        "submissions",
+        "chronology",
+        "appeal_document",
+        "reply_document",
+        "outline_document",
+        "transcript_media",
+    ),
+    excluded_roles={
+        "navigation": "navigation_not_substantive",
+        "search": "search_not_substantive",
+        "database_page": "database_page_not_substantive",
+        "landing_page": "landing_not_substantive",
+        "oembed": "oembed_not_substantive",
+        "recording_page": "recording_page_not_transcript_media",
+        "duplicate_caption": "derived_duplicate_caption",
+        "support_material": "unrelated_support_material",
+    },
+)
+
+
+__all__ = [
+    "OFFLINE_HCA_REGRESSION_PROFILE",
+    "SOURCE_ADMISSION_CONTRACT",
+    "SourceAdmissionProfile",
+    "SourceAdmissionReceipt",
+    "admit_source",
+    "classify_catalogue",
+]

--- a/src/sources/admission.py
+++ b/src/sources/admission.py
@@ -1,42 +1,64 @@
 """Deterministic source admission before canonical parsing.
 
 Admission is a generic catalogue concern: it records what an operator supplied
-and whether that revision may enter compilation.  It never interprets content
-or turns a repository/aggregator into a legal authority.
+and whether that revision may enter compilation. It never interprets content or
+turns a repository/aggregator into a legal authority.
 """
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any, Iterable, Mapping
 
 from src.ontology.external_enrichment import canonical_sha256
 
-SOURCE_ADMISSION_CONTRACT = "source-admission:v0_1"
+SOURCE_ADMISSION_CONTRACT = "source-admission:v0_2"
+_ADMISSION_STATES = {"compile", "evidence_only", "exclude"}
 
 
 @dataclass(frozen=True)
 class SourceAdmissionProfile:
+    """Versioned role policy applied before parser admission."""
+
     profile_ref: str
     admitted_roles: tuple[str, ...]
     excluded_roles: Mapping[str, str]
+    evidence_only_roles: Mapping[str, str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
 class SourceAdmissionReceipt:
+    """Immutable classification of one persisted source revision."""
+
     receipt_ref: str
     source_revision_ref: str
     source_role: str
     semantic_scope: str
-    compile_eligible: bool
+    admission_state: str
     exclusion_reason: str | None
     profile_ref: str
+
+    def __post_init__(self) -> None:
+        if self.admission_state not in _ADMISSION_STATES:
+            raise ValueError("unsupported source admission state")
+
+    @property
+    def compile_eligible(self) -> bool:
+        return self.admission_state == "compile"
+
+    @property
+    def evidence_only(self) -> bool:
+        return self.admission_state == "evidence_only"
 
     def to_dict(self) -> dict[str, Any]:
         return {
             **asdict(self),
+            "compile_eligible": self.compile_eligible,
+            "evidence_only": self.evidence_only,
             "contract_ref": SOURCE_ADMISSION_CONTRACT,
             "authority": "catalogue_admission_only",
+            "semantic_state_promoted": False,
+            "legal_truth_closed": False,
             "immutable": True,
         }
 
@@ -45,24 +67,31 @@ def admit_source(
     source: Mapping[str, Any], *, profile: SourceAdmissionProfile
 ) -> SourceAdmissionReceipt:
     """Create an immutable receipt; unknown roles fail closed."""
+
     role = str(source.get("source_role") or "unclassified")
     revision = str(
         source.get("source_revision_ref") or source.get("document_ref") or ""
     )
     if not revision:
         raise ValueError("source admission requires a source revision reference")
-    eligible = role in set(profile.admitted_roles)
-    reason = (
-        None
-        if eligible
-        else str(profile.excluded_roles.get(role) or "role_not_compile_eligible")
-    )
+
+    if role in set(profile.admitted_roles):
+        state = "compile"
+        reason = None
+    elif role in profile.evidence_only_roles:
+        state = "evidence_only"
+        reason = str(profile.evidence_only_roles[role])
+    else:
+        state = "exclude"
+        reason = str(profile.excluded_roles.get(role) or "role_not_compile_eligible")
+
     identity = {
         "contract": SOURCE_ADMISSION_CONTRACT,
         "profile": profile.profile_ref,
         "revision": revision,
         "role": role,
-        "eligible": eligible,
+        "semantic_scope": str(source.get("semantic_scope") or "source_material"),
+        "state": state,
         "reason": reason,
     }
     return SourceAdmissionReceipt(
@@ -70,7 +99,7 @@ def admit_source(
         source_revision_ref=revision,
         source_role=role,
         semantic_scope=str(source.get("semantic_scope") or "source_material"),
-        compile_eligible=eligible,
+        admission_state=state,
         exclusion_reason=reason,
         profile_ref=profile.profile_ref,
     )
@@ -87,8 +116,29 @@ def classify_catalogue(
     )
 
 
+def admission_manifest(
+    receipts: Iterable[SourceAdmissionReceipt],
+) -> dict[str, Any]:
+    """Return a deterministic build-facing admission summary."""
+
+    ordered = tuple(sorted(receipts, key=lambda row: row.receipt_ref))
+    counts = {state: 0 for state in sorted(_ADMISSION_STATES)}
+    for receipt in ordered:
+        counts[receipt.admission_state] += 1
+    return {
+        "contract_ref": SOURCE_ADMISSION_CONTRACT,
+        "receipt_refs": [row.receipt_ref for row in ordered],
+        "counts": counts,
+        "receipts": [row.to_dict() for row in ordered],
+        "parser_admitted_revision_refs": [
+            row.source_revision_ref for row in ordered if row.compile_eligible
+        ],
+        "network_activity_permitted": False,
+    }
+
+
 OFFLINE_HCA_REGRESSION_PROFILE = SourceAdmissionProfile(
-    profile_ref="profile:offline-hca-regression:v0_1",
+    profile_ref="profile:offline-hca-regression:v0_2",
     admitted_roles=(
         "hearing_transcript",
         "judgment",
@@ -99,13 +149,36 @@ OFFLINE_HCA_REGRESSION_PROFILE = SourceAdmissionProfile(
         "outline_document",
         "transcript_media",
     ),
+    evidence_only_roles={
+        "navigation": "navigation_discovery_evidence_only",
+        "search": "search_discovery_evidence_only",
+        "database_page": "database_discovery_evidence_only",
+        "landing_page": "landing_discovery_evidence_only",
+        "oembed": "oembed_transport_evidence_only",
+        "recording_page": "recording_transport_evidence_only",
+    },
     excluded_roles={
-        "navigation": "navigation_not_substantive",
-        "search": "search_not_substantive",
-        "database_page": "database_page_not_substantive",
-        "landing_page": "landing_not_substantive",
-        "oembed": "oembed_not_substantive",
-        "recording_page": "recording_page_not_transcript_media",
+        "duplicate_caption": "derived_duplicate_caption",
+        "support_material": "unrelated_support_material",
+    },
+)
+
+AU_PRIMARY_LEGAL_SOURCE_PROFILE = SourceAdmissionProfile(
+    profile_ref="profile:au-primary-legal-source:v0_1",
+    admitted_roles=(
+        "primary_legislation",
+        "delegated_legislation",
+        "judgment",
+    ),
+    evidence_only_roles={
+        "repository_record": "repository_transport_evidence_only",
+        "aggregator_record": "aggregator_transport_evidence_only",
+        "navigation": "navigation_discovery_evidence_only",
+        "search": "search_discovery_evidence_only",
+        "landing_page": "landing_discovery_evidence_only",
+    },
+    excluded_roles={
+        "commentary": "commentary_not_primary_authority",
         "duplicate_caption": "derived_duplicate_caption",
         "support_material": "unrelated_support_material",
     },
@@ -113,10 +186,12 @@ OFFLINE_HCA_REGRESSION_PROFILE = SourceAdmissionProfile(
 
 
 __all__ = [
+    "AU_PRIMARY_LEGAL_SOURCE_PROFILE",
     "OFFLINE_HCA_REGRESSION_PROFILE",
     "SOURCE_ADMISSION_CONTRACT",
     "SourceAdmissionProfile",
     "SourceAdmissionReceipt",
+    "admission_manifest",
     "admit_source",
     "classify_catalogue",
 ]

--- a/src/sources/catalogue_metadata.py
+++ b/src/sources/catalogue_metadata.py
@@ -1,0 +1,47 @@
+"""Project explicit source-role metadata from catalogue glob declarations."""
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from pathlib import PurePosixPath
+from typing import Any, Iterable, Mapping
+
+
+def source_metadata_from_rules(
+    relative_paths: Iterable[str],
+    *,
+    rules: Iterable[Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Assign one explicit role to each path; unmatched/ambiguous paths fail closed."""
+
+    ordered_rules = tuple(
+        sorted(
+            (dict(row) for row in rules),
+            key=lambda row: (str(row.get("glob") or ""), str(row.get("source_role") or "")),
+        )
+    )
+    result: dict[str, dict[str, Any]] = {}
+    for raw_path in sorted({str(path) for path in relative_paths}):
+        path = PurePosixPath(raw_path).as_posix()
+        matches = [row for row in ordered_rules if fnmatch(path, str(row.get("glob") or ""))]
+        if len(matches) > 1:
+            distinct_roles = {str(row.get("source_role") or "") for row in matches}
+            if len(distinct_roles) > 1:
+                raise ValueError(f"ambiguous source admission role for {path}")
+        rule = matches[0] if matches else {}
+        result[path] = {
+            "source_role": str(rule.get("source_role") or "unclassified"),
+            "semantic_scope": str(rule.get("semantic_scope") or "source_material"),
+            "jurisdiction_ref": str(rule.get("jurisdiction_ref") or ""),
+            "authority_level": str(rule.get("authority_level") or ""),
+            "provider_profile_refs": tuple(
+                sorted(str(value) for value in rule.get("provider_profile_refs") or ())
+            ),
+            "temporal_refs": tuple(
+                sorted(str(value) for value in rule.get("temporal_refs") or ())
+            ),
+        }
+    return result
+
+
+__all__ = ["source_metadata_from_rules"]

--- a/src/sources/governed_acquisition.py
+++ b/src/sources/governed_acquisition.py
@@ -1,0 +1,177 @@
+"""Explicit operator-authorised acquisition of one bounded legal source.
+
+Normal catalogue compilation never imports or calls this module. The caller must
+supply an operator authorization, provider policy, and bounded fetcher.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import hashlib
+from typing import Any, Callable, Mapping
+from urllib.parse import urlparse
+
+from src.policy.carriers.canonical import canonical_sha256
+
+GOVERNED_ACQUISITION_CONTRACT = "governed-legal-source-acquisition:v0_1"
+
+
+@dataclass(frozen=True)
+class AcquisitionPolicy:
+    provider_profile_ref: str
+    allowed_hosts: tuple[str, ...]
+    maximum_bytes: int
+    allowed_media_types: tuple[str, ...] = (
+        "text/plain",
+        "text/html",
+        "application/xhtml+xml",
+        "application/pdf",
+    )
+
+    def __post_init__(self) -> None:
+        if self.maximum_bytes <= 0:
+            raise ValueError("acquisition maximum_bytes must be positive")
+
+
+@dataclass(frozen=True)
+class AcquisitionRequest:
+    requested_url: str
+    operator_authorization_ref: str
+    provider_profile_ref: str
+    source_role: str
+    jurisdiction_ref: str
+    authority_level: str
+    temporal_refs: tuple[str, ...] = ()
+
+    @property
+    def request_ref(self) -> str:
+        return "governed-acquisition-request:" + canonical_sha256(asdict(self))
+
+
+@dataclass(frozen=True)
+class FetchedSource:
+    final_url: str
+    media_type: str
+    raw_bytes: bytes
+    canonical_text: str
+
+
+@dataclass(frozen=True)
+class AcquisitionReceipt:
+    request_ref: str
+    operator_authorization_ref: str
+    provider_profile_ref: str
+    requested_url: str
+    final_url: str | None
+    source_revision_ref: str | None
+    content_sha256: str | None
+    media_type: str | None
+    byte_count: int
+    state: str
+    failure_reason: str | None = None
+
+    @property
+    def receipt_ref(self) -> str:
+        return "governed-acquisition-receipt:" + canonical_sha256(asdict(self))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "receipt_ref": self.receipt_ref,
+            **asdict(self),
+            "contract_ref": GOVERNED_ACQUISITION_CONTRACT,
+            "network_operation_explicit": True,
+            "semantic_state_promoted": False,
+            "legal_truth_closed": False,
+        }
+
+
+FetchFunction = Callable[[str, int], FetchedSource]
+
+
+def acquire_legal_source(
+    request: AcquisitionRequest,
+    *,
+    policy: AcquisitionPolicy,
+    fetch: FetchFunction,
+) -> tuple[AcquisitionReceipt, Mapping[str, Any] | None]:
+    """Fetch one explicitly authorised source and return a registry payload."""
+
+    if not request.operator_authorization_ref:
+        raise ValueError("operator authorization is required")
+    if request.provider_profile_ref != policy.provider_profile_ref:
+        raise ValueError("request provider profile disagrees with policy")
+    parsed = urlparse(request.requested_url)
+    if parsed.scheme not in {"https", "http"}:
+        raise ValueError("governed acquisition supports HTTP(S) only")
+    if parsed.hostname not in set(policy.allowed_hosts):
+        raise ValueError("requested host is outside the acquisition policy")
+
+    try:
+        fetched = fetch(request.requested_url, policy.maximum_bytes)
+        if len(fetched.raw_bytes) > policy.maximum_bytes:
+            raise ValueError("fetched source exceeds acquisition byte limit")
+        if fetched.media_type not in set(policy.allowed_media_types):
+            raise ValueError("fetched source media type is not permitted")
+        content_sha256 = hashlib.sha256(fetched.raw_bytes).hexdigest()
+        canonical_sha256_hex = hashlib.sha256(
+            fetched.canonical_text.encode("utf-8")
+        ).hexdigest()
+        source_revision_ref = "legal-source-revision:" + canonical_sha256(
+            {
+                "request_ref": request.request_ref,
+                "content_sha256": content_sha256,
+                "canonical_text_sha256": canonical_sha256_hex,
+                "media_type": fetched.media_type,
+            }
+        )
+        receipt = AcquisitionReceipt(
+            request_ref=request.request_ref,
+            operator_authorization_ref=request.operator_authorization_ref,
+            provider_profile_ref=request.provider_profile_ref,
+            requested_url=request.requested_url,
+            final_url=fetched.final_url,
+            source_revision_ref=source_revision_ref,
+            content_sha256=content_sha256,
+            media_type=fetched.media_type,
+            byte_count=len(fetched.raw_bytes),
+            state="persisted",
+        )
+        registry_payload = {
+            "source_revision_ref": source_revision_ref,
+            "jurisdiction_ref": request.jurisdiction_ref,
+            "source_role": request.source_role,
+            "authority_level": request.authority_level,
+            "temporal_refs": request.temporal_refs,
+            "provider_profile_refs": (request.provider_profile_ref,),
+            "media_type": fetched.media_type,
+            "canonical_text_sha256": canonical_sha256_hex,
+            "raw_bytes": fetched.raw_bytes,
+            "canonical_text": fetched.canonical_text,
+            "acquisition_receipt_ref": receipt.receipt_ref,
+        }
+        return receipt, registry_payload
+    except Exception as error:
+        receipt = AcquisitionReceipt(
+            request_ref=request.request_ref,
+            operator_authorization_ref=request.operator_authorization_ref,
+            provider_profile_ref=request.provider_profile_ref,
+            requested_url=request.requested_url,
+            final_url=None,
+            source_revision_ref=None,
+            content_sha256=None,
+            media_type=None,
+            byte_count=0,
+            state="rejected" if isinstance(error, ValueError) else "failed",
+            failure_reason=f"{type(error).__name__}: {error}",
+        )
+        return receipt, None
+
+
+__all__ = [
+    "GOVERNED_ACQUISITION_CONTRACT",
+    "AcquisitionPolicy",
+    "AcquisitionReceipt",
+    "AcquisitionRequest",
+    "FetchedSource",
+    "acquire_legal_source",
+]

--- a/src/storage/postgres/batched_binding_candidate_store.py
+++ b/src/storage/postgres/batched_binding_candidate_store.py
@@ -1,0 +1,301 @@
+"""Batch-oriented persistence for set-valued PNF binding candidates."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from src.storage.postgres.binding_candidate_store import (
+    _sha,
+    _validate_indexed_membership,
+)
+
+
+def persist_binding_candidate_sets_batched(
+    cursor: Any,
+    *,
+    candidate_sets: Sequence[Mapping[str, Any]],
+    refinements: Sequence[Mapping[str, Any]],
+    factor_revisions: Mapping[str, str],
+    factor_anchors: Sequence[Mapping[str, Any]] = (),
+    builds: Sequence[Mapping[str, Any]] = (),
+    meets: Sequence[Mapping[str, Any]] = (),
+    demands: Sequence[Mapping[str, Any]] = (),
+    validate_indexed_query: bool = False,
+) -> None:
+    anchor_rows = []
+    morphology_rows = []
+    for row in factor_anchors:
+        revision_ref = factor_revisions.get(str(row["factor_ref"]))
+        if revision_ref is None:
+            continue
+        anchor_rows.append(
+            (
+                revision_ref,
+                str(row["document_ref"]),
+                row.get("sentence_index"),
+                row.get("clause_ref"),
+                int(row["start_token"]),
+                int(row["end_token"]),
+                str(row["pnf_kind_ref"]),
+                str(row.get("morphology_sha256") or ""),
+                row.get("discourse_unit_ref"),
+                row.get("paragraph_index"),
+                row.get("quotation_depth"),
+                row.get("reporting_scope_ref"),
+                row.get("coordination_group_ref"),
+                row.get("parser_pos"),
+                row.get("parser_dependency"),
+            )
+        )
+        morphology_rows.extend(
+            (revision_ref, str(feature_ref), str(value_ref))
+            for feature_ref, values in sorted((row.get("morphology") or {}).items())
+            for value_ref in sorted(str(value) for value in values)
+        )
+    if anchor_rows:
+        cursor.executemany(
+            """
+            INSERT INTO pnf.factor_anchor
+                (factor_revision_ref, document_ref, sentence_index, clause_ref,
+                 start_token, end_token, pnf_kind_ref, morphology_sha256,
+                 discourse_unit_ref, paragraph_index, quotation_depth,
+                 reporting_scope_ref, coordination_group_ref, parser_pos_ref,
+                 parser_dependency_ref)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                    %s, %s)
+            ON CONFLICT (factor_revision_ref) DO UPDATE SET
+                sentence_index = EXCLUDED.sentence_index,
+                clause_ref = EXCLUDED.clause_ref,
+                start_token = EXCLUDED.start_token,
+                end_token = EXCLUDED.end_token,
+                pnf_kind_ref = EXCLUDED.pnf_kind_ref,
+                morphology_sha256 = EXCLUDED.morphology_sha256,
+                discourse_unit_ref = EXCLUDED.discourse_unit_ref,
+                paragraph_index = EXCLUDED.paragraph_index,
+                quotation_depth = EXCLUDED.quotation_depth,
+                reporting_scope_ref = EXCLUDED.reporting_scope_ref,
+                coordination_group_ref = EXCLUDED.coordination_group_ref,
+                parser_pos_ref = EXCLUDED.parser_pos_ref,
+                parser_dependency_ref = EXCLUDED.parser_dependency_ref
+            """,
+            anchor_rows,
+        )
+    if morphology_rows:
+        cursor.executemany(
+            """
+            INSERT INTO pnf.factor_morphology
+                (factor_revision_ref, feature_ref, value_ref)
+            VALUES (%s, %s, %s) ON CONFLICT DO NOTHING
+            """,
+            morphology_rows,
+        )
+
+    builds_by_set = {str(row["candidate_set_ref"]): dict(row) for row in builds}
+    set_rows = []
+    build_rows = []
+    assessment_rows = []
+    member_rows = []
+    exclusion_rows = []
+    persisted_reference_revisions: dict[str, str] = {}
+    for row in sorted(candidate_sets, key=lambda value: str(value["candidate_set_ref"])):
+        candidate_set_ref = str(row["candidate_set_ref"])
+        reference_factor_ref = str(row["reference_factor_ref"])
+        reference_revision = factor_revisions.get(reference_factor_ref)
+        if reference_revision is None:
+            raise ValueError(
+                "binding candidate set references an unpersisted factor revision"
+            )
+        persisted_reference_revisions[candidate_set_ref] = reference_revision
+        set_rows.append(
+            (
+                candidate_set_ref,
+                str(row["document_ref"]),
+                reference_factor_ref,
+                reference_revision,
+                str(row["referential_type_ref"]),
+                str(row["accessibility_declaration_ref"]),
+                str(row["compatibility_declaration_ref"]),
+                str(row["generator_build_ref"]),
+                str(row["compatibility_state"]),
+                int(row["member_count"]),
+                _sha(row),
+            )
+        )
+        build = builds_by_set.get(candidate_set_ref) or {
+            "generator_build_ref": row["generator_build_ref"],
+            "candidate_set_ref": candidate_set_ref,
+            "reference_factor_revision_ref": reference_revision,
+            "document_pnf_index_ref": "",
+            "accessibility_declaration_ref": row["accessibility_declaration_ref"],
+            "compatibility_declaration_ref": row["compatibility_declaration_ref"],
+            "referential_type_ref": row["referential_type_ref"],
+        }
+        build = {**build, "reference_factor_revision_ref": reference_revision}
+        build_identity = {
+            "generator_build_ref": build["generator_build_ref"],
+            "reference_factor_revision_ref": build["reference_factor_revision_ref"],
+            "document_pnf_index_ref": build.get("document_pnf_index_ref"),
+            "accessibility_declaration_ref": build["accessibility_declaration_ref"],
+            "compatibility_declaration_ref": build["compatibility_declaration_ref"],
+            "referential_type_ref": build["referential_type_ref"],
+        }
+        build_rows.append(
+            (
+                str(build["generator_build_ref"]),
+                candidate_set_ref,
+                reference_revision,
+                str(build.get("document_pnf_index_ref") or ""),
+                str(build["accessibility_declaration_ref"]),
+                str(build["compatibility_declaration_ref"]),
+                str(build["referential_type_ref"]),
+                _sha(build_identity),
+            )
+        )
+        for ordinal, member in enumerate(row.get("members") or ()):
+            assessment_ref = str(member["compatibility_assessment_ref"])
+            candidate_factor_ref = str(member["candidate_factor_ref"])
+            accessibility_path_ref = str(member["accessibility_path_ref"])
+            assessment_rows.append(
+                (
+                    assessment_ref,
+                    candidate_set_ref,
+                    candidate_factor_ref,
+                    str(member["compatibility_state"]),
+                    accessibility_path_ref,
+                    _sha(member),
+                )
+            )
+            member_rows.append(
+                (
+                    candidate_set_ref,
+                    candidate_factor_ref,
+                    assessment_ref,
+                    accessibility_path_ref,
+                    ordinal,
+                )
+            )
+        exclusion_rows.extend(
+            (
+                candidate_set_ref,
+                str(summary["reason_ref"]),
+                int(summary["excluded_count"]),
+                str(summary["generator_build_ref"]),
+            )
+            for summary in row.get("exclusion_summaries") or ()
+        )
+    if set_rows:
+        cursor.executemany(
+            """
+            INSERT INTO resolution.binding_candidate_set
+                (candidate_set_ref, document_ref, reference_factor_ref,
+                 reference_factor_revision_ref, referential_type_ref,
+                 accessibility_declaration_ref, compatibility_declaration_ref,
+                 generator_build_ref, compatibility_state_ref, member_count,
+                 candidate_set_sha256)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (candidate_set_ref) DO NOTHING
+            """,
+            set_rows,
+        )
+        cursor.executemany(
+            """
+            INSERT INTO execution.binding_candidate_set_build
+                (generator_build_ref, candidate_set_ref,
+                 reference_factor_revision_ref, document_pnf_index_ref,
+                 accessibility_declaration_ref, compatibility_declaration_ref,
+                 referential_type_ref, build_key_sha256, build_state_ref)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'completed')
+            ON CONFLICT (generator_build_ref) DO NOTHING
+            """,
+            build_rows,
+        )
+    if assessment_rows:
+        cursor.executemany(
+            """
+            INSERT INTO resolution.binding_compatibility_assessment
+                (compatibility_assessment_ref, candidate_set_ref,
+                 candidate_factor_ref, compatibility_state_ref,
+                 accessibility_path_ref, assessment_sha256)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            ON CONFLICT (compatibility_assessment_ref) DO NOTHING
+            """,
+            assessment_rows,
+        )
+        cursor.executemany(
+            """
+            INSERT INTO resolution.binding_candidate_member
+                (candidate_set_ref, candidate_factor_ref,
+                 compatibility_assessment_ref, accessibility_path_ref, ordinal)
+            VALUES (%s, %s, %s, %s, %s)
+            ON CONFLICT (candidate_set_ref, candidate_factor_ref) DO NOTHING
+            """,
+            member_rows,
+        )
+    if exclusion_rows:
+        cursor.executemany(
+            """
+            INSERT INTO resolution.binding_exclusion_summary
+                (candidate_set_ref, reason_ref, excluded_count, generator_build_ref)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (candidate_set_ref, reason_ref) DO UPDATE SET
+                excluded_count = EXCLUDED.excluded_count,
+                generator_build_ref = EXCLUDED.generator_build_ref
+            """,
+            exclusion_rows,
+        )
+
+    known_sets = {str(row["candidate_set_ref"]) for row in candidate_sets}
+    refinement_links = [
+        (str(refinement["refinement_ref"]), str(candidate_set_ref))
+        for refinement in refinements
+        for candidate_set_ref in refinement.get("candidate_set_refs") or ()
+        if str(candidate_set_ref) in known_sets
+    ]
+    meet_links = [
+        (str(meet["meet_ref"]), str(candidate_set_ref))
+        for meet in meets
+        for candidate_set_ref in meet.get("candidate_set_refs") or ()
+        if str(candidate_set_ref) in known_sets
+    ]
+    demand_links = [
+        (str(demand["demand_ref"]), str(candidate_set_ref))
+        for demand in demands
+        for candidate_set_ref in demand.get("candidate_set_refs") or ()
+        if str(candidate_set_ref) in known_sets
+    ]
+    for statement, rows in (
+        (
+            "INSERT INTO resolution.refinement_candidate_set "
+            "(refinement_ref, candidate_set_ref) VALUES (%s, %s) "
+            "ON CONFLICT DO NOTHING",
+            refinement_links,
+        ),
+        (
+            "INSERT INTO resolution.meet_candidate_set "
+            "(meet_ref, candidate_set_ref) VALUES (%s, %s) "
+            "ON CONFLICT DO NOTHING",
+            meet_links,
+        ),
+        (
+            "INSERT INTO resolution.demand_candidate_set "
+            "(demand_ref, candidate_set_ref) VALUES (%s, %s) "
+            "ON CONFLICT DO NOTHING",
+            demand_links,
+        ),
+    ):
+        if rows:
+            cursor.executemany(statement, rows)
+
+    if validate_indexed_query:
+        for candidate_set in candidate_sets:
+            candidate_set_ref = str(candidate_set["candidate_set_ref"])
+            _validate_indexed_membership(
+                cursor,
+                candidate_set=candidate_set,
+                reference_factor_revision_ref=persisted_reference_revisions[
+                    candidate_set_ref
+                ],
+            )
+
+
+__all__ = ["persist_binding_candidate_sets_batched"]

--- a/src/storage/postgres/batched_compiler_store.py
+++ b/src/storage/postgres/batched_compiler_store.py
@@ -1,0 +1,211 @@
+"""Batch-oriented PostgreSQL store preserving the generic compiler contract."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Mapping, Sequence
+
+from src.policy.carriers.canonical import canonical_sha256
+from src.storage.postgres.compiler_store import PostgresCompilerStore, _stable_bytes
+from src.storage.postgres.token_codec import CorpusCodec, encode_delta_sequence
+
+
+class BatchedPostgresCompilerStore(PostgresCompilerStore):
+    """Use canonical executemany batches for high-volume immutable child rows."""
+
+    def persist_tokens(
+        self,
+        cursor: Any,
+        *,
+        document_ref: str,
+        tokenizer_ref: str,
+        tokenizer_version: str,
+        tokens: Sequence[tuple[str, int, int]],
+        language_ref: str = "und",
+        lexical_kind_ref: str = "surface",
+    ) -> str:
+        run_ref = "tokenizer-run:" + canonical_sha256(
+            {
+                "document_ref": document_ref,
+                "tokenizer_ref": tokenizer_ref,
+                "tokenizer_version": tokenizer_version,
+                "tokens": tokens,
+            }
+        )
+        lexeme_keys = tuple(sorted({surface.casefold() for surface, _, _ in tokens}))
+        if lexeme_keys:
+            cursor.executemany(
+                """
+                INSERT INTO language.lexeme
+                    (language_ref, normalized_text, lexical_kind_ref)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (language_ref, normalized_text, lexical_kind_ref)
+                DO NOTHING
+                """,
+                [(language_ref, key, lexical_kind_ref) for key in lexeme_keys],
+            )
+            cursor.execute(
+                """
+                SELECT normalized_text, lexeme_id
+                FROM language.lexeme
+                WHERE language_ref = %s AND lexical_kind_ref = %s
+                  AND normalized_text = ANY(%s)
+                """,
+                (language_ref, lexical_kind_ref, list(lexeme_keys)),
+            )
+            lexeme_by_key = {str(row[0]): int(row[1]) for row in cursor.fetchall()}
+            if len(lexeme_by_key) != len(lexeme_keys):
+                raise RuntimeError("lexeme batch did not return every requested key")
+        else:
+            lexeme_by_key = {}
+
+        lexeme_ids = [lexeme_by_key[surface.casefold()] for surface, _, _ in tokens]
+        starts = [start for _, start, _ in tokens]
+        ends = [end for _, _, end in tokens]
+        cursor.execute(
+            """
+            INSERT INTO language.tokenizer_run
+                (tokenizer_run_ref, document_ref, tokenizer_ref,
+                 tokenizer_version, token_count, output_sha256)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            ON CONFLICT (tokenizer_run_ref) DO NOTHING
+            """,
+            (
+                run_ref,
+                document_ref,
+                tokenizer_ref,
+                tokenizer_version,
+                len(tokens),
+                _stable_bytes({"lexeme_ids": lexeme_ids, "starts": starts, "ends": ends}),
+            ),
+        )
+        if not tokens:
+            return run_ref
+
+        codec = CorpusCodec.from_lexeme_ids(lexeme_ids)
+        codec_ref = "codec:" + canonical_sha256(
+            {"run_ref": run_ref, "mapping": codec.logical_to_symbol}
+        )
+        cursor.execute(
+            """
+            INSERT INTO language.codec
+                (codec_ref, codec_kind_ref, codec_version, dictionary_sha256)
+            VALUES (%s, 'frequency-ranked-uvarint', 'v0_1', %s)
+            ON CONFLICT (codec_ref) DO NOTHING
+            """,
+            (codec_ref, _stable_bytes(codec.logical_to_symbol)),
+        )
+        frequencies: dict[int, int] = {}
+        for lexeme_id in lexeme_ids:
+            frequencies[lexeme_id] = frequencies.get(lexeme_id, 0) + 1
+        ranked = sorted(frequencies, key=lambda value: (-frequencies[value], value))
+        cursor.executemany(
+            """
+            INSERT INTO language.codec_symbol
+                (codec_ref, symbol_code, lexeme_id, frequency_rank)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (codec_ref, symbol_code) DO NOTHING
+            """,
+            [
+                (codec_ref, codec.logical_to_symbol[lexeme_id], lexeme_id, rank)
+                for rank, lexeme_id in enumerate(ranked)
+            ],
+        )
+        encoded_symbols = codec.encode(lexeme_ids)
+        encoded_offsets = encode_delta_sequence(
+            [value for pair in zip(starts, ends, strict=True) for value in pair]
+        )
+        cursor.execute(
+            """
+            INSERT INTO language.token_stream_chunk
+                (tokenizer_run_ref, chunk_index, first_token_index, token_count,
+                 codec_ref, encoded_symbols, encoded_offsets, content_sha256)
+            VALUES (%s, 0, 0, %s, %s, %s, %s, %s)
+            ON CONFLICT (tokenizer_run_ref, chunk_index) DO NOTHING
+            """,
+            (
+                run_ref,
+                len(tokens),
+                codec_ref,
+                encoded_symbols,
+                encoded_offsets,
+                hashlib.sha256(encoded_symbols + encoded_offsets).digest(),
+            ),
+        )
+        return run_ref
+
+    def persist_annotation_layer(
+        self, cursor: Any, *, document_ref: str, layer: Mapping[str, Any]
+    ) -> None:
+        layer_ref = str(layer["layer_ref"])
+        cursor.execute(
+            """
+            INSERT INTO language.annotation_layer
+                (annotation_layer_ref, document_ref, backend_ref,
+                 backend_version, input_sha256, output_sha256)
+            VALUES (%s, %s, %s, 'v0_1', %s, %s)
+            ON CONFLICT (annotation_layer_ref) DO NOTHING
+            """,
+            (
+                layer_ref,
+                document_ref,
+                str(layer.get("tokenizer_ref") or "unknown"),
+                bytes.fromhex(str(layer["text_sha256"])),
+                _stable_bytes(layer),
+            ),
+        )
+        node_rows = [
+            (
+                f"{layer_ref}:token:{token['token_index']}",
+                layer_ref,
+                str(token["annotation_type"]),
+                None,
+                str(token["value"]),
+            )
+            for token in layer.get("token_annotations") or ()
+        ]
+        node_rows.extend(
+            (
+                str(span["span_ref"]),
+                layer_ref,
+                str(span["annotation_type"]),
+                str(span["span_ref"]),
+                str((span.get("value") or {}).get("surface") or ""),
+            )
+            for span in layer.get("span_annotations") or ()
+        )
+        if node_rows:
+            cursor.executemany(
+                """
+                INSERT INTO language.annotation_node
+                    (annotation_node_ref, annotation_layer_ref,
+                     annotation_type_ref, span_ref, value_ref)
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (annotation_node_ref) DO NOTHING
+                """,
+                node_rows,
+            )
+        relation_rows = [
+            (
+                str(row["relation_ref"]),
+                layer_ref,
+                str(row["relation_type"]),
+                str(row["left_ref"]),
+                str(row["right_ref"]),
+            )
+            for row in layer.get("relation_annotations") or ()
+        ]
+        if relation_rows:
+            cursor.executemany(
+                """
+                INSERT INTO language.annotation_relation
+                    (annotation_relation_ref, annotation_layer_ref,
+                     relation_type_ref, source_node_ref, target_node_ref)
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (annotation_relation_ref) DO NOTHING
+                """,
+                relation_rows,
+            )
+
+
+__all__ = ["BatchedPostgresCompilerStore"]

--- a/src/storage/postgres/batched_semantic_fibre_store.py
+++ b/src/storage/postgres/batched_semantic_fibre_store.py
@@ -1,0 +1,395 @@
+"""Batched persistence for semantic fibre coordinates, elements, and receipts."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from src.pnf.factor_proposals import INTEGRATED_SEMANTIC_PRODUCER_CONTRACT
+from src.pnf.integrated_semantic_producer import IntegratedProducerReceipt
+from src.pnf.semantic_fibres import (
+    AxisObligation,
+    FibreBoundaryObligation,
+    OntologyAxis,
+    SemanticFibreLedger,
+    SemanticTransport,
+    fibre_element_from_proposal_row,
+)
+from src.storage.postgres.semantic_fibre_store import (
+    _fibre_derivations,
+    _json,
+    _observation_elements,
+    _proposal_coordinate,
+)
+
+
+def persist_semantic_fibre_artifacts_batched(
+    cursor: Any,
+    *,
+    document_ref: str,
+    observation_deltas: Sequence[Mapping[str, Any]],
+    proposals: Sequence[Mapping[str, Any]],
+    solver_jobs: Sequence[Mapping[str, Any]],
+    solver_receipts: Sequence[Mapping[str, Any]],
+    materialized_reduction: Mapping[str, Any],
+    transports: Sequence[Mapping[str, Any]] = (),
+    ontology_axes: Sequence[Mapping[str, Any]] = (),
+    axis_obligations: Sequence[Mapping[str, Any]] = (),
+    boundary_obligations: Sequence[Mapping[str, Any]] = (),
+) -> IntegratedProducerReceipt:
+    coordinates, elements = _observation_elements(document_ref, observation_deltas)
+    content_to_element_ref = {row.content_ref: row.element_ref for row in elements}
+    proposal_by_ref = {
+        str(row.get("proposal_ref") or ""): row
+        for row in proposals
+        if row.get("proposal_ref")
+    }
+    proposal_extension_rows = []
+    for proposal in proposals:
+        coordinate = _proposal_coordinate(proposal)
+        element = fibre_element_from_proposal_row(proposal)
+        coordinates[coordinate.coordinate_ref] = coordinate
+        elements.append(element)
+        content_to_element_ref[str(proposal["proposal_ref"])] = element.element_ref
+        proposal_extension_rows.append(
+            (
+                proposal.get("semantic_coordinate_ref"),
+                proposal.get("scope_ref"),
+                proposal.get("statement_role") or "main",
+                proposal.get("coordinate_kind") or "object",
+                proposal.get("fibre_kind") or "hypothesis",
+                proposal.get("derivation_role") or "support",
+                proposal.get("producer_scope") or "integrated",
+                proposal.get("operation_contract"),
+                _json(proposal.get("ontology_axis_refs") or ()),
+                _json(proposal.get("transport_refs") or ()),
+                proposal.get("support_state") or "candidate",
+                proposal.get("confidence"),
+                _json(proposal.get("assumptions") or ()),
+                _json(proposal.get("coverage_requirements") or ()),
+                _json(proposal.get("execution_metadata") or {}),
+                proposal["proposal_ref"],
+            )
+        )
+    if proposal_extension_rows:
+        cursor.executemany(
+            """
+            UPDATE pnf_factor_proposal
+            SET semantic_coordinate_ref = %s, scope_ref = %s,
+                statement_role = %s, coordinate_kind = %s, fibre_kind = %s,
+                derivation_role = %s, producer_scope = %s,
+                operation_contract = %s, ontology_axis_refs = %s::jsonb,
+                transport_refs = %s::jsonb, support_state = %s, confidence = %s,
+                assumptions = %s::jsonb, coverage_requirements = %s::jsonb,
+                execution_metadata = %s::jsonb
+            WHERE proposal_ref = %s
+            """,
+            proposal_extension_rows,
+        )
+
+    derivations = _fibre_derivations(
+        document_ref=document_ref,
+        solver_jobs=solver_jobs,
+        solver_receipts=solver_receipts,
+        proposal_by_ref=proposal_by_ref,
+        content_to_element_ref=content_to_element_ref,
+    )
+    transport_rows = tuple(
+        SemanticTransport(
+            document_ref=str(row["document_ref"]),
+            source_coordinate_ref=str(row["source_coordinate_ref"]),
+            target_coordinate_ref=str(row["target_coordinate_ref"]),
+            transport_type=str(row["transport_type"]),
+            strength=str(row["strength"]),
+            evidence_refs=tuple(row.get("evidence_refs") or ()),
+            ontology_axis_refs=tuple(row.get("ontology_axis_refs") or ()),
+            allowed_operations=tuple(row.get("allowed_operations") or ()),
+            residual_refs=tuple(row.get("residual_refs") or ()),
+        )
+        for row in transports
+    )
+    axis_rows = tuple(
+        OntologyAxis(
+            axis_ref=str(row["axis_ref"]),
+            label=str(row["label"]),
+            authority_ref=str(row["authority_ref"]),
+            relation_refs=tuple(row.get("relation_refs") or ()),
+            root_refs=tuple(row.get("root_refs") or ()),
+            open_world=bool(row.get("open_world", True)),
+        )
+        for row in ontology_axes
+    )
+    obligation_rows = tuple(
+        AxisObligation(
+            document_ref=str(row["document_ref"]),
+            coordinate_ref=str(row["coordinate_ref"]),
+            axis_ref=str(row["axis_ref"]),
+            obligation_type=str(row["obligation_type"]),
+            trigger_refs=tuple(row.get("trigger_refs") or ()),
+            frontier_refs=tuple(row.get("frontier_refs") or ()),
+            state=str(row.get("state") or "open"),
+            resource_limit_reached=bool(row.get("resource_limit_reached", False)),
+        )
+        for row in axis_obligations
+    )
+    boundary_rows = tuple(
+        FibreBoundaryObligation(
+            document_ref=str(row["document_ref"]),
+            coordinate_ref=str(row["coordinate_ref"]),
+            scope_ref=str(row["scope_ref"]),
+            boundary_kind=str(row["boundary_kind"]),
+            evidence_refs=tuple(row.get("evidence_refs") or ()),
+            frontier_refs=tuple(row.get("frontier_refs") or ()),
+            required_axis_refs=tuple(row.get("required_axis_refs") or ()),
+            state=str(row.get("state") or "open"),
+            message=str(row.get("message") or ""),
+        )
+        for row in boundary_obligations
+    )
+
+    coordinate_payloads = [coordinates[key].to_dict() for key in sorted(coordinates)]
+    if coordinate_payloads:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_coordinate
+                (coordinate_ref, document_ref, scope_ref, source_span_refs,
+                 statement_role, factor_family, coordinate_kind,
+                 source_coordinate_refs, target_coordinate_refs)
+            VALUES (%s, %s, %s, %s::jsonb, %s, %s, %s, %s::jsonb, %s::jsonb)
+            ON CONFLICT (coordinate_ref) DO NOTHING
+            """,
+            [
+                (
+                    row["coordinate_ref"], row["document_ref"], row["scope_ref"],
+                    _json(row["source_span_refs"]), row["statement_role"],
+                    row["factor_family"], row["coordinate_kind"],
+                    _json(row["source_coordinate_refs"]),
+                    _json(row["target_coordinate_refs"]),
+                )
+                for row in coordinate_payloads
+            ],
+        )
+    element_payloads = [row.to_dict() for row in sorted(elements, key=lambda item: item.element_ref)]
+    if element_payloads:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_fibre_element
+                (element_ref, document_ref, coordinate_ref, fibre_kind, content_ref,
+                 derivation_role, producer_contract, operation_contract, source_refs,
+                 dependency_refs, transport_refs, ontology_axis_refs, assumptions,
+                 coverage_requirements, support_state, confidence, payload, external,
+                 execution_metadata, authority, semantic_state_promoted,
+                 legal_truth_closed)
+            VALUES
+                (%s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb,
+                 %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb, %s, %s,
+                 %s::jsonb, %s, %s::jsonb, %s, FALSE, FALSE)
+            ON CONFLICT (element_ref) DO NOTHING
+            """,
+            [
+                (
+                    row["element_ref"], row["document_ref"], row["coordinate_ref"],
+                    row["fibre_kind"], row["content_ref"], row["derivation_role"],
+                    row["producer_contract"], row["operation_contract"],
+                    _json(row["source_refs"]), _json(row["dependency_refs"]),
+                    _json(row["transport_refs"]), _json(row["ontology_axis_refs"]),
+                    _json(row["assumptions"]), _json(row["coverage_requirements"]),
+                    row["support_state"], row["confidence"], _json(row["payload"]),
+                    row["external"], _json(row["execution_metadata"]), row["authority"],
+                )
+                for row in element_payloads
+            ],
+        )
+    derivation_payloads = [row.to_dict() for row in derivations]
+    if derivation_payloads:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_fibre_derivation
+                (derivation_ref, document_ref, operation_kind, declaration_ref,
+                 producer_contract, input_element_refs, output_element_refs,
+                 sub_executor_ref, rule_set_revision, receipt_ref, assumptions,
+                 metrics, semantic_state_promoted)
+            VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s, %s,
+                    %s::jsonb, %s::jsonb, FALSE)
+            ON CONFLICT (derivation_ref) DO NOTHING
+            """,
+            [
+                (
+                    row["derivation_ref"], row["document_ref"], row["operation_kind"],
+                    row["declaration_ref"], row["producer_contract"],
+                    _json(row["input_element_refs"]), _json(row["output_element_refs"]),
+                    row["sub_executor_ref"], row["rule_set_revision"], row["receipt_ref"],
+                    _json(row["assumptions"]), _json(row["metrics"]),
+                )
+                for row in derivation_payloads
+            ],
+        )
+    if transport_rows:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_transport
+                (transport_ref, document_ref, source_coordinate_ref,
+                 target_coordinate_ref, transport_type, strength, evidence_refs,
+                 ontology_axis_refs, allowed_operations, residual_refs,
+                 identity_closed, semantic_state_promoted)
+            VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb,
+                    %s::jsonb, %s::jsonb, FALSE, FALSE)
+            ON CONFLICT (transport_ref) DO NOTHING
+            """,
+            [
+                (
+                    payload["transport_ref"], payload["document_ref"],
+                    payload["source_coordinate_ref"], payload["target_coordinate_ref"],
+                    payload["transport_type"], payload["strength"],
+                    _json(payload["evidence_refs"]), _json(payload["ontology_axis_refs"]),
+                    _json(payload["allowed_operations"]), _json(payload["residual_refs"]),
+                )
+                for payload in (row.to_dict() for row in transport_rows)
+            ],
+        )
+    if axis_rows:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_ontology_axis
+                (axis_ref, label, authority_ref, relation_refs, root_refs, open_world)
+            VALUES (%s, %s, %s, %s::jsonb, %s::jsonb, %s)
+            ON CONFLICT (axis_ref) DO NOTHING
+            """,
+            [
+                (row.axis_ref, row.label, row.authority_ref, _json(row.relation_refs),
+                 _json(row.root_refs), row.open_world)
+                for row in axis_rows
+            ],
+        )
+    if obligation_rows:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_axis_obligation
+                (obligation_ref, document_ref, coordinate_ref, axis_ref,
+                 obligation_type, trigger_refs, frontier_refs, state,
+                 resource_limit_reached, truth_closed)
+            VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s, %s, FALSE)
+            ON CONFLICT (obligation_ref) DO NOTHING
+            """,
+            [
+                (
+                    payload["obligation_ref"], payload["document_ref"],
+                    payload["coordinate_ref"], payload["axis_ref"],
+                    payload["obligation_type"], _json(payload["trigger_refs"]),
+                    _json(payload["frontier_refs"]), payload["state"],
+                    payload["resource_limit_reached"],
+                )
+                for payload in (row.to_dict() for row in obligation_rows)
+            ],
+        )
+    if boundary_rows:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_fibre_boundary_obligation
+                (boundary_ref, document_ref, coordinate_ref, scope_ref,
+                 boundary_kind, evidence_refs, frontier_refs,
+                 required_axis_refs, state, message)
+            VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb, %s, %s)
+            ON CONFLICT (boundary_ref) DO NOTHING
+            """,
+            [
+                (
+                    payload["boundary_ref"], payload["document_ref"],
+                    payload["coordinate_ref"], payload["scope_ref"],
+                    payload["boundary_kind"], _json(payload["evidence_refs"]),
+                    _json(payload["frontier_refs"]), _json(payload["required_axis_refs"]),
+                    payload["state"], payload["message"],
+                )
+                for payload in (row.to_dict() for row in boundary_rows)
+            ],
+        )
+
+    graph_ref = str(materialized_reduction.get("graph_ref") or "")
+    summary_rows = [
+        (
+            factor["factor_ref"], graph_ref, document_ref,
+            factor.get("semantic_coordinate_ref"), factor.get("fibre_kind") or "hypothesis",
+            factor["factor_type_ref"], factor.get("structural_signature") or "",
+            _json(factor.get("proposal_refs") or ()),
+            _json(factor.get("derivation_roles") or ()),
+            _json(factor.get("ontology_axis_refs") or ()),
+            _json(factor.get("transport_refs") or ()),
+            _json(factor.get("support_states") or ()),
+            _json(factor.get("residuals") or ()),
+        )
+        for factor in materialized_reduction.get("factors") or ()
+    ]
+    if summary_rows:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_fibre_summary
+                (factor_ref, graph_ref, document_ref, semantic_coordinate_ref,
+                 fibre_kind, factor_type_ref, structural_signature,
+                 proposal_refs, derivation_roles, ontology_axis_refs,
+                 transport_refs, support_states, residual_refs,
+                 deterministic_materialisation, identity_promoted, legal_truth_closed)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb,
+                    %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb, TRUE, FALSE, FALSE)
+            ON CONFLICT (factor_ref) DO NOTHING
+            """,
+            summary_rows,
+        )
+
+    ledger = SemanticFibreLedger(
+        coordinates=tuple(coordinates[key] for key in sorted(coordinates)),
+        elements=tuple(sorted(elements, key=lambda row: row.element_ref)),
+        transports=tuple(sorted(transport_rows, key=lambda row: row.transport_ref)),
+        derivations=derivations,
+        ontology_axes=tuple(sorted(axis_rows, key=lambda row: row.axis_ref)),
+        axis_obligations=tuple(sorted(obligation_rows, key=lambda row: row.obligation_ref)),
+        boundary_obligations=tuple(sorted(boundary_rows, key=lambda row: row.boundary_ref)),
+    )
+    producer_receipt = IntegratedProducerReceipt(
+        document_ref=document_ref,
+        contract_ref=INTEGRATED_SEMANTIC_PRODUCER_CONTRACT,
+        proposal_refs=tuple(sorted(str(row["proposal_ref"]) for row in proposals)),
+        sub_executor_receipt_refs=tuple(
+            sorted(
+                str(row.get("receipt_ref") or "")
+                for row in solver_receipts
+                if row.get("receipt_ref")
+            )
+        ),
+        fibre_ledger_ref=ledger.ledger_ref,
+        residual_refs=tuple(
+            sorted(
+                str(row.get("residual_ref") or "")
+                for row in materialized_reduction.get("residuals") or ()
+                if row.get("residual_ref")
+            )
+        ),
+        external_proposal_refs=tuple(
+            sorted(
+                str(row["proposal_ref"])
+                for row in proposals
+                if str(row.get("producer_scope") or "integrated") == "external"
+            )
+        ),
+    )
+    payload = producer_receipt.to_dict()
+    cursor.execute(
+        """
+        INSERT INTO integrated_semantic_producer_receipt
+            (receipt_ref, document_ref, contract_ref, proposal_refs,
+             sub_executor_receipt_refs, fibre_ledger_ref, residual_refs,
+             external_proposal_refs, one_proposal_contract,
+             one_reduction_authority, identity_promoted, legal_truth_closed)
+        VALUES (%s, %s, %s, %s::jsonb, %s::jsonb, %s, %s::jsonb,
+                %s::jsonb, TRUE, TRUE, FALSE, FALSE)
+        ON CONFLICT (receipt_ref) DO NOTHING
+        """,
+        (
+            payload["receipt_ref"], payload["document_ref"], payload["contract_ref"],
+            _json(payload["proposal_refs"]), _json(payload["sub_executor_receipt_refs"]),
+            payload["fibre_ledger_ref"], _json(payload["residual_refs"]),
+            _json(payload["external_proposal_refs"]),
+        ),
+    )
+    return producer_receipt
+
+
+__all__ = ["persist_semantic_fibre_artifacts_batched"]

--- a/src/storage/postgres/batched_semantic_store.py
+++ b/src/storage/postgres/batched_semantic_store.py
@@ -1,0 +1,380 @@
+"""Batched persistence for PNF graphs and resolution child rows."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+from src.policy.carriers.canonical import canonical_sha256
+from src.storage.postgres.factor_revision_store import (
+    factor_revision_payload,
+    factor_revision_ref,
+)
+
+
+def _sha(value: object) -> bytes:
+    return bytes.fromhex(canonical_sha256(value))
+
+
+def persist_pnf_graph_batched(
+    cursor: Any,
+    *,
+    document_ref: str,
+    graph: Mapping[str, Any],
+) -> dict[str, str]:
+    graph_ref = str(graph["graph_ref"])
+    factors = tuple(graph.get("factors") or ())
+    graph_state = (
+        "locally_closed"
+        if all(
+            row.get("closure_state") in {"locally_closed", "closed", "not_required"}
+            for row in factors
+        )
+        else "open"
+    )
+    cursor.execute(
+        """
+        INSERT INTO pnf.graph
+            (graph_ref, document_ref, graph_type_ref, schema_version_ref,
+             closure_state_ref, graph_sha256)
+        VALUES (%s, %s, 'generic.factor_graph', 'v0_1', %s, %s)
+        ON CONFLICT (graph_ref) DO NOTHING
+        """,
+        (graph_ref, document_ref, graph_state, _sha(graph)),
+    )
+    revisions = {
+        str(factor["factor_ref"]): factor_revision_ref(factor) for factor in factors
+    }
+    if factors:
+        cursor.executemany(
+            """
+            INSERT INTO algebra.factor (factor_ref, document_ref, factor_type_ref)
+            VALUES (%s, %s, %s) ON CONFLICT (factor_ref) DO NOTHING
+            """,
+            [
+                (str(factor["factor_ref"]), document_ref, str(factor["factor_type"]))
+                for factor in factors
+            ],
+        )
+        cursor.executemany(
+            """
+            INSERT INTO algebra.factor_revision
+                (factor_revision_ref, factor_ref, closure_state_ref, factor_sha256)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (factor_revision_ref) DO NOTHING
+            """,
+            [
+                (
+                    revisions[str(factor["factor_ref"])],
+                    str(factor["factor_ref"]),
+                    str(factor["closure_state"]),
+                    _sha(factor_revision_payload(factor)),
+                )
+                for factor in factors
+            ],
+        )
+        cursor.executemany(
+            """
+            INSERT INTO pnf.graph_factor_revision
+                (graph_ref, factor_revision_ref, graph_role_ref)
+            VALUES (%s, %s, %s) ON CONFLICT DO NOTHING
+            """,
+            [
+                (
+                    graph_ref,
+                    revisions[str(factor["factor_ref"])],
+                    str(factor["factor_type"]),
+                )
+                for factor in factors
+            ],
+        )
+    alternatives = [
+        (factor, alternative)
+        for factor in factors
+        for alternative in factor.get("alternatives") or ()
+    ]
+    if alternatives:
+        cursor.executemany(
+            """
+            INSERT INTO algebra.alternative
+                (alternative_ref, type_ref, value_ref, value_literal,
+                 authority_state_ref, alternative_sha256)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            ON CONFLICT (alternative_ref) DO NOTHING
+            """,
+            [
+                (
+                    str(alternative["alternative_ref"]),
+                    str(alternative["type_ref"]),
+                    (
+                        str(alternative.get("value", {}).get("mention_ref"))
+                        if isinstance(alternative.get("value"), Mapping)
+                        and alternative.get("value", {}).get("mention_ref")
+                        else None
+                    ),
+                    (
+                        None
+                        if isinstance(alternative.get("value"), Mapping)
+                        else str(alternative.get("value"))
+                    ),
+                    str(alternative.get("authority_state") or "candidate_only"),
+                    _sha(alternative),
+                )
+                for _, alternative in alternatives
+            ],
+        )
+        cursor.executemany(
+            """
+            INSERT INTO algebra.factor_revision_alternative
+                (factor_revision_ref, alternative_ref, alternative_state_ref)
+            VALUES (%s, %s, 'alternative') ON CONFLICT DO NOTHING
+            """,
+            [
+                (
+                    revisions[str(factor["factor_ref"])],
+                    str(alternative["alternative_ref"]),
+                )
+                for factor, alternative in alternatives
+            ],
+        )
+    residual_rows = [
+        (
+            f"{revisions[str(factor['factor_ref'])]}:residual:{residual}",
+            revisions[str(factor["factor_ref"])],
+            str(residual),
+            _sha(
+                {
+                    "factor_revision_ref": revisions[str(factor["factor_ref"])],
+                    "residual": residual,
+                }
+            ),
+        )
+        for factor in factors
+        for residual in factor.get("residuals") or ()
+    ]
+    if residual_rows:
+        cursor.executemany(
+            """
+            INSERT INTO algebra.residual
+                (residual_ref, target_ref, residual_type_ref,
+                 residual_state_ref, residual_sha256)
+            VALUES (%s, %s, %s, 'open', %s)
+            ON CONFLICT (residual_ref) DO NOTHING
+            """,
+            residual_rows,
+        )
+    return revisions
+
+
+def persist_resolution_artifacts_batched(
+    cursor: Any,
+    *,
+    factor_revisions: Mapping[str, str],
+    demands: Sequence[Mapping[str, Any]],
+    evidence: Sequence[Mapping[str, Any]],
+    meets: Sequence[Mapping[str, Any]],
+    refinements: Sequence[Mapping[str, Any]],
+) -> tuple[str, ...]:
+    if evidence:
+        cursor.executemany(
+            """
+            INSERT INTO evidence.local_evidence
+                (evidence_ref, document_ref, evidence_type_ref, relation_ref,
+                 evidence_sha256)
+            VALUES (%s, %s, %s, %s, %s)
+            ON CONFLICT (evidence_ref) DO NOTHING
+            """,
+            [
+                (
+                    str(row["evidence_ref"]),
+                    str(row["document_ref"]),
+                    str(row["evidence_type"]),
+                    str(row.get("relation") or ""),
+                    _sha(row),
+                )
+                for row in evidence
+            ],
+        )
+        subjects = [
+            (str(row["evidence_ref"]), str(subject_ref))
+            for row in evidence
+            for subject_ref in row.get("subject_refs") or ()
+        ]
+        if subjects:
+            cursor.executemany(
+                """
+                INSERT INTO evidence.local_evidence_subject
+                    (evidence_ref, subject_ref)
+                VALUES (%s, %s) ON CONFLICT DO NOTHING
+                """,
+                subjects,
+            )
+
+    demand_rows = []
+    facet_rows = []
+    for row in demands:
+        demand_ref = str(row["demand_ref"])
+        factor_ref = str(row["factor_ref"])
+        scope_ref = str(
+            row.get("scope_ref")
+            or row.get("document_scope")
+            or row.get("document_ref")
+            or "document_local"
+        )
+        demand_rows.append(
+            (
+                demand_ref,
+                factor_ref,
+                factor_revisions.get(factor_ref),
+                str(row.get("subject_kind") or row.get("factor_type") or "unknown"),
+                row.get("formal_role"),
+                scope_ref,
+                _sha(row.get("semantic_key") or row),
+                str(row.get("budget_class") or row.get("budget") or "default"),
+            )
+        )
+        facet_rows.extend(
+            (demand_ref, str(facet)) for facet in row.get("requested_facets") or ()
+        )
+    if demand_rows:
+        cursor.executemany(
+            """
+            INSERT INTO resolution.demand
+                (demand_ref, factor_ref, factor_revision_ref, subject_kind_ref,
+                 formal_role_ref, scope_ref, semantic_key_sha256,
+                 budget_class_ref, demand_state_ref)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, 'open')
+            ON CONFLICT (demand_ref) DO NOTHING
+            """,
+            demand_rows,
+        )
+    if facet_rows:
+        cursor.executemany(
+            """
+            INSERT INTO resolution.demand_facet (demand_ref, facet_ref)
+            VALUES (%s, %s) ON CONFLICT DO NOTHING
+            """,
+            facet_rows,
+        )
+
+    if meets:
+        cursor.executemany(
+            """
+            INSERT INTO resolution.typed_meet
+                (meet_ref, left_ref, right_ref, meet_type_ref, meet_state_ref,
+                 meet_sha256)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            ON CONFLICT (meet_ref) DO NOTHING
+            """,
+            [
+                (
+                    str(row["meet_ref"]),
+                    str(row["left_ref"]),
+                    str(row["right_ref"]),
+                    str(row["meet_type"]),
+                    str(row["state"]),
+                    _sha(row),
+                )
+                for row in meets
+            ],
+        )
+        meet_evidence = [
+            (str(row["meet_ref"]), str(evidence_ref))
+            for row in meets
+            for evidence_ref in row.get("evidence_refs") or ()
+        ]
+        if meet_evidence:
+            cursor.executemany(
+                """
+                INSERT INTO resolution.meet_evidence (meet_ref, evidence_ref)
+                VALUES (%s, %s) ON CONFLICT DO NOTHING
+                """,
+                meet_evidence,
+            )
+
+    revision_rows = []
+    refinement_rows = []
+    alternative_transition_rows = []
+    residual_transition_rows = []
+    for row in refinements:
+        prior = row["prior_factor"]
+        resulting = row["resulting_factor"]
+        factor_ref = str(prior["factor_ref"])
+        prior_revision_ref = factor_revision_ref(prior)
+        resulting_revision_ref = factor_revision_ref(resulting)
+        revision_rows.append(
+            (
+                resulting_revision_ref,
+                factor_ref,
+                str(resulting["closure_state"]),
+                _sha(factor_revision_payload(resulting)),
+            )
+        )
+        refinement_rows.append(
+            (
+                str(row["refinement_ref"]),
+                factor_ref,
+                prior_revision_ref,
+                resulting_revision_ref,
+                _sha(row),
+            )
+        )
+        for transition_type, key in (
+            ("added", "added_alternative_refs"),
+            ("retained", "retained_alternative_refs"),
+            ("rejected", "rejected_alternative_refs"),
+        ):
+            alternative_transition_rows.extend(
+                (str(row["refinement_ref"]), str(ref), transition_type)
+                for ref in row.get(key) or ()
+            )
+        residual_transition_rows.extend(
+            (
+                str(row["refinement_ref"]),
+                str(transition["residual_ref"]),
+                str(transition.get("prior_state") or ""),
+                str(transition.get("resulting_state") or ""),
+            )
+            for transition in row.get("residual_transitions") or ()
+        )
+    if revision_rows:
+        cursor.executemany(
+            """
+            INSERT INTO algebra.factor_revision
+                (factor_revision_ref, factor_ref, closure_state_ref, factor_sha256)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (factor_revision_ref) DO NOTHING
+            """,
+            revision_rows,
+        )
+        cursor.executemany(
+            """
+            INSERT INTO resolution.refinement
+                (refinement_ref, factor_ref, prior_factor_revision_ref,
+                 resulting_factor_revision_ref, refinement_sha256)
+            VALUES (%s, %s, %s, %s, %s)
+            ON CONFLICT (refinement_ref) DO NOTHING
+            """,
+            refinement_rows,
+        )
+    if alternative_transition_rows:
+        cursor.executemany(
+            """
+            INSERT INTO resolution.refinement_alternative_transition
+                (refinement_ref, alternative_ref, transition_type_ref)
+            VALUES (%s, %s, %s) ON CONFLICT DO NOTHING
+            """,
+            alternative_transition_rows,
+        )
+    if residual_transition_rows:
+        cursor.executemany(
+            """
+            INSERT INTO resolution.refinement_residual_transition
+                (refinement_ref, residual_ref, prior_state_ref, resulting_state_ref)
+            VALUES (%s, %s, %s, %s) ON CONFLICT DO NOTHING
+            """,
+            residual_transition_rows,
+        )
+    return tuple(sorted(str(row["demand_ref"]) for row in demands))
+
+
+__all__ = ["persist_pnf_graph_batched", "persist_resolution_artifacts_batched"]

--- a/src/storage/postgres/batched_streaming_semantic_store.py
+++ b/src/storage/postgres/batched_streaming_semantic_store.py
@@ -1,0 +1,278 @@
+"""Batched persistence for append-only streaming semantic receipts."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+from src.policy.carriers.canonical import canonical_sha256
+from src.storage.postgres.stage_timing_store import persist_stage_timings
+
+
+def _json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha(value: object) -> bytes:
+    return bytes.fromhex(canonical_sha256(value))
+
+
+def persist_streaming_semantic_artifacts_batched(
+    cursor: Any,
+    *,
+    document_ref: str,
+    streaming_build: Mapping[str, Any],
+    stage_timing_ledger: Mapping[str, Any],
+) -> None:
+    ledger = streaming_build.get("ledger") or {}
+    deltas = [
+        row
+        for row in streaming_build.get("observation_deltas") or ()
+        if isinstance(row, Mapping)
+    ]
+    if deltas:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_observation_delta
+                (delta_ref, document_ref, batch_ref, scope_ref, sequence_no,
+                 parser_contract, observation_refs, observations, token_start,
+                 token_end, char_start, char_end, token_count, coverage_barrier,
+                 coverage_complete, payload_sha256)
+            VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb,
+                    %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (delta_ref) DO NOTHING
+            """,
+            [
+                (
+                    row["delta_ref"], document_ref, row["batch_ref"], row["scope_ref"],
+                    int(row["sequence_no"]), row["parser_contract"],
+                    _json(row.get("observation_refs") or ()),
+                    _json(row.get("observations") or ()), int(row["token_start"]),
+                    int(row["token_end"]), int(row["char_start"]), int(row["char_end"]),
+                    int(row["token_count"]), row["coverage_barrier"],
+                    bool(row["coverage_complete"]), _sha(row),
+                )
+                for row in deltas
+            ],
+        )
+    notices = [
+        row
+        for row in streaming_build.get("coverage_notices") or ()
+        if isinstance(row, Mapping)
+    ]
+    if notices:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_coverage_notice
+                (notice_ref, document_ref, scope_ref, barrier, state, evidence_refs)
+            VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+            ON CONFLICT (notice_ref) DO NOTHING
+            """,
+            [
+                (
+                    row["notice_ref"], document_ref, row["scope_ref"], row["barrier"],
+                    row["state"], _json(row.get("evidence_refs") or ()),
+                )
+                for row in notices
+            ],
+        )
+    proposals = [
+        row for row in streaming_build.get("proposals") or () if isinstance(row, Mapping)
+    ]
+    if proposals:
+        cursor.executemany(
+            """
+            INSERT INTO pnf_factor_proposal
+                (proposal_ref, proposal_digest, document_ref, source_revision_ref,
+                 factor_type_ref, structural_signature, producer_contract,
+                 declaration_revision, source_span_refs, input_observation_refs,
+                 dependency_factor_refs, role_bindings, qualifier_state,
+                 candidate_payload, residuals, authority)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s,
+                    %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb,
+                    %s::jsonb, %s::jsonb, 'candidate_only')
+            ON CONFLICT (proposal_ref) DO NOTHING
+            """,
+            [
+                (
+                    row["proposal_ref"], row["proposal_digest"], row["document_ref"],
+                    row["source_revision_ref"], row["factor_type_ref"],
+                    row["structural_signature"], row["producer_contract"],
+                    row["declaration_revision"], _json(row.get("source_span_refs") or ()),
+                    _json(row.get("input_observation_refs") or ()),
+                    _json(row.get("dependency_factor_refs") or ()),
+                    _json(row.get("role_bindings") or {}),
+                    _json(row.get("qualifier_state") or {}),
+                    _json(row.get("candidate_payload") or {}),
+                    _json(row.get("residuals") or ()),
+                )
+                for row in proposals
+            ],
+        )
+    jobs = [
+        row for row in streaming_build.get("solver_jobs") or () if isinstance(row, Mapping)
+    ]
+    if jobs:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_solver_job
+                (job_ref, document_ref, owner_ref, scope_ref, factor_family,
+                 declaration_ref, input_revision, input_refs, input_payload,
+                 rule_set_revision, coverage_requirements, assumptions, priority)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb,
+                    %s, %s::jsonb, %s::jsonb, %s)
+            ON CONFLICT (job_ref) DO NOTHING
+            """,
+            [
+                (
+                    row["job_ref"], document_ref,
+                    "semantic-owner:" + canonical_sha256(row.get("owner_key") or {}),
+                    str((row.get("owner_key") or {}).get("scope_ref") or ""),
+                    str((row.get("owner_key") or {}).get("factor_family") or ""),
+                    row["declaration_ref"], int(row["input_revision"]),
+                    _json(row.get("input_refs") or ()), _json(row.get("input_payload") or {}),
+                    row["rule_set_revision"], _json(row.get("coverage_requirements") or ()),
+                    _json(row.get("assumptions") or ()), int(row.get("priority", 100)),
+                )
+                for row in jobs
+            ],
+        )
+    receipts = [
+        row for row in streaming_build.get("solver_receipts") or () if isinstance(row, Mapping)
+    ]
+    if receipts:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_solver_receipt
+                (receipt_ref, job_ref, document_ref, owner_ref, input_revision,
+                 input_refs, rule_set_revision, proposal_refs, residuals,
+                 assumptions, coverage_requirements, metrics, backend_ref,
+                 semantic_state_promoted)
+            VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s::jsonb,
+                    %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb, %s, FALSE)
+            ON CONFLICT (receipt_ref) DO NOTHING
+            """,
+            [
+                (
+                    row["receipt_ref"], row["job_ref"], document_ref,
+                    "semantic-owner:" + canonical_sha256(row.get("owner_key") or {}),
+                    int(row["input_revision"]), _json(row.get("input_refs") or ()),
+                    row["rule_set_revision"], _json(row.get("proposal_refs") or ()),
+                    _json(row.get("residuals") or ()), _json(row.get("assumptions") or ()),
+                    _json(row.get("coverage_requirements") or ()),
+                    _json(row.get("metrics") or {}), str(row.get("backend_ref") or ""),
+                )
+                for row in receipts
+            ],
+        )
+    state_deltas = [
+        row for row in streaming_build.get("state_deltas") or () if isinstance(row, Mapping)
+    ]
+    if state_deltas:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_state_delta
+                (document_ref, resulting_revision, prior_revision,
+                 accepted_observation_refs, accepted_proposal_refs,
+                 changed_factor_refs, introduced_residual_refs,
+                 discharged_residual_refs, dirty_owner_refs, emitted_job_refs)
+            VALUES (%s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb,
+                    %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb)
+            ON CONFLICT (document_ref, resulting_revision) DO NOTHING
+            """,
+            [
+                (
+                    document_ref, int(row["resulting_revision"]), int(row["prior_revision"]),
+                    _json(row.get("accepted_observation_refs") or ()),
+                    _json(row.get("accepted_proposal_refs") or ()),
+                    _json(row.get("changed_factor_refs") or ()),
+                    _json(row.get("introduced_residual_refs") or ()),
+                    _json(row.get("discharged_residual_refs") or ()),
+                    _json(row.get("dirty_owner_refs") or ()),
+                    _json(row.get("emitted_job_refs") or ()),
+                )
+                for row in state_deltas
+            ],
+        )
+    materialized = streaming_build.get("materialized_reduction") or {}
+    cursor.execute(
+        """
+        INSERT INTO semantic_materialized_reduction
+            (graph_ref, document_ref, revision, ledger_ref, proposal_count,
+             factor_refs, residual_refs, shared_graph_mutation, last_writer_wins)
+        VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s::jsonb, FALSE, FALSE)
+        ON CONFLICT (graph_ref) DO NOTHING
+        """,
+        (
+            materialized["graph_ref"], document_ref, int(streaming_build["revision"]),
+            ledger["ledger_ref"], int(materialized.get("proposal_count", 0)),
+            _json([row.get("factor_ref") for row in materialized.get("factors") or ()]),
+            _json([row.get("residual_ref") for row in materialized.get("residuals") or ()]),
+        ),
+    )
+    boundaries = [
+        row
+        for row in streaming_build.get("region_boundary_summaries") or ()
+        if isinstance(row, Mapping)
+    ]
+    if boundaries:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_region_boundary_summary
+                (summary_ref, document_ref, scope_ref, stable_factor_refs,
+                 unresolved_external_refs, possible_cross_scope_hosts,
+                 definition_scope_obligations, coverage_notice_refs)
+            VALUES (%s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb,
+                    %s::jsonb, %s::jsonb)
+            ON CONFLICT (summary_ref) DO NOTHING
+            """,
+            [
+                (
+                    row["summary_ref"], document_ref, row["scope_ref"],
+                    _json(row.get("stable_factor_refs") or ()),
+                    _json(row.get("unresolved_external_refs") or ()),
+                    _json(row.get("possible_cross_scope_hosts") or ()),
+                    _json(row.get("definition_scope_obligations") or ()),
+                    _json(row.get("coverage_notice_refs") or ()),
+                )
+                for row in boundaries
+            ],
+        )
+    certificate = streaming_build.get("fixed_point_certificate") or {}
+    cursor.execute(
+        """
+        INSERT INTO semantic_fixed_point_certificate
+            (certificate_ref, document_ref, revision, ledger_ref,
+             materialized_graph_ref, local_fixed_point,
+             unconsumed_observation_deltas, dirty_reduction_groups,
+             pending_jobs, in_flight_jobs, unresolved_local_boundary_obligations,
+             open_required_coverage_barriers, unresolved_external_residuals,
+             resource_limit_reached, identity_promoted, legal_truth_closed)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                %s::jsonb, %s, FALSE, FALSE)
+        ON CONFLICT (certificate_ref) DO NOTHING
+        """,
+        (
+            certificate["certificate_ref"], document_ref, int(certificate["revision"]),
+            certificate["ledger_ref"], certificate["materialized_graph_ref"],
+            certificate["local_fixed_point"], int(certificate["unconsumed_observation_deltas"]),
+            int(certificate["dirty_reduction_groups"]), int(certificate["pending_jobs"]),
+            int(certificate["in_flight_jobs"]),
+            int(certificate["unresolved_local_boundary_obligations"]),
+            int(certificate["open_required_coverage_barriers"]),
+            _json(certificate.get("unresolved_external_residuals") or ()),
+            bool(certificate.get("resource_limit_reached", False)),
+        ),
+    )
+    persist_stage_timings(
+        cursor,
+        document_ref=document_ref,
+        timings=(
+            row
+            for row in stage_timing_ledger.get("timings") or ()
+            if isinstance(row, Mapping)
+        ),
+    )
+
+
+__all__ = ["persist_streaming_semantic_artifacts_batched"]

--- a/src/storage/postgres/compiler_store.py
+++ b/src/storage/postgres/compiler_store.py
@@ -313,7 +313,11 @@ class PostgresCompilerStore:
 
     def count_persisted_tokens(self, cursor: Any, *, document_ref: str) -> int:
         cursor.execute(
-            "SELECT count(*) FROM language.token WHERE document_ref = %s",
+            """
+            SELECT COALESCE(MAX(token_count), 0)
+            FROM language.tokenizer_run
+            WHERE document_ref = %s
+            """,
             (document_ref,),
         )
         return int(cursor.fetchone()[0])

--- a/src/storage/postgres/compiler_store.py
+++ b/src/storage/postgres/compiler_store.py
@@ -221,22 +221,39 @@ class PostgresCompilerStore:
                 "tokens": tokens,
             }
         )
-        lexeme_ids: list[int] = []
-        starts: list[int] = []
-        ends: list[int] = []
-        for surface, start, end in tokens:
-            cursor.execute(
+        # Lexemes are shared immutable vocabulary.  Insert every unique key in
+        # canonical order, then read the complete stable map once.  This avoids
+        # one upsert/update lock per token while preserving token order below.
+        lexeme_keys = tuple(sorted({surface.casefold() for surface, _, _ in tokens}))
+        if lexeme_keys:
+            cursor.executemany(
                 """
                 INSERT INTO language.lexeme
                     (language_ref, normalized_text, lexical_kind_ref)
                 VALUES (%s, %s, %s)
-                ON CONFLICT (language_ref, normalized_text, lexical_kind_ref)
-                DO UPDATE SET normalized_text = EXCLUDED.normalized_text
-                RETURNING lexeme_id
+                ON CONFLICT (language_ref, normalized_text, lexical_kind_ref) DO NOTHING
                 """,
-                (language_ref, surface.casefold(), lexical_kind_ref),
+                [(language_ref, key, lexical_kind_ref) for key in lexeme_keys],
             )
-            lexeme_ids.append(int(cursor.fetchone()[0]))
+            cursor.execute(
+                """
+                SELECT normalized_text, lexeme_id
+                FROM language.lexeme
+                WHERE language_ref = %s AND lexical_kind_ref = %s
+                  AND normalized_text = ANY(%s)
+                """,
+                (language_ref, lexical_kind_ref, list(lexeme_keys)),
+            )
+            lexeme_by_key = {str(row[0]): int(row[1]) for row in cursor.fetchall()}
+            if len(lexeme_by_key) != len(lexeme_keys):
+                raise RuntimeError("lexeme batch did not return every requested key")
+        else:
+            lexeme_by_key = {}
+        lexeme_ids: list[int] = []
+        starts: list[int] = []
+        ends: list[int] = []
+        for surface, start, end in tokens:
+            lexeme_ids.append(lexeme_by_key[surface.casefold()])
             starts.append(start)
             ends.append(end)
         output_sha = _stable_bytes(

--- a/src/storage/postgres/legal_source_store.py
+++ b/src/storage/postgres/legal_source_store.py
@@ -1,0 +1,343 @@
+"""Durable source admission, legal-source selection, and parity receipts."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, Mapping, Sequence
+
+from src.pnf.legal_adjunct import (
+    LegalSourcePlan,
+    NormativeInteractionDemand,
+    PersistedLegalSource,
+)
+from src.policy.carriers.canonical import canonical_sha256
+from src.sources.admission import SourceAdmissionReceipt
+
+
+def _json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha(value: object) -> bytes:
+    return bytes.fromhex(canonical_sha256(value))
+
+
+def persist_source_admission_receipts(
+    cursor: Any,
+    *,
+    corpus_ref: str,
+    receipts: Iterable[SourceAdmissionReceipt | Mapping[str, Any]],
+) -> tuple[str, ...]:
+    rows: list[tuple[Any, ...]] = []
+    refs: list[str] = []
+    for value in receipts:
+        payload = value.to_dict() if isinstance(value, SourceAdmissionReceipt) else dict(value)
+        refs.append(str(payload["receipt_ref"]))
+        rows.append(
+            (
+                payload["receipt_ref"],
+                corpus_ref,
+                payload["source_revision_ref"],
+                payload["source_role"],
+                payload["semantic_scope"],
+                payload["admission_state"],
+                payload.get("exclusion_reason"),
+                payload["profile_ref"],
+                payload.get("contract_ref") or "source-admission:v0_2",
+                _sha(payload),
+            )
+        )
+    if rows:
+        cursor.executemany(
+            """
+            INSERT INTO source_admission_receipt
+                (receipt_ref, corpus_ref, source_revision_ref, source_role,
+                 semantic_scope, admission_state, exclusion_reason, profile_ref,
+                 contract_ref, receipt_sha256)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (receipt_ref) DO NOTHING
+            """,
+            rows,
+        )
+    return tuple(sorted(set(refs)))
+
+
+def persist_legal_source_revision(
+    cursor: Any,
+    source: PersistedLegalSource | Mapping[str, Any],
+) -> str:
+    payload = source.to_dict() if isinstance(source, PersistedLegalSource) else dict(source)
+    cursor.execute(
+        """
+        INSERT INTO legal_source_revision
+            (source_revision_ref, document_ref, admission_receipt_ref,
+             acquisition_receipt_ref, jurisdiction_ref, source_role,
+             authority_level, temporal_refs, provider_profile_refs, media_type,
+             canonical_text_sha256, compile_eligible, revision_sha256)
+        VALUES
+            (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s::jsonb,
+             %s, %s, TRUE, %s)
+        ON CONFLICT (source_revision_ref) DO NOTHING
+        """,
+        (
+            payload["source_revision_ref"],
+            payload["document_ref"],
+            payload["admission_receipt_ref"],
+            payload.get("acquisition_receipt_ref"),
+            payload["jurisdiction_ref"],
+            payload["source_role"],
+            payload["authority_level"],
+            _json(payload.get("temporal_refs") or ()),
+            _json(payload.get("provider_profile_refs") or ()),
+            payload.get("media_type") or "text/plain",
+            payload["canonical_text_sha256"],
+            _sha(payload),
+        ),
+    )
+    return str(payload["source_revision_ref"])
+
+
+def load_compatible_legal_sources(
+    cursor: Any,
+    demand: NormativeInteractionDemand,
+) -> tuple[PersistedLegalSource, ...]:
+    """Load only persisted revisions compatible with an explicit legal demand."""
+
+    cursor.execute(
+        """
+        SELECT source_revision_ref, document_ref, admission_receipt_ref,
+               acquisition_receipt_ref, jurisdiction_ref, source_role,
+               authority_level, temporal_refs, provider_profile_refs, media_type,
+               canonical_text_sha256, compile_eligible
+        FROM legal_source_revision
+        WHERE compile_eligible = TRUE
+          AND jurisdiction_ref = ANY(%s)
+          AND source_role = ANY(%s)
+          AND authority_level = ANY(%s)
+        ORDER BY source_revision_ref
+        """,
+        (
+            list(demand.jurisdiction_refs),
+            list(demand.source_role_refs),
+            list(demand.authority_level_refs),
+        ),
+    )
+    rows = []
+    for row in cursor.fetchall():
+        temporal_refs = tuple(str(value) for value in (row[7] or ()))
+        provider_refs = tuple(str(value) for value in (row[8] or ()))
+        if demand.temporal_refs and temporal_refs and not set(demand.temporal_refs).intersection(temporal_refs):
+            continue
+        if demand.provider_profile_refs and not set(demand.provider_profile_refs).intersection(provider_refs):
+            continue
+        rows.append(
+            PersistedLegalSource(
+                source_revision_ref=str(row[0]),
+                document_ref=str(row[1]),
+                admission_receipt_ref=str(row[2]),
+                acquisition_receipt_ref=str(row[3]) if row[3] else None,
+                jurisdiction_ref=str(row[4]),
+                source_role=str(row[5]),
+                authority_level=str(row[6]),
+                temporal_refs=temporal_refs,
+                provider_profile_refs=provider_refs,
+                media_type=str(row[9]),
+                canonical_text_sha256=str(row[10]),
+                compile_eligible=bool(row[11]),
+            )
+        )
+    return tuple(rows)
+
+
+def load_legal_source_payload(
+    cursor: Any,
+    *,
+    source_revision_ref: str,
+) -> Mapping[str, Any] | None:
+    """Read the canonical payload attached to one registered source revision."""
+
+    cursor.execute(
+        """
+        SELECT l.source_revision_ref, l.document_ref, l.media_type,
+               l.canonical_text_sha256, convert_from(c.payload, 'UTF8')
+        FROM legal_source_revision AS l
+        JOIN corpus.document AS d ON d.document_ref = l.document_ref
+        JOIN corpus.canonical_content AS c ON c.canonical_ref = d.canonical_ref
+        WHERE l.source_revision_ref = %s AND l.compile_eligible = TRUE
+        """,
+        (source_revision_ref,),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return None
+    return {
+        "source_revision_ref": str(row[0]),
+        "document_ref": str(row[1]),
+        "media_type": str(row[2]),
+        "canonical_text_sha256": str(row[3]),
+        "canonical_text": str(row[4]),
+    }
+
+
+def persist_legal_source_plans(
+    cursor: Any,
+    plans: Sequence[LegalSourcePlan],
+) -> tuple[str, ...]:
+    rows = []
+    refs = []
+    for plan in plans:
+        payload = plan.to_dict()
+        plan_ref = "legal-source-plan:" + canonical_sha256(payload)
+        refs.append(plan_ref)
+        rows.append(
+            (
+                plan_ref,
+                plan.demand_ref,
+                plan.plan_key,
+                plan.state,
+                _json(plan.selected_source_revision_refs),
+                _json(plan.blocked_reasons),
+                _sha(payload),
+            )
+        )
+    if rows:
+        cursor.executemany(
+            """
+            INSERT INTO legal_source_plan_receipt
+                (plan_ref, demand_ref, plan_key, state,
+                 selected_source_revision_refs, blocked_reasons, plan_sha256)
+            VALUES (%s, %s, %s, %s, %s::jsonb, %s::jsonb, %s)
+            ON CONFLICT (plan_ref) DO NOTHING
+            """,
+            rows,
+        )
+    return tuple(sorted(refs))
+
+
+def persist_governed_acquisition_receipt(
+    cursor: Any,
+    receipt: Mapping[str, Any],
+) -> str:
+    cursor.execute(
+        """
+        INSERT INTO governed_acquisition_receipt
+            (receipt_ref, request_ref, operator_authorization_ref,
+             provider_profile_ref, requested_url, final_url,
+             source_revision_ref, content_sha256, media_type, byte_count,
+             state, failure_reason, receipt_sha256)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (receipt_ref) DO NOTHING
+        """,
+        (
+            receipt["receipt_ref"],
+            receipt["request_ref"],
+            receipt["operator_authorization_ref"],
+            receipt["provider_profile_ref"],
+            receipt["requested_url"],
+            receipt.get("final_url"),
+            receipt.get("source_revision_ref"),
+            receipt.get("content_sha256"),
+            receipt.get("media_type"),
+            int(receipt.get("byte_count") or 0),
+            receipt["state"],
+            receipt.get("failure_reason"),
+            _sha(receipt),
+        ),
+    )
+    return str(receipt["receipt_ref"])
+
+
+def persist_transaction_attempt(
+    cursor: Any,
+    *,
+    document_ref: str,
+    build_key_sha256: str,
+    attempt_no: int,
+    state: str,
+    sqlstate: str | None,
+    retry_delay_ms: int,
+    worker_ref: str,
+) -> str:
+    payload = {
+        "document_ref": document_ref,
+        "build_key_sha256": build_key_sha256,
+        "attempt_no": attempt_no,
+        "state": state,
+        "sqlstate": sqlstate,
+        "retry_delay_ms": retry_delay_ms,
+        "worker_ref": worker_ref,
+    }
+    attempt_ref = "document-transaction-attempt:" + canonical_sha256(payload)
+    cursor.execute(
+        """
+        INSERT INTO execution_document_transaction_attempt
+            (attempt_ref, document_ref, build_key_sha256, attempt_no, state,
+             sqlstate, retry_delay_ms, worker_ref, telemetry_sha256)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (attempt_ref) DO NOTHING
+        """,
+        (
+            attempt_ref,
+            document_ref,
+            build_key_sha256,
+            attempt_no,
+            state,
+            sqlstate,
+            retry_delay_ms,
+            worker_ref,
+            _sha(payload),
+        ),
+    )
+    return attempt_ref
+
+
+def persist_parity_receipt(cursor: Any, receipt: Mapping[str, Any]) -> str:
+    cursor.execute(
+        """
+        INSERT INTO curated_legal_ir_parity_receipt
+            (receipt_ref, corpus_ref, admission_profile_ref,
+             compiler_contract_ref, source_revision_refs, ordinary_graph_refs,
+             legal_graph_refs, demand_refs, plan_refs, legal_ir_refs,
+             typed_meet_refs, legacy_witness_refs, identity_snapshot,
+             control_snapshot, identity_parity, network_attempt_count,
+             unexpected_failure_refs, receipt_sha256)
+        VALUES
+            (%s, %s, %s, %s, %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb,
+             %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb,
+             %s::jsonb, %s, %s, %s::jsonb, %s)
+        ON CONFLICT (receipt_ref) DO NOTHING
+        """,
+        (
+            receipt["receipt_ref"],
+            receipt["corpus_ref"],
+            receipt["admission_profile_ref"],
+            receipt["compiler_contract_ref"],
+            _json(receipt.get("source_revision_refs") or ()),
+            _json(receipt.get("ordinary_graph_refs") or ()),
+            _json(receipt.get("legal_graph_refs") or ()),
+            _json(receipt.get("demand_refs") or ()),
+            _json(receipt.get("plan_refs") or ()),
+            _json(receipt.get("legal_ir_refs") or ()),
+            _json(receipt.get("typed_meet_refs") or ()),
+            _json(receipt.get("legacy_witness_refs") or ()),
+            _json(receipt["identity_snapshot"]),
+            _json(receipt["control_snapshot"]) if receipt.get("control_snapshot") is not None else None,
+            receipt.get("identity_parity"),
+            int(receipt.get("network_attempt_count") or 0),
+            _json(receipt.get("unexpected_failure_refs") or ()),
+            _sha(receipt),
+        ),
+    )
+    return str(receipt["receipt_ref"])
+
+
+__all__ = [
+    "load_compatible_legal_sources",
+    "load_legal_source_payload",
+    "persist_governed_acquisition_receipt",
+    "persist_legal_source_plans",
+    "persist_legal_source_revision",
+    "persist_parity_receipt",
+    "persist_source_admission_receipts",
+    "persist_transaction_attempt",
+]

--- a/src/storage/postgres/legal_source_store.py
+++ b/src/storage/postgres/legal_source_store.py
@@ -5,11 +5,8 @@ from __future__ import annotations
 import json
 from typing import Any, Iterable, Mapping, Sequence
 
-from src.pnf.legal_adjunct import (
-    LegalSourcePlan,
-    NormativeInteractionDemand,
-    PersistedLegalSource,
-)
+from src.pnf.legal_adjunct import LegalSourcePlan, NormativeInteractionDemand
+from src.pnf.legal_source_registry import RegisteredLegalSource
 from src.policy.carriers.canonical import canonical_sha256
 from src.sources.admission import SourceAdmissionReceipt
 
@@ -64,9 +61,9 @@ def persist_source_admission_receipts(
 
 def persist_legal_source_revision(
     cursor: Any,
-    source: PersistedLegalSource | Mapping[str, Any],
+    source: RegisteredLegalSource | Mapping[str, Any],
 ) -> str:
-    payload = source.to_dict() if isinstance(source, PersistedLegalSource) else dict(source)
+    payload = source.to_dict() if isinstance(source, RegisteredLegalSource) else dict(source)
     cursor.execute(
         """
         INSERT INTO legal_source_revision
@@ -100,9 +97,11 @@ def persist_legal_source_revision(
 def load_compatible_legal_sources(
     cursor: Any,
     demand: NormativeInteractionDemand,
-) -> tuple[PersistedLegalSource, ...]:
+) -> tuple[RegisteredLegalSource, ...]:
     """Load only persisted revisions compatible with an explicit legal demand."""
 
+    if not demand.acquisition_ready:
+        return ()
     cursor.execute(
         """
         SELECT source_revision_ref, document_ref, admission_receipt_ref,
@@ -122,16 +121,23 @@ def load_compatible_legal_sources(
             list(demand.authority_level_refs),
         ),
     )
-    rows = []
+    rows: list[RegisteredLegalSource] = []
     for row in cursor.fetchall():
         temporal_refs = tuple(str(value) for value in (row[7] or ()))
         provider_refs = tuple(str(value) for value in (row[8] or ()))
-        if demand.temporal_refs and temporal_refs and not set(demand.temporal_refs).intersection(temporal_refs):
+        if (
+            demand.temporal_refs
+            and temporal_refs
+            and not set(demand.temporal_refs).intersection(temporal_refs)
+        ):
             continue
-        if demand.provider_profile_refs and not set(demand.provider_profile_refs).intersection(provider_refs):
+        if (
+            demand.provider_profile_refs
+            and not set(demand.provider_profile_refs).intersection(provider_refs)
+        ):
             continue
         rows.append(
-            PersistedLegalSource(
+            RegisteredLegalSource(
                 source_revision_ref=str(row[0]),
                 document_ref=str(row[1]),
                 admission_receipt_ref=str(row[2]),
@@ -154,8 +160,6 @@ def load_legal_source_payload(
     *,
     source_revision_ref: str,
 ) -> Mapping[str, Any] | None:
-    """Read the canonical payload attached to one registered source revision."""
-
     cursor.execute(
         """
         SELECT l.source_revision_ref, l.document_ref, l.media_type,
@@ -321,7 +325,11 @@ def persist_parity_receipt(cursor: Any, receipt: Mapping[str, Any]) -> str:
             _json(receipt.get("typed_meet_refs") or ()),
             _json(receipt.get("legacy_witness_refs") or ()),
             _json(receipt["identity_snapshot"]),
-            _json(receipt["control_snapshot"]) if receipt.get("control_snapshot") is not None else None,
+            (
+                _json(receipt["control_snapshot"])
+                if receipt.get("control_snapshot") is not None
+                else None
+            ),
             receipt.get("identity_parity"),
             int(receipt.get("network_attempt_count") or 0),
             _json(receipt.get("unexpected_failure_refs") or ()),

--- a/src/storage/postgres/proposal_parent_store.py
+++ b/src/storage/postgres/proposal_parent_store.py
@@ -1,0 +1,50 @@
+"""Parent-row persistence required before fibred proposal extensions."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Sequence
+
+
+def _json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def persist_factor_proposal_parents(
+    cursor: Any,
+    proposals: Sequence[Mapping[str, Any]],
+) -> None:
+    if not proposals:
+        return
+    cursor.executemany(
+        """
+        INSERT INTO pnf_factor_proposal
+            (proposal_ref, proposal_digest, document_ref, source_revision_ref,
+             factor_type_ref, structural_signature, producer_contract,
+             declaration_revision, source_span_refs, input_observation_refs,
+             dependency_factor_refs, role_bindings, qualifier_state,
+             candidate_payload, residuals, authority)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s,
+                %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb, %s::jsonb,
+                %s::jsonb, %s::jsonb, 'candidate_only')
+        ON CONFLICT (proposal_ref) DO NOTHING
+        """,
+        [
+            (
+                row["proposal_ref"], row["proposal_digest"], row["document_ref"],
+                row["source_revision_ref"], row["factor_type_ref"],
+                row["structural_signature"], row["producer_contract"],
+                row["declaration_revision"], _json(row.get("source_span_refs") or ()),
+                _json(row.get("input_observation_refs") or ()),
+                _json(row.get("dependency_factor_refs") or ()),
+                _json(row.get("role_bindings") or {}),
+                _json(row.get("qualifier_state") or {}),
+                _json(row.get("candidate_payload") or {}),
+                _json(row.get("residuals") or ()),
+            )
+            for row in proposals
+        ],
+    )
+
+
+__all__ = ["persist_factor_proposal_parents"]

--- a/src/storage/postgres/stage_timing_store.py
+++ b/src/storage/postgres/stage_timing_store.py
@@ -1,0 +1,64 @@
+"""Direct persistence for execution-only stage timing rows."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, Mapping
+
+
+def _json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def persist_stage_timings(
+    cursor: Any,
+    *,
+    document_ref: str,
+    timings: Iterable[Mapping[str, Any]],
+) -> None:
+    rows = []
+    for timing in timings:
+        rows.append(
+            (
+                str(timing["timing_ref"]),
+                document_ref,
+                str(timing["stage"]),
+                int(timing["ordinal"]),
+                int(timing["elapsed_ms"]),
+                timing.get("backend_ref"),
+                timing.get("input_nodes"),
+                timing.get("output_nodes"),
+                timing.get("input_edges"),
+                timing.get("output_edges"),
+                timing.get("proposals_generated"),
+                timing.get("duplicates_collapsed"),
+                timing.get("invalid_rejected"),
+                timing.get("alternatives_retained"),
+                timing.get("residuals_emitted"),
+                timing.get("tokens_processed"),
+                timing.get("tokens_per_second"),
+                timing.get("reduction_ratio"),
+                timing.get("reduction_efficiency_edges_per_second"),
+                _json(timing.get("details") or {}),
+            )
+        )
+    if rows:
+        cursor.executemany(
+            """
+            INSERT INTO semantic_stage_timing
+                (timing_ref, document_ref, stage, ordinal, elapsed_ms,
+                 backend_ref, input_nodes, output_nodes, input_edges,
+                 output_edges, proposals_generated, duplicates_collapsed,
+                 invalid_rejected, alternatives_retained, residuals_emitted,
+                 tokens_processed, tokens_per_second, reduction_ratio,
+                 reduction_efficiency_edges_per_second, details)
+            VALUES
+                (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                 %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
+            ON CONFLICT (timing_ref) DO NOTHING
+            """,
+            rows,
+        )
+
+
+__all__ = ["persist_stage_timings"]

--- a/tests/pnf/test_curated_legal_ir_flow.py
+++ b/tests/pnf/test_curated_legal_ir_flow.py
@@ -1,0 +1,102 @@
+from src.pnf.curated_legal_ir_flow import run_curated_legal_ir_flow
+from src.pnf.legal_source_registry import RegisteredLegalSource
+
+
+def _graph(document_ref: str, factor_ref: str) -> dict[str, object]:
+    return {
+        "graph_ref": f"graph:{document_ref}",
+        "document_ref": document_ref,
+        "factors": [
+            {
+                "factor_ref": factor_ref,
+                "factor_type": "semantic.normative_relation",
+                "alternatives": [],
+                "constraints": [],
+                "residuals": [],
+                "closure_state": "locally_closed",
+                "metadata": {
+                    "factor_revision_ref": f"revision:{factor_ref}",
+                    "structural_signature_ref": "signature:normative:drive",
+                },
+            }
+        ],
+        "constraints": [],
+        "relation_refs": [],
+        "residuals": [],
+    }
+
+
+def _compilation(document_ref: str, *, legal_demand: bool) -> dict[str, object]:
+    demand = {
+        "demand_ref": "demand:law",
+        "factor_ref": "factor:world",
+        "factor_revision_ref": "revision:factor:world",
+        "structural_signature_ref": "signature:normative:drive",
+        "requested_facets": [
+            "legal.authority_absent",
+            "legal.jurisdiction:AU-QLD",
+            "legal.source_role:primary_legislation",
+            "legal.authority_level:primary",
+        ],
+    }
+    return {
+        "artifacts": {
+            "pnf_graph": _graph(document_ref, f"factor:{document_ref}"),
+            "refined_pnf_graph": _graph(document_ref, f"factor:{document_ref}"),
+            "resolution_demands": [demand] if legal_demand else [],
+            "streaming_semantic_build": {
+                "fibre_ledger_ref": f"ledger:{document_ref}",
+                "proposals": [],
+                "materialized_reduction": {"residuals": []},
+                "fixed_point_certificate": {"local_fixed_point": "reached"},
+            },
+        }
+    }
+
+
+def test_flow_selects_persisted_source_and_never_fetches() -> None:
+    source = RegisteredLegalSource(
+        source_revision_ref="source:act",
+        document_ref="document:act",
+        admission_receipt_ref="admission:act",
+        jurisdiction_ref="AU-QLD",
+        source_role="primary_legislation",
+        authority_level="primary",
+        canonical_text_sha256="a" * 64,
+    )
+    payload_reads = []
+
+    result = run_curated_legal_ir_flow(
+        corpus_ref="corpus:hca",
+        admission_profile_ref="profile:offline-hca-regression:v0_2",
+        compiler_contract_ref="postgres-fibred-semantic-compiler:v0_1",
+        ordinary_compilations=(_compilation("world", legal_demand=True),),
+        source_lookup=lambda demand: (source,),
+        payload_lookup=lambda source_ref: payload_reads.append(source_ref)
+        or {"source_revision_ref": source_ref},
+        compile_legal_source=lambda payload: _compilation("law", legal_demand=False),
+        network_attempt_count=0,
+    )
+
+    assert result.plans[0].state == "ready_persisted"
+    assert result.acquisition_requirements == ()
+    assert payload_reads == ["source:act"]
+    assert result.parity_receipt.network_attempt_count == 0
+    assert result.parity_receipt.to_dict()["legal_truth_closed"] is False
+
+
+def test_flow_preserves_missing_source_as_blocked_requirement() -> None:
+    result = run_curated_legal_ir_flow(
+        corpus_ref="corpus:hca",
+        admission_profile_ref="profile:offline-hca-regression:v0_2",
+        compiler_contract_ref="postgres-fibred-semantic-compiler:v0_1",
+        ordinary_compilations=(_compilation("world", legal_demand=True),),
+        source_lookup=lambda demand: (),
+        payload_lookup=lambda source_ref: (_ for _ in ()).throw(AssertionError(source_ref)),
+        compile_legal_source=lambda payload: (_ for _ in ()).throw(AssertionError(payload)),
+        network_attempt_count=0,
+    )
+
+    assert result.plans[0].state == "blocked_acquisition_required"
+    assert len(result.acquisition_requirements) == 1
+    assert result.legal_compilations == ()

--- a/tests/pnf/test_legal_ir_parity.py
+++ b/tests/pnf/test_legal_ir_parity.py
@@ -1,0 +1,50 @@
+from src.pnf.legal_ir_parity import (
+    CuratedLegalIRParityReceipt,
+    SemanticIdentitySnapshot,
+    compare_identity_snapshots,
+)
+
+
+def test_identity_parity_ignores_execution_telemetry_by_construction() -> None:
+    control = SemanticIdentitySnapshot(
+        proposal_refs=("proposal:1",),
+        factor_refs=("factor:1",),
+        graph_refs=("graph:1",),
+        fibre_ledger_refs=("ledger:1",),
+    )
+    candidate = SemanticIdentitySnapshot(
+        factor_refs=("factor:1",),
+        proposal_refs=("proposal:1",),
+        fibre_ledger_refs=("ledger:1",),
+        graph_refs=("graph:1",),
+    )
+
+    parity = compare_identity_snapshots(control, candidate)
+    assert parity.identical is True
+    assert parity.added_refs == {}
+    assert parity.removed_refs == {}
+
+
+def test_parity_receipt_never_promotes_legal_truth() -> None:
+    snapshot = SemanticIdentitySnapshot(graph_refs=("graph:1",))
+    receipt = CuratedLegalIRParityReceipt(
+        corpus_ref="corpus:1",
+        admission_profile_ref="profile:offline-hca-regression:v0_2",
+        compiler_contract_ref="postgres-fibred-semantic-compiler:v0_1",
+        source_revision_refs=("source:1",),
+        ordinary_graph_refs=("graph:1",),
+        legal_graph_refs=(),
+        demand_refs=("demand:1",),
+        plan_refs=("plan:1",),
+        legal_ir_refs=(),
+        typed_meet_refs=(),
+        legacy_witness_refs=(),
+        identity_snapshot=snapshot.to_dict(),
+        control_snapshot=None,
+        identity_parity=None,
+        network_attempt_count=0,
+    )
+    payload = receipt.to_dict()
+    assert payload["semantic_state_promoted"] is False
+    assert payload["applicability_closed"] is False
+    assert payload["legal_truth_closed"] is False

--- a/tests/pnf/test_legal_persisted_selection.py
+++ b/tests/pnf/test_legal_persisted_selection.py
@@ -1,0 +1,37 @@
+from src.pnf.legal_adjunct import (
+    PersistedLegalSource,
+    plan_legal_sources,
+    project_acquisition_requirements,
+    project_normative_interaction_demands,
+)
+
+
+def test_legal_plan_selects_persisted_authority_or_remains_blocked() -> None:
+    demands = project_normative_interaction_demands(
+        (
+            {
+                "demand_ref": "demand:drive",
+                "factor_revision_ref": "revision:1",
+                "structural_signature_ref": "signature:1",
+                "requested_facets": (
+                    "legal.relevance_unresolved",
+                    "legal.jurisdiction:AU",
+                    "legal.source_role:primary_legislation",
+                    "legal.authority_level:official",
+                ),
+            },
+        )
+    )
+    blocked = plan_legal_sources(demands)
+    assert blocked[0].state == "blocked_acquisition_required"
+    assert project_acquisition_requirements(blocked)[0].demand_ref == "demand:drive"
+    ready = plan_legal_sources(
+        demands,
+        (
+            PersistedLegalSource(
+                "revision:act", "AU", "primary_legislation", "official"
+            ),
+        ),
+    )
+    assert ready[0].state == "ready_persisted"
+    assert ready[0].selected_source_revision_refs == ("revision:act",)

--- a/tests/pnf/test_reducer_partition_metrics.py
+++ b/tests/pnf/test_reducer_partition_metrics.py
@@ -1,0 +1,56 @@
+from dataclasses import replace
+
+from src.pnf.factor_proposals import FactorProposal, reduce_factor_proposals
+
+
+def _proposal(index: int, *, scope: str) -> FactorProposal:
+    return FactorProposal(
+        document_ref="document:partition-test",
+        source_revision_ref="source:1",
+        factor_type_ref="semantic.entity_link",
+        source_span_refs=(scope,),
+        input_observation_refs=(),
+        dependency_factor_refs=(),
+        structural_signature="entity-link:v1",
+        role_bindings={"mention": f"mention:{index}"},
+        qualifier_state={},
+        producer_contract="linker:test:v1",
+        declaration_revision="v1",
+        candidate_payload={"target_ref": f"wd:Q{index}"},
+        scope_ref=scope,
+    )
+
+
+def test_partitioning_avoids_cross_fibre_comparisons_without_identity_drift() -> None:
+    proposals = tuple(_proposal(index, scope=f"span:{index}") for index in range(6))
+    forward = reduce_factor_proposals(
+        document_ref="document:partition-test",
+        proposals=proposals,
+    )
+    reverse = reduce_factor_proposals(
+        document_ref="document:partition-test",
+        proposals=tuple(reversed(proposals)),
+    )
+
+    assert forward.graph_ref == reverse.graph_ref
+    assert forward.metrics["bucket_count"] == 6
+    assert forward.metrics["largest_bucket"] == 1
+    assert forward.metrics["candidate_comparisons"] == 0
+    assert forward.metrics["comparison_avoidance_ratio"] == 1.0
+
+
+def test_execution_metrics_do_not_enter_graph_identity() -> None:
+    first = _proposal(1, scope="span:1")
+    second = replace(first, execution_metadata={"backend": "zelph"})
+    left = reduce_factor_proposals(
+        document_ref=first.document_ref,
+        proposals=(first,),
+    )
+    right = reduce_factor_proposals(
+        document_ref=second.document_ref,
+        proposals=(second,),
+    )
+
+    assert first.proposal_ref == second.proposal_ref
+    assert left.graph_ref == right.graph_ref
+    assert left.to_dict()["metrics"] == right.to_dict()["metrics"]

--- a/tests/policy/test_fibred_operational_corpus_compilation.py
+++ b/tests/policy/test_fibred_operational_corpus_compilation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from src.pnf.factor_proposals import FactorProposal, reduce_factor_proposals
 from src.policy import fibred_operational_corpus_compilation as module
+from src.policy.algebra import factor_revision_ref
 from src.policy.corpus_compilation import DocumentCompilation, default_compiler_context
 
 
@@ -114,6 +115,7 @@ def test_fibred_wrapper_replaces_existing_compatibility_coordinate(
     assert factor["metadata"]["fibre_summary_ref"] == (
         reduction.factors[0].factor_ref
     )
+    assert factor_revision_ref(factor) == factor["metadata"]["factor_revision_ref"]
     assert receipt["replaced_factor_count"] == 1
     assert receipt["added_factor_count"] == 0
     assert artifacts["factor_refinements"] == []

--- a/tests/policy/test_fibred_operational_corpus_compilation.py
+++ b/tests/policy/test_fibred_operational_corpus_compilation.py
@@ -150,6 +150,9 @@ def test_fibred_wrapper_adds_new_higher_order_coordinate(monkeypatch) -> None:
         fibre_kind="composition",
     )
     base, reduction = _base_compilation(proposal)
+    base.artifacts["pnf_graph"]["factors"][0]["metadata"] = {
+        "factor_revision_ref": "factor-revision:stale"
+    }
     compilation = _compile(monkeypatch, base)
     artifacts = compilation.artifacts
     factors = artifacts["pnf_graph"]["factors"]
@@ -160,5 +163,9 @@ def test_fibred_wrapper_adds_new_higher_order_coordinate(monkeypatch) -> None:
         row for row in factors if row["factor_ref"] == reduction.factors[0].factor_ref
     )
     assert added["metadata"]["fibre_summary_ref"] == added["factor_ref"]
+    assert all(
+        factor_revision_ref(row) == row["metadata"]["factor_revision_ref"]
+        for row in factors
+    )
     assert receipt["added_factor_count"] == 1
     assert receipt["replaced_factor_count"] == 0

--- a/tests/policy/test_fibred_operational_corpus_compilation.py
+++ b/tests/policy/test_fibred_operational_corpus_compilation.py
@@ -77,6 +77,11 @@ def _compile(monkeypatch, base: DocumentCompilation) -> DocumentCompilation:
 def test_fibred_wrapper_replaces_existing_compatibility_coordinate(
     monkeypatch,
 ) -> None:
+    monkeypatch.setattr(
+        module,
+        "derive_resolution_demands",
+        lambda graph: ({"demand_ref": "demand:1", "graph_ref": graph.graph_ref},),
+    )
     proposal = FactorProposal(
         document_ref="document:1",
         source_revision_ref="source:1",
@@ -121,6 +126,8 @@ def test_fibred_wrapper_replaces_existing_compatibility_coordinate(
     assert artifacts["phase_boundary"][
         "constraints_after_fibre_materialisation"
     ] is True
+    assert artifacts["resolution_demands"]
+    assert all(isinstance(row, dict) for row in artifacts["resolution_demands"])
 
 
 def test_fibred_wrapper_adds_new_higher_order_coordinate(monkeypatch) -> None:

--- a/tests/policy/test_operational_corpus_compilation.py
+++ b/tests/policy/test_operational_corpus_compilation.py
@@ -36,7 +36,9 @@ def test_operational_compiler_never_materializes_pairwise_binding(monkeypatch) -
     assert compilation.artifacts["reference_binding_operational_contract"] == (
         REFERENCE_BINDING_CONTRACT_REF
     )
-    assert OPERATIONAL_COMPILER_CONTRACT == "postgres-semantic-compiler:v0_8"
+    assert compilation.artifacts["operational_compiler_contract"] == (
+        OPERATIONAL_COMPILER_CONTRACT
+    )
     assert compilation.artifacts["binding_candidate_sets"]
     assert not any(
         row["evidence_type"] == "typed_binding_candidate"
@@ -70,7 +72,7 @@ def test_operational_html_uses_one_canonical_coordinate_system() -> None:
     canonical_text = artifacts["canonical_text"]
     canonical_sha256 = hashlib.sha256(canonical_text.encode("utf-8")).hexdigest()
 
-    assert OPERATIONAL_COMPILER_CONTRACT == "postgres-semantic-compiler:v0_8"
+    assert artifacts["operational_compiler_contract"] == OPERATIONAL_COMPILER_CONTRACT
     assert artifacts["reference_binding_operational_contract"] == (
         REFERENCE_BINDING_CONTRACT_REF
     )

--- a/tests/runtime/test_offline_network_guard.py
+++ b/tests/runtime/test_offline_network_guard.py
@@ -8,7 +8,7 @@ from src.runtime.offline_network_guard import (
 )
 
 
-def test_offline_guard_records_and_rejects_network_attempts() -> None:
+def test_offline_guard_records_and_rejects_external_attempts() -> None:
     guard = OfflineNetworkGuard()
     with pytest.raises(OfflineNetworkViolation):
         with guard:
@@ -16,7 +16,7 @@ def test_offline_guard_records_and_rejects_network_attempts() -> None:
 
     receipt = guard.receipt.to_dict()
     assert receipt["network_attempt_count"] == 1
-    assert receipt["network_absent"] is False
+    assert receipt["external_network_absent"] is False
 
 
 def test_offline_guard_certifies_pure_local_work() -> None:
@@ -26,4 +26,4 @@ def test_offline_guard_certifies_pure_local_work() -> None:
 
     receipt = guard.receipt.to_dict()
     assert receipt["network_attempt_count"] == 0
-    assert receipt["network_absent"] is True
+    assert receipt["external_network_absent"] is True

--- a/tests/runtime/test_offline_network_guard.py
+++ b/tests/runtime/test_offline_network_guard.py
@@ -1,0 +1,29 @@
+import socket
+
+import pytest
+
+from src.runtime.offline_network_guard import (
+    OfflineNetworkGuard,
+    OfflineNetworkViolation,
+)
+
+
+def test_offline_guard_records_and_rejects_network_attempts() -> None:
+    guard = OfflineNetworkGuard()
+    with pytest.raises(OfflineNetworkViolation):
+        with guard:
+            socket.create_connection(("example.test", 443))
+
+    receipt = guard.receipt.to_dict()
+    assert receipt["network_attempt_count"] == 1
+    assert receipt["network_absent"] is False
+
+
+def test_offline_guard_certifies_pure_local_work() -> None:
+    guard = OfflineNetworkGuard()
+    with guard:
+        assert sorted([3, 1, 2]) == [1, 2, 3]
+
+    receipt = guard.receipt.to_dict()
+    assert receipt["network_attempt_count"] == 0
+    assert receipt["network_absent"] is True

--- a/tests/sources/test_admission.py
+++ b/tests/sources/test_admission.py
@@ -1,7 +1,11 @@
-from src.sources.admission import OFFLINE_HCA_REGRESSION_PROFILE, classify_catalogue
+from src.sources.admission import (
+    OFFLINE_HCA_REGRESSION_PROFILE,
+    admission_manifest,
+    classify_catalogue,
+)
 
 
-def test_hca_profile_excludes_transport_artifacts_before_parser_admission() -> None:
+def test_hca_profile_keeps_transport_as_evidence_but_out_of_parser() -> None:
     receipts = classify_catalogue(
         (
             {
@@ -14,14 +18,25 @@ def test_hca_profile_excludes_transport_artifacts_before_parser_admission() -> N
                 "source_revision_ref": "source:recording",
                 "source_role": "recording_page",
             },
+            {
+                "source_revision_ref": "source:duplicate",
+                "source_role": "duplicate_caption",
+            },
+            {"source_revision_ref": "source:unknown", "source_role": "unknown"},
         ),
         profile=OFFLINE_HCA_REGRESSION_PROFILE,
     )
     assert [row.source_revision_ref for row in receipts if row.compile_eligible] == [
         "source:transcript"
     ]
-    assert {row.exclusion_reason for row in receipts if not row.compile_eligible} == {
-        "search_not_substantive",
-        "oembed_not_substantive",
-        "recording_page_not_transcript_media",
-    }
+    assert {
+        row.source_revision_ref for row in receipts if row.admission_state == "evidence_only"
+    } == {"source:search", "source:oembed", "source:recording"}
+    assert {
+        row.source_revision_ref for row in receipts if row.admission_state == "exclude"
+    } == {"source:duplicate", "source:unknown"}
+
+    manifest = admission_manifest(receipts)
+    assert manifest["counts"] == {"compile": 1, "evidence_only": 3, "exclude": 2}
+    assert manifest["parser_admitted_revision_refs"] == ["source:transcript"]
+    assert manifest["network_activity_permitted"] is False

--- a/tests/sources/test_admission.py
+++ b/tests/sources/test_admission.py
@@ -1,0 +1,27 @@
+from src.sources.admission import OFFLINE_HCA_REGRESSION_PROFILE, classify_catalogue
+
+
+def test_hca_profile_excludes_transport_artifacts_before_parser_admission() -> None:
+    receipts = classify_catalogue(
+        (
+            {
+                "source_revision_ref": "source:transcript",
+                "source_role": "hearing_transcript",
+            },
+            {"source_revision_ref": "source:search", "source_role": "search"},
+            {"source_revision_ref": "source:oembed", "source_role": "oembed"},
+            {
+                "source_revision_ref": "source:recording",
+                "source_role": "recording_page",
+            },
+        ),
+        profile=OFFLINE_HCA_REGRESSION_PROFILE,
+    )
+    assert [row.source_revision_ref for row in receipts if row.compile_eligible] == [
+        "source:transcript"
+    ]
+    assert {row.exclusion_reason for row in receipts if not row.compile_eligible} == {
+        "search_not_substantive",
+        "oembed_not_substantive",
+        "recording_page_not_transcript_media",
+    }

--- a/tests/sources/test_governed_acquisition.py
+++ b/tests/sources/test_governed_acquisition.py
@@ -1,0 +1,72 @@
+from src.sources.governed_acquisition import (
+    AcquisitionPolicy,
+    AcquisitionRequest,
+    FetchedSource,
+    acquire_legal_source,
+)
+
+
+def test_acquisition_requires_explicit_policy_and_returns_candidate_revision() -> None:
+    request = AcquisitionRequest(
+        requested_url="https://example.test/act.txt",
+        operator_authorization_ref="operator-authorization:1",
+        provider_profile_ref="provider:test:v1",
+        source_role="primary_legislation",
+        jurisdiction_ref="AU-QLD",
+        authority_level="primary",
+    )
+    policy = AcquisitionPolicy(
+        provider_profile_ref="provider:test:v1",
+        allowed_hosts=("example.test",),
+        maximum_bytes=1024,
+        allowed_media_types=("text/plain",),
+    )
+
+    receipt, payload = acquire_legal_source(
+        request,
+        policy=policy,
+        fetch=lambda url, limit: FetchedSource(
+            final_url=url,
+            media_type="text/plain",
+            raw_bytes=b"A person must stop.",
+            canonical_text="A person must stop.",
+        ),
+    )
+
+    assert receipt.state == "persisted"
+    assert receipt.operator_authorization_ref == "operator-authorization:1"
+    assert payload is not None
+    assert payload["source_revision_ref"] == receipt.source_revision_ref
+    assert receipt.to_dict()["semantic_state_promoted"] is False
+    assert receipt.to_dict()["legal_truth_closed"] is False
+
+
+def test_acquisition_rejects_unapproved_host_without_fetching() -> None:
+    calls = 0
+
+    def fetch(url: str, limit: int) -> FetchedSource:
+        nonlocal calls
+        calls += 1
+        raise AssertionError((url, limit))
+
+    request = AcquisitionRequest(
+        requested_url="https://other.test/act.txt",
+        operator_authorization_ref="operator-authorization:1",
+        provider_profile_ref="provider:test:v1",
+        source_role="primary_legislation",
+        jurisdiction_ref="AU-QLD",
+        authority_level="primary",
+    )
+    policy = AcquisitionPolicy(
+        provider_profile_ref="provider:test:v1",
+        allowed_hosts=("example.test",),
+        maximum_bytes=1024,
+    )
+
+    try:
+        acquire_legal_source(request, policy=policy, fetch=fetch)
+    except ValueError as error:
+        assert "outside the acquisition policy" in str(error)
+    else:
+        raise AssertionError("unapproved host must fail before fetching")
+    assert calls == 0


### PR DESCRIPTION
## Summary

Completes the curated Legal-IR tranche from the fast-forward admission revision rather than creating a second semantic compiler.

The branch currently includes:

- reconciliation of the curated admission revision onto the `main` lineage;
- ternary source admission (`compile`, `evidence_only`, `exclude`);
- durable admission, legal-source registry, acquisition, retry, and parity receipts;
- explicit operator-authorised bounded acquisition separate from normal builds;
- external-network absence guard with declared local-service allowances;
- fibre-signature prepartitioning and reducer efficiency metrics outside semantic identity;
- batched token/codec, graph/revision, resolution, streaming receipt, and fibre-ledger stores;
- nested PostgreSQL persistence stage timings;
- whole-document retry telemetry for deadlock/serialization failures;
- persisted-source-only Legal IR orchestration and blocked acquisition requirements;
- stale compiler-contract regression repair;
- focused regression tests.

## Authority boundaries

- admission is catalogue policy, not legal interpretation;
- repository/search/landing records remain evidence-only;
- normal compilation has no acquisition operation;
- selected legal sources are retrieval-compatible candidates, not applicable law;
- legacy witnesses remain diagnostic;
- identity, applicability, breach, liability, and legal truth remain open.

## Remaining commits on this PR

The offline catalogue entrypoint, explicit acquisition CLI, parity CLI, documentation, and hosted PostgreSQL workflow are being added to this same branch before merge.