### PR TITLE
Document and enforce runtime authority surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,17 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-Python orchestration lives under `src/` (`sensiblaw`, `sensiblaw_streamlit`, `fastapi`, and `pydantic` packages) with shared utilities in `scripts/` and CLI-ready entry points in `sensiblaw/`. UI assets and experimental dashboards sit in `sensiblaw_streamlit/` and `ui/`, while legal corpora and fixtures reside in `data/` and `examples/`. Keep unit tests in the parallel `tests/` tree; reuse fixtures in `tests/fixtures/` and seeded payloads in `tests/templates/`. Design notes, automation walkthroughs, and deep dives belong in `docs/`.
+Python orchestration lives under `src/`, with the installed product package in
+`src/sensiblaw` and the single source-tree CLI gateway at `src/cli.py`. The
+top-level `cli/` package is internal command implementation, not another
+entrypoint. Repository-root `sensiblaw/`, `fastapi*`, and `pydantic*` paths are
+compatibility or test-shadow debt and must not receive new product behavior.
+Shared utilities live under `scripts/`, but durable operator workflows should
+converge on the CLI gateway. UI assets and experimental dashboards sit in
+`sensiblaw_streamlit/` and `ui/`, while legal corpora and fixtures reside in
+`data/` and `examples/`. Keep unit tests in the parallel `tests/` tree; reuse
+fixtures in `tests/fixtures/` and seeded payloads in `tests/templates/`.
+Design notes, automation walkthroughs, and deep dives belong in `docs/`.
 
 ## Required Reading
 Before writing code, read:
@@ -9,6 +19,7 @@ Before writing code, read:
 - `README.md`
 - `docs/itir_vs_sl.md`
 - `docs/implementation_style_guide.md`
+- `docs/authority_surfaces.md`
 
 Do not start from generic Python repo habits alone. SensibLaw follows ITIR
 style rules that prefer a generic data-in/world-model-out product surface and
@@ -16,6 +27,19 @@ treat lane modules as demos or compatibility shims.
 
 Hard rules:
 
+- `src.cli:main` is the single source-tree CLI gateway. Invoke it with
+  `python -m src.cli`; do not add direct `python -m cli.__main__` calls.
+- One capability has one semantic authority. Concurrency, persistence,
+  admission, progress, UI, or lane identity must be injected as strategy or
+  profile rather than creating another top-level implementation.
+- Do not add another corpus compiler entrypoint while the operational/fibred
+  compiler contracts remain non-equivalent.
+- Do not import `src.section_parser` in new code. It is a deprecated
+  compatibility projection over `src.ingestion.section_parser`.
+- PostgreSQL migrations under `database/postgres_migrations/` are the sole
+  active semantic migration track. SQLite migrations are deprecated; root and
+  schema migration directories are superseded references.
+- Do not add a migration whose numeric prefix already exists in its directory.
 - If the module name already carries the lane or domain, public function names
   must stay generic: `build_report`, `build_case`, `build_contract`,
   `build_receipt`, `attach_receipt`, `load_fixture`, `load_records`.
@@ -91,7 +115,7 @@ Hard rules:
   them as lane-owned primitives.
 
 ## Build, Test, and Development Commands
-Create a virtual environment and install tooling: `pip install -e .[dev,test]`. Run `pytest` for the full Python test suite, and scope to modules with `pytest tests/streaming/test_versioned_store.py`. Format with `ruff format` and lint via `ruff check --fix`; run `ruff check --select I` if imports need sorting. Verify type coverage using `mypy .`. For dashboards, launch `streamlit run streamlit_app.py`. Invoke the CLI with `python -m sensiblaw.cli --help` when iterating locally.
+Create a virtual environment and install tooling: `pip install -e .[dev,test]`. Run `pytest` for the full Python test suite, and scope to modules with `pytest tests/streaming/test_versioned_store.py`. Format with `ruff format` and lint via `ruff check --fix`; run `ruff check --select I` if imports need sorting. Verify type coverage using `mypy .`. For dashboards, launch `streamlit run streamlit_app.py`. Invoke the CLI with `python -m src.cli --help` when iterating locally.
 
 ## Coding Style & Naming Conventions
 Target Python 3.11 features (match statements, typing.Annotated) while keeping modules import-safe for 3.10 fallback. Use 4-space indentation, descriptive snake_case for functions and variables, and PascalCase for Pydantic models and FastAPI routers. Keep module-level constants in UPPER_SNAKE_CASE, and prefer dependency injection over module globals. Format exclusively with Ruff to avoid churn, and ensure new modules expose a concise `__all__` where APIs are intended for reuse.

--- a/DATABASE.md
+++ b/DATABASE.md
@@ -143,13 +143,24 @@ guardrails.
 
 ## Database Migration Tracks
 
-- SQLite migrations live in `database/migrations` and are exercised by tests via `MigrationRunner`.
-  `MigrationRunner` tracks applied migrations in a `schema_migrations` table so `ensure_database()`
-  is safe to call repeatedly.
-- The Postgres-first schema (no data carry-forward) is defined in `database/postgres_migrations`; apply with `scripts/apply_pg_migrations.sh` using your `PG*` env vars or `DATABASE_URL`.
+- **Active:** PostgreSQL migrations live in
+  `database/postgres_migrations/`. This is the sole active semantic schema and
+  persistence track. Apply it with `scripts/apply_pg_migrations.sh` using
+  `PG*` environment variables or `DATABASE_URL`.
+- **Deprecated:** SQLite ontology migrations live in `database/migrations/`.
+  They are retained for bounded historical import/replay fixtures and tests
+  through `MigrationRunner`; they are not a parallel runtime semantic
+  authority.
+- **Superseded reference only:** SQL under `migrations/` and
+  `schemas/migrations/` must not be executed.
 - Migration `007_compiler_substrate.sql` adds the generic compiler substrate:
   immutable declarations and build dependencies, canonical compiler documents,
   shared annotations, factorised PNF graphs/revisions, local typed meets, and
   unresolved demands. These rows intentionally do not require legal-source,
   actor, or event records; later legal bridges must be explicit.
-- Legacy, unrun SQL in `migrations/` and `schemas/migrations/` is superseded by the new Postgres track but retained for reference.
+
+The active PostgreSQL directory currently contains duplicate `006_*` and
+`007_*` numeric prefixes. The deprecated SQLite directory contains duplicate
+`002_*` prefixes. Do not add another duplicate prefix, rename an applied file
+in place, or rely on the numeric prefix as a unique migration identity until a
+checksum-preserving renumbering plan is completed.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,29 @@ structured, inspectable outputs instead of opaque summaries. It is used for
 legal/normative review, structured evidence handling, and bounded ontology
 diagnostics such as the current Wikidata work.
 
+## Runtime Authority
+
+The repository is under a documentation freeze while overlapping runtime
+surfaces are consolidated. The normative authority map is
+[`docs/authority_surfaces.md`](docs/authority_surfaces.md).
+
+The single source-tree CLI gateway is:
+
+```bash
+python -m src.cli
+```
+
+The project metadata still declares an installed console alias, but package
+resolution can differ from a source checkout. Until package topology is
+consolidated, new documentation and automation must use `python -m src.cli`.
+The top-level `cli` package is internal implementation and must not be invoked
+directly.
+
+New runtime work must extend one semantic authority. Executor, persistence,
+admission, retry, progress, and lane/profile differences belong in strategies
+or configuration rather than new compiler, parser, router, graph, linkage, or
+world-model implementations.
+
 ## Public Interface Boundary
 
 The supported downstream product boundary now includes a generic bounded
@@ -166,11 +189,12 @@ report's content into truth.
 
 The first P0a parser consolidation slice is implemented: canonical parsing,
 rule extraction, and structural-node construction now live in
-`src.ingestion.section_parser`; `src.section_parser` is a compatibility
-projection that retains historical `Provision` trees and simple section JSON.
-This removes the reverse parser dependency while preserving existing legacy
-callers. Span-only internal storage, one-pass annotation views, and cache keys
-remain subsequent P0a work.
+`src.ingestion.section_parser`. The remaining `src.section_parser` module is a
+deprecated compatibility projection that retains historical `Provision` trees
+and simple section JSON. Its presence still creates import ambiguity: new code
+must not use it, existing callers must migrate, and the projection should be
+removed after its last caller moves. Span-only internal storage, one-pass
+annotation views, and cache keys remain subsequent P0a work.
 
 The first P0b carrier slice is also implemented in
 `src.policy.entity_resolution`. It validates and deterministically serializes
@@ -1289,7 +1313,7 @@ cd SensibLaw
 Useful first commands:
 
 ```bash
-../.venv/bin/python -m sensiblaw.cli --help
+../.venv/bin/python -m src.cli --help
 ../.venv/bin/python -m pytest -q tests/test_wikidata_disjointness.py
 ../.venv/bin/python -m pytest -q tests/test_wikidata_structural_handoff.py
 ```
@@ -1312,9 +1336,9 @@ Note:
 Current operational entry points include:
 
 ```bash
-../.venv/bin/python -m cli.__main__ wikidata build-slice
-../.venv/bin/python -m cli.__main__ wikidata project
-../.venv/bin/python -m cli.__main__ wikidata find-qualifier-drift
+../.venv/bin/python -m src.cli wikidata build-slice
+../.venv/bin/python -m src.cli wikidata project
+../.venv/bin/python -m src.cli wikidata find-qualifier-drift
 ../.venv/bin/python scripts/run_wikidata_qualifier_drift_scan.py
 ```
 
@@ -1326,8 +1350,7 @@ generic ontology cleanup claims.
 If you want to see what the current CLI exposes:
 
 ```bash
-../.venv/bin/python -m sensiblaw.cli --help
-../.venv/bin/python -m cli.__main__ --help
+../.venv/bin/python -m src.cli --help
 ```
 
 ### Checked artifact review
@@ -1391,7 +1414,7 @@ Current status:
 - some lanes still expose lane-local grouped facades as an intermediate step;
   that is better than raw helper sprawl, but it is not the end-state
 - the current canonical operator entrypoint for cross-lane reporting is:
-  `../.venv/bin/python -m cli.__main__ wikidata world-model-lane-summary --input ...`
+  `../.venv/bin/python -m src.cli wikidata world-model-lane-summary --input ...`
 - broader lane rebinding and shared-surface extraction are still the next
   phase
 

--- a/cli/code_observer.py
+++ b/cli/code_observer.py
@@ -5,10 +5,10 @@ import json
 import sys
 from pathlib import Path
 
-from src.code_observer import observe_paths
-
 
 def handle_observe(args: argparse.Namespace) -> None:
+    from src.code_observer import observe_paths
+
     rows = observe_paths(
         args.root,
         include_globs=args.include_glob,

--- a/database/postgres_migrations/README.md
+++ b/database/postgres_migrations/README.md
@@ -14,3 +14,16 @@
   unresolved demands without requiring a legal-ontology row.
 - `024_generic_follow_projection.sql` persists derived-only, challengeable
   follow projections as rows with FK closure and exposes legal/non-legal views.
+
+## Migration identifier guardrail
+
+The directory currently contains duplicate `006_*` and `007_*` prefixes.
+Filename plus content hash remains the applied-migration identity, so an
+already-applied file must not be renamed in place. Until a
+checksum-preserving renumbering plan is complete:
+
+- every new migration must use a previously unused numeric prefix;
+- reviewers must inspect full filenames rather than treating the prefix as a
+  unique identifier;
+- no migration may be copied into the deprecated SQLite or superseded
+  reference tracks.

--- a/docs/ARCHITECTURE_LAYERS.md
+++ b/docs/ARCHITECTURE_LAYERS.md
@@ -12,6 +12,11 @@ This note tracks the six-layer architecture that underpins the timeline stream v
 
 These layers provide the shared vocabulary for the Streamline roadmap and its dependencies.
 
+They do not authorize parallel implementations. Parser, compiler, persistence,
+API, follow, linkage, and world-model ownership is recorded separately in
+`docs/authority_surfaces.md`; each capability must remain singular across
+these semantic layers.
+
 For current compiler-shaped legal work, read them with one extra boundary:
 
 - evidence and promoted outcomes remain canonical

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,19 @@
 
 Read-only, deterministic endpoints that expose existing obligation data. No reasoning, no inference, no identity changes.
 
+## Router authority status
+
+The repository currently has two independent router implementations:
+`src/api/routes.py` and `sensiblaw/api/routes.py`. They expose different
+capabilities and consumers and are therefore competing authorities, not
+aliases.
+
+The consolidation target is one router tree under the installed
+`src/sensiblaw/api` package. Until that merge is complete, this document
+describes behavior but does not designate either current router as the general
+API authority. Do not add a new endpoint to only one router without an
+explicit migration plan. See `docs/authority_surfaces.md`.
+
 ## `POST /obligations/query`
 - **Purpose:** Filter extracted obligations.
 - **Request:**

--- a/docs/authority_surfaces.md
+++ b/docs/authority_surfaces.md
@@ -1,0 +1,162 @@
+# Runtime Authority Surfaces
+
+Status: documentation freeze before consolidation  
+Baseline audited: `f8f6ff5db1bc2b443e03e9f58cb14e1bd1486aa5`
+
+SensibLaw currently contains several cases where execution policy, persistence
+policy, lane identity, or compatibility history created a second top-level
+implementation. This document records the authority boundary to use while
+those implementations are consolidated.
+
+It is normative for new code and documentation. Historical modules may remain
+temporarily for compatibility, but they must not be described as independent
+authorities or used as templates for new surfaces.
+
+## Governing Rule
+
+A capability has one semantic authority. Variation belongs in explicit
+strategies or profiles:
+
+```text
+one capability authority
+  + execution strategy
+  + persistence strategy
+  + admission policy
+  + progress sink
+  + lane/profile configuration
+```
+
+Concurrency, storage, admission, UI, and corpus identity do not justify a new
+semantic compiler, parser, API, graph, linkage engine, or world model.
+
+## Canonical Entry Point
+
+The single source-tree CLI gateway is:
+
+```bash
+python -m src.cli
+```
+
+Its callable authority is `src.cli:main`.
+
+The top-level `cli` package contains the current command implementation. It is
+internal and may be imported by `src.cli`; users, automation, scripts, and new
+documentation must not invoke `python -m cli.__main__` directly.
+
+The project metadata declares an installed `sensiblaw` console command, but the
+current package topology can make it resolve differently from a source
+checkout. It is compatibility debt, not a supported second entry point.
+Packaging should eventually bind that alias through the same gateway once the
+package layout is consolidated.
+
+Standalone maintenance scripts are not project entry points. A script that
+remains necessary should become a subcommand or explicitly document why it
+cannot use the shared CLI lifecycle.
+
+## Current Authority Map
+
+| Capability | Current competing surfaces | Authority decision | Transitional treatment |
+| --- | --- | --- | --- |
+| Project CLI | `src/cli.py`, `cli/__main__.py`, declared console alias, direct scripts | `src.cli:main` is the gateway; `cli` is internal implementation | Do not add direct `cli.__main__` invocations. Move durable scripts under the gateway. |
+| Section parsing | `src/ingestion/section_parser.py`, `src/section_parser.py` | `src.ingestion.section_parser` owns parsing and structural construction | `src.section_parser` is a deprecated compatibility projection. Migrate callers, then remove it. |
+| Public parser naming | `sensiblaw.interfaces.parser_adapter.parse_canonical_text`, `src.ingestion.media_adapter.parse_canonical_text` | `sensiblaw.interfaces.parse_canonical_text` owns the public parse operation | Prefer `build_parsed_envelope` for the media-envelope operation; retire its ambiguous alias. |
+| Corpus compilation | base, operational, fibred, PostgreSQL, streaming, optimized streaming, parallel, and curated modules | One document/corpus compiler contract must own semantics | Freeze new compiler entry points. Treat executor, persistence, admission, retry, and progress as strategies pending parity work. |
+| Package identity | root `sensiblaw/__init__.py`, `src/sensiblaw/__init__.py` | `src/sensiblaw` is the target installed product package | Root package is a temporary checkout compatibility shim; do not add exports to it. |
+| Dependency imports | root `fastapi.py` / `pydantic.py`, root `fastapi/` / `pydantic/`, real dependencies | Real third-party packages own these names | Move test doubles into test fixtures and remove repository-root shadows. |
+| HTTP API | `src/api/routes.py`, `sensiblaw/api/routes.py` | One router tree under the installed `src/sensiblaw/api` package | Freeze new endpoints in competing routers until routes, stores, and extraction behavior are merged. |
+| Legal follow | `src/policy/legal_follow_graph.py`, `src/policy/gwb_legal_follow_graph.py` | Shared follow machinery configured by profiles | AU/GWB labels may remain only as profile defaults and outward labels. |
+| Semantic linkage | `src/au_semantic/linkage.py`, `src/gwb_us_law/linkage.py` | Shared persistence, matching, selection, and reporting engine | Lane modules become field mappings and defaults only. |
+| World-model construction | generic runtime plus AU, GWB narrative, GWB broader-review, and Brexit builders | `world_model.py`, `world_model_adapters.py`, and `world_model_projections.py` own the shared process | Lane builders are transitional adapters and must collapse to configuration plus mapping. |
+| Fetch/progress/serialization utilities | repeated request pacing, `_json`, `_refs`, `_as_text`, hashing, cache, and progress helpers | Shared runtime utility owners | Do not copy helpers into another lane or script. Extract when touched. |
+| UI/story ingestion | multiple frontends and incompatible `StoryImporter` contracts | One product UI and one ingestion contract are required | Classify alternates as examples or retire them after caller inventory. |
+
+## Compiler Freeze
+
+The existing compiler modules do not differ only by throughput:
+
+- `compile_directory_postgres` uses `compile_document_operational` and the
+  `postgres-semantic-compiler:v0_10` contract.
+- parallel and curated paths use `compile_document_fibred_operational` and the
+  `postgres-fibred-semantic-compiler:v0_2` contract.
+- persistence, retry, admission-receipt, and progress behavior also differ.
+
+Therefore changing a caller from the sequential function to the parallel or
+curated function is not presumed behavior-preserving.
+
+Until output parity and one canonical contract are established:
+
+- do not create another compiler module or directory-level compiler;
+- do not call an execution variant a canonical compiler;
+- record the exact compiler contract in receipts and operator output;
+- add concurrency only after semantic and persistence parity is demonstrated;
+- model concurrency, persistence, admission, retry, and progress as strategies
+  of the eventual single compiler.
+
+## Parser Compatibility Freeze
+
+`src.section_parser` creates ambiguity even though it delegates parsing. It
+retains historical `Provision` and simple-section output shapes and is
+therefore a projection, not a parser authority.
+
+Rules:
+
+- new code imports `src.ingestion.section_parser` or the public
+  `sensiblaw.interfaces` parser surface;
+- no new import of `src.section_parser` is permitted;
+- compatibility callers should be inventoried and migrated;
+- the shim is removed after its last caller moves;
+- two operations with different input/output contracts must not share the
+  public name `parse_canonical_text`.
+
+## Persistence and Migration Tracks
+
+| Location | Status | Permitted use |
+| --- | --- | --- |
+| `database/postgres_migrations/` | Active | Sole active semantic persistence and schema migration track |
+| `database/migrations/` | Deprecated | Bounded historical SQLite ontology import/replay and tests only |
+| `migrations/` | Superseded reference | Read-only historical reference; never execute |
+| `schemas/migrations/` | Superseded reference | Read-only historical reference; never execute |
+
+The active PostgreSQL directory currently contains duplicate numeric prefixes
+(`006_*` and `007_*`). The deprecated SQLite directory also contains duplicate
+`002_*` prefixes. Lexical ordering happens to be deterministic, but the
+identifier convention is ambiguous for humans, tooling, and backports.
+
+Until a renumbering plan preserves already-applied filename/checksum receipts:
+
+- do not add a new migration with an existing prefix;
+- do not rename an already-applied migration in place;
+- do not execute either superseded reference directory;
+- require a unique next prefix for every new PostgreSQL migration;
+- treat SQLite migration work as retirement/import maintenance, not active
+  semantic development.
+
+## Consolidation Order
+
+1. Freeze new compiler and authority entry points.
+2. Establish one document compiler contract and parity-test operational and
+   fibred products.
+3. Express sequential, process-parallel, curated, streaming, and progress
+   behavior as strategies.
+4. Remove dependency shadows and converge the two `sensiblaw` initializers.
+5. Merge the HTTP routers.
+6. Extract shared follow and linkage engines.
+7. Collapse lane world-model builders into declarative adapters.
+8. Extract shared fetch, progress, serialization, cache, hash, and
+   normalization utilities.
+9. Retire or explicitly classify alternate UI and story-ingestion surfaces.
+10. Remove the section-parser compatibility projection after its callers move.
+
+## Review Checklist
+
+Before adding a module, command, store, router, or lane implementation, answer:
+
+1. Which existing capability authority owns this behavior?
+2. Is the requested difference semantic, or only execution/storage/profile
+   policy?
+3. Can it be an injected strategy, declaration, or profile?
+4. Does it create a second public invocation or import path?
+5. Which compatibility surface can be retired as part of the change?
+
+If the change would create a second authority, stop and extend the existing
+authority instead.

--- a/docs/cli_examples.md
+++ b/docs/cli_examples.md
@@ -1,11 +1,22 @@
 # CLI Usage Examples
 
+All examples in this document use the canonical source-tree gateway:
+
+```bash
+python -m src.cli --help
+```
+
+The project metadata still declares an installed console alias, but it remains
+package-topology compatibility debt and is not a second authority. The
+top-level `cli` package is internal; do not invoke its `__main__` module in user
+documentation or automation.
+
 ## Obligations (Sprint 7 read-only surfaces)
 
 Extract obligations from text and emit projections or explanations without adding semantics:
 
 ```bash
-sensiblaw obligations --text-file examples/sample.txt \
+python -m src.cli obligations --text-file examples/sample.txt \
   --emit-projections actor action timeline \
   --emit-explanation
 ```
@@ -19,7 +30,7 @@ Outputs JSON with:
 Diff/align two versions while keeping identities stable:
 
 ```bash
-sensiblaw obligations --text-file old.txt \
+python -m src.cli obligations --text-file old.txt \
   --diff-text-file new.txt \
   --emit-obligation-alignment
 ```
@@ -27,7 +38,7 @@ sensiblaw obligations --text-file old.txt \
 Simulate activation using a FactEnvelope:
 
 ```bash
-sensiblaw obligations --text-file doc.txt \
+python -m src.cli obligations --text-file doc.txt \
   --simulate-activation --facts facts.json
 ```
 
@@ -42,7 +53,7 @@ Download specific sections from an Act hosted on AustLII and store them in the
 local database:
 
 ```bash
-sensiblaw austlii-fetch --act https://example.org/act --sections s5,s223
+python -m src.cli austlii-fetch --act https://example.org/act --sections s5,s223
 ```
 
 ## Search AustLII for a known case and fetch one hit
@@ -51,7 +62,7 @@ Use the bounded SINO search seam to select one authority page, then save the
 fetched artifact for local review:
 
 ```bash
-sensiblaw austlii-search \
+python -m src.cli austlii-search \
   --query '"Marvel & Marvel"' \
   --method phrase \
   --pick by_mnc \
@@ -74,7 +85,7 @@ Use the direct AustLII authority seam when you already know the neutral
 citation or explicit AustLII case URL:
 
 ```bash
-sensiblaw austlii-case-fetch \
+python -m src.cli austlii-case-fetch \
   --citation "[2010] FamCAFC 13" \
   --paragraph 100 \
   --paragraph-window 1 \
@@ -91,7 +102,7 @@ happens locally after fetch, and `--db-path` persists the bounded receipt.
 Use the repo-owned JADE seam for a known neutral citation or explicit JADE URL:
 
 ```bash
-sensiblaw jade-fetch \
+python -m src.cli jade-fetch \
   --citation "[2021] FamCA 83" \
   --paragraph 120 \
   --paragraph-window 1 \
@@ -110,7 +121,7 @@ Use the secondary JADE search seam when you start from free text or want the
 operator path to synthesize an exact-MNC `/mnc/...` hit locally:
 
 ```bash
-sensiblaw jade-search \
+python -m src.cli jade-search \
   --query "[2021] FamCA 83" \
   --pick by_mnc \
   --mnc "[2021] FamCA 83" \
@@ -132,7 +143,7 @@ Display the text, extracted rules, provenance and ontology tags for a stored
 section identified by its canonical ID:
 
 ```bash
-sensiblaw view --id s5
+python -m src.cli view --id s5
 ```
 
 Both commands use `data/store.db` by default. Provide `--db` to specify a

--- a/docs/dev/CuratedLegalIRPerformanceParity.md
+++ b/docs/dev/CuratedLegalIRPerformanceParity.md
@@ -2,9 +2,12 @@
 
 ## Status
 
-This document describes the implemented offline product path. It is not a
-second legal parser or semantic compiler. All substantive documents use the
-existing fibred PNF compiler and its single deterministic reduction boundary.
+This document describes the implemented offline product path. It is intended
+to become admission, execution, retry, and persistence strategy around one
+semantic compiler. At present it uses the fibred compiler contract and is not
+behaviorally interchangeable with the operational PostgreSQL compiler. It
+must therefore remain transitional until contract and product parity are
+proved. See `docs/authority_surfaces.md`.
 
 ```text
 persisted source catalogue

--- a/docs/dev/FibredSemanticCompiler.md
+++ b/docs/dev/FibredSemanticCompiler.md
@@ -5,6 +5,13 @@
 This document defines the semantic organisation implemented by the SensibLaw
 PNF compiler after the streaming fixed-point tranche.
 
+This is the intended semantic organisation, not a claim that the repository's
+operational and fibred compiler paths are already one implementation. They
+currently publish different compiler contracts and products. The fibred path
+must converge with the operational path through explicit parity work; it must
+not become a second corpus-compiler authority. See
+`docs/authority_surfaces.md`.
+
 `ITIR-suite` is the suite-level control and handoff surface. `SensibLaw` owns the
 substantive deterministic semantic compiler, proposal contract, PNF reduction,
 and immutable build evidence. The fibred algebra therefore lives here rather

--- a/docs/dev/StreamingSemanticFixedPoint.md
+++ b/docs/dev/StreamingSemanticFixedPoint.md
@@ -6,6 +6,11 @@ This document defines the execution contract for the document-local semantic com
 It does not define legal truth, applicability, identity resolution, breach, liability, or
 professional review outcomes. Execution produces candidate semantic evidence only.
 
+Streaming is an execution strategy, not an independent semantic authority. The
+current implementation remains transitional until it preserves the same
+document-compiler contract and products as the operational path. See
+`docs/authority_surfaces.md`.
+
 ## Architectural change
 
 The compiler is no longer modelled as:

--- a/docs/dev/StreamingSemanticFixedPointImplementation.md
+++ b/docs/dev/StreamingSemanticFixedPointImplementation.md
@@ -3,6 +3,11 @@
 This document complements `StreamingSemanticFixedPoint.md` with the concrete implementation
 map and the distinction between active production paths and available extension contracts.
 
+The catalogue path described here is an execution/persistence variant, not a
+second semantic authority. It is not presumed interchangeable with the
+operational compiler until contract and product parity are demonstrated. See
+`docs/authority_surfaces.md`.
+
 ## Active catalogue path
 
 The catalogue compiler currently executes:

--- a/docs/end_to_end.md
+++ b/docs/end_to_end.md
@@ -1,7 +1,7 @@
 # End-to-End Query Flow
 
 This document demonstrates the experimental query pipeline that powers
-`sensiblaw query`. The command accepts different forms of user input and
+`python -m src.cli query`. The command accepts different forms of user input and
 converts them into a concept cloud.
 
 The high level steps are:
@@ -21,13 +21,13 @@ The high level steps are:
 ### Question
 
 ```bash
-sensiblaw query --text "Can a native title be extinguished by state law?"
+python -m src.cli query --text "Can a native title be extinguished by state law?"
 ```
 
 ### Keyword search
 
 ```bash
-sensiblaw query --text "native title extinguishment"
+python -m src.cli query --text "native title extinguishment"
 ```
 
 ### Story graph
@@ -46,7 +46,7 @@ Given a minimal story graph JSON file:
 Invoke the command with the path to the file:
 
 ```bash
-sensiblaw query --graph story.json
+python -m src.cli query --graph story.json
 ```
 
 Each of the above inputs will produce a simple concept cloud based on the
@@ -57,5 +57,5 @@ matched tokens.
 Retrieve how later authorities have treated a given case:
 
 ```bash
-sensiblaw query treatment --case case123
+python -m src.cli query treatment --case case123
 ```

--- a/docs/goldset_harness.md
+++ b/docs/goldset_harness.md
@@ -16,7 +16,7 @@ Gold set fixtures live under `tests/goldsets/`:
 Run the evaluation from the repository root:
 
 ```bash
-sensiblaw eval goldset
+python -m src.cli eval goldset
 ```
 
 Use `--threshold` to set the minimum precision/recall (defaults to `0.9`).

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -149,7 +149,7 @@ format.
 The CLI exposes the workflow under ``graph inference``:
 
 ```bash
-python -m sensiblaw.cli graph inference train \
+python -m src.cli graph inference train \
   --graph data/knowledge_graph.json \
   --model transe \
   --epochs 25 \
@@ -165,7 +165,7 @@ target a different predicate and ``--top-k`` to limit the number of
 recommendations per case. Persisted predictions can be queried later:
 
 ```bash
-python -m sensiblaw.cli graph inference rank \
+python -m src.cli graph inference rank \
   --case Case#Mabo1992 \
   --sqlite data/graph_applies_predictions.sqlite \
   --top-k 5
@@ -180,7 +180,7 @@ triples. By default the export includes only graph edges; pass
 actor nodes.
 
 ```bash
-python -m sensiblaw.cli graph export \
+python -m src.cli graph export \
   --graph data/knowledge_graph.json \
   --include-external-refs
 ```

--- a/docs/implementation_style_guide.md
+++ b/docs/implementation_style_guide.md
@@ -9,8 +9,27 @@ Before writing code, read:
 1. `README.md`
 2. `docs/itir_vs_sl.md`
 3. this file
+4. `docs/authority_surfaces.md`
 
 Agents and contributors should not start coding from local habit alone.
+
+## Single-Authority Rule
+
+Every capability has one semantic authority. Execution, persistence,
+admission, retry, progress, presentation, or lane identity must be expressed
+as an explicit strategy or profile, not as another top-level implementation.
+
+In particular:
+
+- `src.cli:main` is the source-tree CLI gateway;
+- the top-level `cli` package is internal implementation;
+- `src.ingestion.section_parser` owns section parsing;
+- `src.section_parser` is deprecated compatibility output projection;
+- PostgreSQL is the active semantic persistence authority;
+- no new corpus compiler entrypoint may be introduced until the current
+  operational and fibred contracts converge.
+
+See `docs/authority_surfaces.md` for the complete transitional map.
 
 ## Naming Rule
 

--- a/docs/parser_ir_interface.md
+++ b/docs/parser_ir_interface.md
@@ -114,6 +114,15 @@ from sensiblaw.interfaces import (
 The public import path should be through `sensiblaw.interfaces`, not through
 private implementation modules.
 
+`src.ingestion.media_adapter.parse_canonical_text(CanonicalText)` is a
+different envelope-building operation with a different return type. New code
+should call its clearer `build_parsed_envelope(...)` name instead of treating
+that private alias as the public parser contract.
+
+`src.section_parser` is also not a public parser surface. It is a deprecated
+compatibility projection over `src.ingestion.section_parser` that returns
+historical output shapes. New callers must not import it.
+
 ## Status Note
 
 At the time of this document:

--- a/docs/planning/curated_legal_ir_performance_parity_20260724.md
+++ b/docs/planning/curated_legal_ir_performance_parity_20260724.md
@@ -1,5 +1,11 @@
 # Curated Legal-IR performance and parity tranche
 
+Authority note: curated compilation is currently a transitional execution,
+admission, retry, and persistence path over the fibred compiler contract. It is
+not yet a strategy of a behaviorally unified corpus compiler and must not be
+substituted for the operational compiler without product-parity evidence. See
+`docs/authority_surfaces.md`.
+
 The offline catalogue boundary is explicit:
 
 ```text

--- a/docs/planning/directory_compilation_kernel_20260718.md
+++ b/docs/planning/directory_compilation_kernel_20260718.md
@@ -3,6 +3,13 @@
 Date: 2026-07-18
 Status: local-only corpus orchestration contract
 
+Authority note: this document states the intended single-kernel design. The
+current repository still has semantically non-equivalent operational, fibred,
+parallel, streaming, optimized, and curated compiler paths. Until they pass
+contract and product parity, none of those execution variants should be
+presented as a behavior-preserving substitute for another. See
+`docs/authority_surfaces.md`.
+
 ## Purpose
 
 The directory kernel turns a bounded filesystem corpus into deterministic,

--- a/docs/planning/postgres_generic_compiler_runtime_20260718.md
+++ b/docs/planning/postgres_generic_compiler_runtime_20260718.md
@@ -3,6 +3,11 @@
 Date: 2026-07-18
 Status: implementation tranche; database application still environment-bound
 
+Authority note: PostgreSQL is the persistence authority, but the repository
+does not yet have one behaviorally unified directory compiler. Executor and
+persistence variants remain transitional until operational/fibred output
+parity is proved. See `docs/authority_surfaces.md`.
+
 ## Decision
 
 PostgreSQL is the active operational store for new corpus, language, semantic

--- a/docs/planning/postgres_semantic_compiler_p0_20260718.md
+++ b/docs/planning/postgres_semantic_compiler_p0_20260718.md
@@ -3,6 +3,12 @@
 Date: 2026-07-18
 Status: active implementation contract
 
+Authority note: this is the target semantic/persistence contract, not evidence
+that every current directory compiler implements it. In particular, the
+operational and fibred compiler families currently publish different contract
+versions and products. Concurrency must not be treated as a behavior-only
+switch until parity is proved. See `docs/authority_surfaces.md`.
+
 ## Purpose
 
 ## Persistence boundary

--- a/docs/planning/wikidata_climate_change_property_migration_protocol_20260327.md
+++ b/docs/planning/wikidata_climate_change_property_migration_protocol_20260327.md
@@ -811,7 +811,7 @@ review_pack = {
 2. Use the new bounded migration-pack contract for property-to-property review:
    - `docs/planning/wikidata_migration_pack_contract_20260328.md`
    - `schemas/sl.wikidata_migration_pack.v1.schema.yaml`
-3. Use `sensiblaw wikidata build-migration-pack` as the first executable
+3. Use `python -m src.cli wikidata build-migration-pack` as the first executable
    surface for checked-safe subset construction.
 4. Materialize one pinned climate-change migration pack before discussing any
    wider batch.

--- a/docs/planning/wikidata_migration_pack_contract_20260328.md
+++ b/docs/planning/wikidata_migration_pack_contract_20260328.md
@@ -27,7 +27,7 @@ Implemented in bounded `v0.1` form through:
 - runtime:
   - `src/ontology/wikidata.py`
 - CLI:
-  - `sensiblaw wikidata build-migration-pack`
+  - `python -m src.cli wikidata build-migration-pack`
 
 `sensiblaw` is the installed console-script name from `pyproject.toml`. In a
 plain checkout where that script has not been installed, use the module form
@@ -35,7 +35,7 @@ instead:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata build-migration-pack --help
+../.venv/bin/python -m src.cli wikidata build-migration-pack --help
 ```
 
 ## Bounded live discovery and reconciliation
@@ -558,7 +558,7 @@ Immediate next policy goal:
 Build a pack from a bounded slice:
 
 ```bash
-sensiblaw wikidata build-migration-pack \
+python -m src.cli wikidata build-migration-pack \
   --input path/to/slice.json \
   --source-property P5991 \
   --target-property P14143 \
@@ -621,7 +621,7 @@ One-step materialization plus OpenRefine CSV:
 Export a materialized migration pack to OpenRefine CSV:
 
 ```bash
-sensiblaw wikidata export-migration-pack-openrefine \
+python -m src.cli wikidata export-migration-pack-openrefine \
   --input path/to/migration_pack.json \
   --output path/to/migration_pack_openrefine.csv
 ```
@@ -629,7 +629,7 @@ sensiblaw wikidata export-migration-pack-openrefine \
 Export only the checked-safe subset:
 
 ```bash
-sensiblaw wikidata export-migration-pack-checked-safe \
+python -m src.cli wikidata export-migration-pack-checked-safe \
   --input path/to/migration_pack.json \
   --output path/to/migration_pack_checked_safe.csv
 ```
@@ -637,7 +637,7 @@ sensiblaw wikidata export-migration-pack-checked-safe \
 Verify the checked-safe subset against an after-state slice/export:
 
 ```bash
-sensiblaw wikidata verify-migration-pack \
+python -m src.cli wikidata verify-migration-pack \
   --input path/to/migration_pack.json \
   --after path/to/after_state_slice.json \
   --output path/to/migration_verification.json
@@ -663,7 +663,7 @@ contract:
 - schema:
   `schemas/sl.wikidata_split_plan.v0_1.schema.yaml`
 - CLI:
-  `sensiblaw wikidata build-split-plan`
+  `python -m src.cli wikidata build-split-plan`
 
 Boundary:
 - `MigrationPack` detects and explains split pressure

--- a/docs/planning/wikidata_nat_automation_graduation_criteria_20260402.md
+++ b/docs/planning/wikidata_nat_automation_graduation_criteria_20260402.md
@@ -146,7 +146,7 @@ Design constraints:
 Next bounded operator/control surface now also exists:
 
 - CLI command:
-  `sensiblaw wikidata automation-graduation-eval --criteria ... --proposal ...`
+  `python -m src.cli wikidata automation-graduation-eval --criteria ... --proposal ...`
 - deterministic report wrapper:
   `build_nat_automation_graduation_report(criteria, proposal)`
 - pinned proposal fixtures:
@@ -158,7 +158,7 @@ Next bounded queue/index surface now also exists:
 - deterministic batch wrapper:
   `build_nat_automation_graduation_batch_report(criteria, proposal_batch)`
 - CLI command:
-  `sensiblaw wikidata automation-graduation-eval-batch --criteria ... --proposal-batch ...`
+  `python -m src.cli wikidata automation-graduation-eval-batch --criteria ... --proposal-batch ...`
 - pinned batch fixture:
   `wikidata_nat_automation_promotion_proposal_batch_20260402.json`
 
@@ -170,7 +170,7 @@ Next bounded measured-evidence surface now also exists:
 - deterministic repeated-run scorecard:
   `build_nat_automation_graduation_evidence_report(criteria, proposal_batches)`
 - CLI command:
-  `sensiblaw wikidata automation-graduation-evidence-report --criteria ... --proposal-batches ...`
+  `python -m src.cli wikidata automation-graduation-evidence-report --criteria ... --proposal-batches ...`
 - pinned repeated-run fixture:
   `wikidata_nat_automation_promotion_proposal_batches_20260402.json`
 
@@ -186,7 +186,7 @@ Next bounded governance-index surface now also exists:
 - deterministic cross-snapshot index:
   `build_nat_automation_graduation_governance_index(criteria, evidence_snapshots)`
 - CLI command:
-  `sensiblaw wikidata automation-graduation-governance-index --criteria ... --evidence-snapshots ...`
+  `python -m src.cli wikidata automation-graduation-governance-index --criteria ... --evidence-snapshots ...`
 - pinned snapshot fixture:
   `wikidata_nat_automation_evidence_snapshots_20260402.json`
 
@@ -202,7 +202,7 @@ Next bounded governance-summary surface now also exists:
 - deterministic repeated-index governance summary:
   `build_nat_automation_graduation_governance_summary(criteria, governance_snapshots)`
 - CLI command:
-  `sensiblaw wikidata automation-graduation-governance-summary --criteria ... --governance-snapshots ...`
+  `python -m src.cli wikidata automation-graduation-governance-summary --criteria ... --governance-snapshots ...`
 - pinned governance-snapshot fixture:
   `wikidata_nat_automation_governance_snapshots_20260402.json`
 

--- a/docs/planning/wikidata_nat_cohort_c_live_preview_extension_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_c_live_preview_extension_20260402.md
@@ -22,7 +22,7 @@ packet evidence while keeping every artifact review-first and fail-closed.
 
 - Cohort C population scan fixture: `tests/fixtures/wikidata/wikidata_nat_cohort_c_population_scan_20260402.json`
 - New live preview fixture: `tests/fixtures/wikidata/wikidata_nat_cohort_c_live_preview_extension_20260402.json`
-- Operator packet CLI entrypoint: `sensiblaw wikidata cohort-c-operator-packet`
+- Operator packet CLI entrypoint: `python -m src.cli wikidata cohort-c-operator-packet`
 
 ## ZKP Frame
 

--- a/docs/planning/wikidata_nat_cohort_c_operator_evidence_20260403.md
+++ b/docs/planning/wikidata_nat_cohort_c_operator_evidence_20260403.md
@@ -15,7 +15,7 @@ Strengthen the Cohort C operator evidence surface by packetizing a broader live-
 ## Inputs
 
 - Extended preview fixture: `tests/fixtures/wikidata/wikidata_nat_cohort_c_operator_packet_extension_20260403.json`
-- Operator CLI: `sensiblaw wikidata cohort-c-operator-packet`
+- Operator CLI: `python -m src.cli wikidata cohort-c-operator-packet`
 
 ## ZKP Frame
 
@@ -71,13 +71,13 @@ Strengthen the Cohort C operator evidence surface by packetizing a broader live-
 
 1. Use the fixture to inspect reference anchors before updating classification logs.
 2. Keep `promotion_guard: hold` until a second reviewer confirms the policy risk is mitigated.
-3. Log CLI execution (`sensiblaw wikidata cohort-c-operator-packet`) as part of the fix-it review so the packet ties back to the documented fixture.
+3. Log CLI execution (`python -m src.cli wikidata cohort-c-operator-packet`) as part of the fix-it review so the packet ties back to the documented fixture.
 
 ## Runtime Seam
 
 - The new helper `build_nat_cohort_c_operator_evidence_packet` (see `src/ontology/wikidata_cohort_c_operator_evidence.py`)
   deterministically materializes this richer evidence packet from any Cohort C preview payload.
-- Use `sensiblaw wikidata cohort-c-operator-evidence` to rerun the preview helper, regenerate the fixture, and append the packet hash so operators can confirm the data slice.
-- Run `sensiblaw wikidata cohort-c-operator-report` (or point it at the generated evidence packet via `--input`) to materialize the derived hold/reference summary that operators cite in downstream review logs.
-- Run `sensiblaw wikidata cohort-c-operator-report-batch --inputs <file1> <file2> ...` to merge several evidence packets into one batch summary, keeping every candidate clearly held under the same gating semantics.
+- Use `python -m src.cli wikidata cohort-c-operator-evidence` to rerun the preview helper, regenerate the fixture, and append the packet hash so operators can confirm the data slice.
+- Run `python -m src.cli wikidata cohort-c-operator-report` (or point it at the generated evidence packet via `--input`) to materialize the derived hold/reference summary that operators cite in downstream review logs.
+- Run `python -m src.cli wikidata cohort-c-operator-report-batch --inputs <file1> <file2> ...` to merge several evidence packets into one batch summary, keeping every candidate clearly held under the same gating semantics.
 - The CLI command shares the same fail-closed gate (`review_first_population_scan`) and respects the `promotion_guard: hold` semantics so the evidence remains a review artifact.

--- a/docs/planning/wikidata_nat_cohort_c_operator_index_20260406.md
+++ b/docs/planning/wikidata_nat_cohort_c_operator_index_20260406.md
@@ -17,4 +17,4 @@ The Ptolemy lane’s next step is to produce a deterministic operator index over
 - Run the helper after batch reporting to produce an index that maps reference anchors to all qualifier hints seen on nearby policy-risk candidates.
 - Share the index alongside the batch report so reviewers can quickly scan where hold reasons concentrate and how qualifiers spread while a gate remains closed.
 - No automation claims are made; rerun live preview if candidate populations shift before reusing the index.
-- Operators can now run `sensiblaw wikidata cohort-c-operator-digest --inputs <packet1> <packet2> ...` to materialize a governance digest that aggregates hold reasons and reference qualifier penetration across indexes while keeping every row under `promotion_guard: hold`.
+- Operators can now run `python -m src.cli wikidata cohort-c-operator-digest --inputs <packet1> <packet2> ...` to materialize a governance digest that aggregates hold reasons and reference qualifier penetration across indexes while keeping every row under `promotion_guard: hold`.

--- a/docs/planning/wikidata_nat_cohort_c_population_scan_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_c_population_scan_20260402.md
@@ -107,5 +107,5 @@ be verified during the scan.
 - `review_first_population_scan_ready` (runtime normalizer surface)
 - `review_first_population_scan_live_preview` (bounded live helper surface)
 - `review_first_population_scan_operator_packet` (review packet surface)
-- CLI entrypoint: `sensiblaw wikidata cohort-c-operator-packet`
+- CLI entrypoint: `python -m src.cli wikidata cohort-c-operator-packet`
 - future packetized review surface once the scan yields reproducible rows

--- a/docs/planning/wikidata_nat_cohort_c_ptolemy_evidence_20260405.md
+++ b/docs/planning/wikidata_nat_cohort_c_ptolemy_evidence_20260405.md
@@ -10,12 +10,12 @@ Push the Ptolemy lane by recording a broader operator evidence slice for Cohort 
 
 - Extended evidence fixture `tests/fixtures/wikidata/wikidata_nat_cohort_c_operator_evidence_packet_20260404.json`
 - New broader fixture `tests/fixtures/wikidata/wikidata_nat_cohort_c_ptolemy_evidence_sample_20260405.json`
-- CLI entrypoints: `sensiblaw wikidata cohort-c-operator-evidence` and `sensiblaw wikidata cohort-c-operator-report-batch`
+- CLI entrypoints: `python -m src.cli wikidata cohort-c-operator-evidence` and `python -m src.cli wikidata cohort-c-operator-report-batch`
 
 ## Ptolemy Operator Surface
 
 - The new fixture mirrors a broader live-preview slice (3+ candidates) with per-candidate `reference_anchor`, `preview_hold_reason`, `operator_hold_reason`, and `qualifier_hint` statements.
-- Operators feed the evidence fixture into `sensiblaw wikidata cohort-c-operator-report-batch` along with previously generated packets to produce an aggregated hold/reference summary that always stays within the review-first gate.
+- Operators feed the evidence fixture into `python -m src.cli wikidata cohort-c-operator-report-batch` along with previously generated packets to produce an aggregated hold/reference summary that always stays within the review-first gate.
 - The aggregate summary can be published as governance evidence; every row retains `promotion_guard: hold` and `hold_gate: review_first_population_scan`.
 
 ## Live-Preview/Runtime Boundary

--- a/docs/planning/wikidata_nat_cohort_d_operator_report_batch_surface_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_d_operator_report_batch_surface_20260402.md
@@ -17,7 +17,7 @@ This remains non-executing and fail-closed.
 
 ## CLI Surface
 
-- `sensiblaw wikidata cohort-d-operator-report-batch --input <batch_input.json> [--output <batch_report.json>]`
+- `python -m src.cli wikidata cohort-d-operator-report-batch --input <batch_input.json> [--output <batch_report.json>]`
 
 ## Pinned Artifacts
 

--- a/docs/planning/wikidata_nat_cohort_d_operator_report_surface_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_d_operator_report_surface_20260402.md
@@ -16,7 +16,7 @@ governance.
 
 ## CLI Surface
 
-- `sensiblaw wikidata cohort-d-operator-report --input <operator_review.json> [--output <operator_report.json>]`
+- `python -m src.cli wikidata cohort-d-operator-report --input <operator_review.json> [--output <operator_report.json>]`
 
 ## Pinned Artifact
 

--- a/docs/planning/wikidata_nat_cohort_d_operator_review_cli_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_d_operator_review_cli_20260402.md
@@ -9,7 +9,7 @@ operator/reviewer queue from a Cohort D type-probing artifact.
 
 ## Command
 
-- `sensiblaw wikidata cohort-d-operator-review --input <type_probing.json> [--output <operator_review.json>]`
+- `python -m src.cli wikidata cohort-d-operator-review --input <type_probing.json> [--output <operator_review.json>]`
 
 ## Behavior
 

--- a/docs/planning/wikidata_nat_cohort_d_review_control_index_20260402.md
+++ b/docs/planning/wikidata_nat_cohort_d_review_control_index_20260402.md
@@ -17,7 +17,7 @@ This is a deterministic index layer above batch reporting.
 
 ## CLI Surface
 
-- `sensiblaw wikidata cohort-d-review-control-index --input <index_input.json> [--output <index.json>]`
+- `python -m src.cli wikidata cohort-d-review-control-index --input <index_input.json> [--output <index.json>]`
 
 ## Pinned Artifacts
 

--- a/docs/planning/wikidata_nat_cohort_e_diagnostics_cli_20260403.md
+++ b/docs/planning/wikidata_nat_cohort_e_diagnostics_cli_20260403.md
@@ -10,7 +10,7 @@ diagnostic report from the sample axis fixture without touching shared scripts.
 ## Usage
 
 ```
-sensiblaw cohort-e-diagnostics \
+python -m src.cli cohort-e-diagnostics \
   --samples SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_e_split_axis_sample_20260403.json \
   --output SensibLaw/tests/fixtures/wikidata/wikidata_nat_cohort_e_diagnostic_report_20260403.json
 ```

--- a/docs/planning/wikidata_octf_entrypoint_20260421.md
+++ b/docs/planning/wikidata_octf_entrypoint_20260421.md
@@ -304,14 +304,14 @@ Local repo invocation used in the existing docs:
 ```bash
 cd SensibLaw
 ../.venv/bin/pip install -e .[dev,test]
-../.venv/bin/python -m cli.__main__ wikidata --help
+../.venv/bin/python -m src.cli wikidata --help
 ```
 
 Climate migration pack:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata build-migration-pack \
+../.venv/bin/python -m src.cli wikidata build-migration-pack \
   --input data/ontology/wikidata_migration_packs/p5991_p14143_climate_pilot_20260328/slice.json \
   --source-property P5991 \
   --target-property P14143 \
@@ -322,7 +322,7 @@ OpenRefine review export:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata export-migration-pack-openrefine \
+../.venv/bin/python -m src.cli wikidata export-migration-pack-openrefine \
   --input data/ontology/wikidata_migration_packs/p5991_p14143_climate_pilot_20260328/migration_pack.json \
   --output /tmp/p5991_p14143_openrefine.csv
 ```
@@ -331,7 +331,7 @@ Checked-safe-only export:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata export-migration-pack-checked-safe \
+../.venv/bin/python -m src.cli wikidata export-migration-pack-checked-safe \
   --input data/ontology/wikidata_migration_packs/p5991_p14143_climate_pilot_20260328/migration_pack.json \
   --output /tmp/p5991_p14143_checked_safe.csv
 ```
@@ -340,7 +340,7 @@ Post-edit verification:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata verify-migration-pack \
+../.venv/bin/python -m src.cli wikidata verify-migration-pack \
   --input data/ontology/wikidata_migration_packs/p5991_p14143_climate_pilot_20260328/migration_pack.json \
   --after path/to/after_state_slice.json \
   --output /tmp/p5991_p14143_verification.json
@@ -350,7 +350,7 @@ Split-plan review surface:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata build-split-plan \
+../.venv/bin/python -m src.cli wikidata build-split-plan \
   --input data/ontology/wikidata_migration_packs/p5991_p14143_climate_pilot_20260328/migration_pack.json \
   --output /tmp/p5991_p14143_split_plan.json
 ```
@@ -359,7 +359,7 @@ Cross-lane governance summary:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata world-model-lane-summary \
+../.venv/bin/python -m src.cli wikidata world-model-lane-summary \
   --input path/to/lane_report_1.json \
   --input path/to/lane_report_2.json \
   --output /tmp/wikidata_world_model_lane_summary.json
@@ -413,7 +413,7 @@ isolated item at a time.
 - CLI:
 
 ```bash
-PYTHONPATH=SensibLaw .venv/bin/python -m cli.__main__ wikidata hotspot-generate-clusters \
+PYTHONPATH=SensibLaw .venv/bin/python -m src.cli wikidata hotspot-generate-clusters \
   --manifest docs/planning/wikidata_hotspot_pilot_pack_v1.manifest.json \
   --output /tmp/wikidata_hotspot_clusters.json
 ```
@@ -434,7 +434,7 @@ qualifiers carried by the bounded `P2738` statements.
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata disjointness-report \
+../.venv/bin/python -m src.cli wikidata disjointness-report \
   --input path/to/bounded_disjointness_slice.json \
   --output /tmp/wikidata_disjointness_report.json
 ```

--- a/docs/planning/wikidata_pnf_residual_review_example_20260429.md
+++ b/docs/planning/wikidata_pnf_residual_review_example_20260429.md
@@ -332,7 +332,7 @@ The narrower claim is:
 
 This note now has a bounded runtime companion:
 
-- `../.venv/bin/python -m cli.__main__ wikidata climate-review-demonstrator \
+- `../.venv/bin/python -m src.cli wikidata climate-review-demonstrator \
   --migration-pack data/ontology/wikidata_migration_packs/p5991_p14143_climate_pilot_20260328/migration_pack.json \
   --climate-text data/ontology/wikidata_migration_packs/p5991_p14143_climate_pilot_20260328/climate_text_source_q10403939_akademiska_hus_scope1_2018_2020.json \
   --review-packet tests/fixtures/wikidata/wikidata_nat_review_packet_20260401.json \

--- a/docs/planning/wikidata_review_packet_plan_20260401.md
+++ b/docs/planning/wikidata_review_packet_plan_20260401.md
@@ -112,7 +112,7 @@ Update:
 - that grounding lane now also has a reproducible operator path:
   - `SensibLaw/src/ontology/wikidata_grounding_depth.py`
   - `SensibLaw/cli/grounding_depth.py`
-  - `sensiblaw wikidata grounding-depth`
+  - `python -m src.cli wikidata grounding-depth`
 - variant comparison now has a grounded Nat example path: when the split
   payload includes sibling plans from the same cohort, the packet can derive
   a small bounded comparison set automatically, so the comparison lane is no

--- a/docs/planning/wikidata_shixiong_handoff_20260402.md
+++ b/docs/planning/wikidata_shixiong_handoff_20260402.md
@@ -68,7 +68,7 @@ These pieces are real now:
 - a schema-backed contract:
   `SensibLaw/schemas/sl.wikidata_migration_pack.v1.schema.yaml`
 - a CLI builder:
-  `sensiblaw wikidata build-migration-pack`
+  `python -m src.cli wikidata build-migration-pack`
 - first runtime buckets:
   - `safe_equivalent`
   - `safe_with_reference_transfer`
@@ -77,13 +77,13 @@ These pieces are real now:
   - `split_required`
   - `abstain`
 - checked-safe export:
-  `sensiblaw wikidata export-migration-pack-checked-safe`
+  `python -m src.cli wikidata export-migration-pack-checked-safe`
 - OpenRefine CSV export:
-  `sensiblaw wikidata export-migration-pack-openrefine`
+  `python -m src.cli wikidata export-migration-pack-openrefine`
 - post-edit verification:
-  `sensiblaw wikidata verify-migration-pack`
+  `python -m src.cli wikidata verify-migration-pack`
 - split-plan support for hard rows:
-  `sensiblaw wikidata build-split-plan`
+  `python -m src.cli wikidata build-split-plan`
 
 ## What the first real pilot shows
 

--- a/docs/planning/wikidata_split_plan_contract_20260328.md
+++ b/docs/planning/wikidata_split_plan_contract_20260328.md
@@ -21,7 +21,7 @@ Implemented in bounded `v0.1` form through:
 - runtime:
   - `src/ontology/wikidata.py`
 - CLI:
-  - `sensiblaw wikidata build-split-plan`
+  - `python -m src.cli wikidata build-split-plan`
 
 ## Contract shape
 Schema version:
@@ -93,7 +93,7 @@ still needs review:
 ## CLI contract
 
 ```bash
-sensiblaw wikidata build-split-plan \
+python -m src.cli wikidata build-split-plan \
   --input path/to/migration_pack.json \
   --output path/to/split_plan.json
 ```

--- a/docs/roadmaps/sprint9_proposal.md
+++ b/docs/roadmaps/sprint9_proposal.md
@@ -22,7 +22,7 @@ Enable human review, comparison, and export of existing obligation artifacts **w
 ## Deliverables
 1) **review.collection.v1** schema: references to multiple review bundles with labels.
 2) **Streamlit collection view**: bundle picker + side-by-side obligation/activation/topology diffs (structural only).
-3) **Deterministic export pipeline**: `sensiblaw review export` → zip(JSON, PDF render, manifest with hashes).
+3) **Deterministic export pipeline**: `python -m src.cli review export` → zip(JSON, PDF render, manifest with hashes).
 4) **Workflow metadata (optional, side-band)**: `ReviewStatus` (stage, owner, timestamp) stored outside bundles; stripping it yields identical bundle hashes.
 
 ## Tests / Red-flag guards
@@ -49,7 +49,7 @@ Enable human review, comparison, and export of existing obligation artifacts **w
    - New tab “Collections”: bundle picker + structural diff view.
    - Read-only; no mutation controls.
 4) **Export pipeline**
-   - CLI: `python -m sensiblaw.cli review export --collection examples/review_collection_minimal.json`.
+   - CLI: `python -m src.cli review export --collection examples/review_collection_minimal.json`.
    - Outputs: zip (bundles + manifest + optional PDF render).
    - Tests: manifest hashes deterministic across runs.
 

--- a/docs/roadmaps/sprint_s7.md
+++ b/docs/roadmaps/sprint_s7.md
@@ -57,7 +57,7 @@ Goal: expose, exercise, and extend the S6 normative surfaces **without inference
 
 ## TODO (implementation-ready checklist)
 - Add FastAPI routes for `/obligations/query`, `/obligations/explain`, `/obligations/alignment`, `/obligations/projections/{view}` using S6 primitives; deterministic JSON + schema versions.
-- Extend CLI (`sensiblaw obligations`) to emit projections (`--emit-projections`) and explanations (`--emit-explanation`); reuse existing alignment flag for diffs.
+- Extend CLI (`python -m src.cli obligations`) to emit projections (`--emit-projections`) and explanations (`--emit-explanation`); reuse existing alignment flag for diffs.
 - Wire snapshot/golden tests for API + CLI outputs (fixtures from sample corpus) as red flags.
 - Keep all new outputs flag-gated and identity-neutral; no activation or cross-doc logic until tracks A/B start.
 - Track A prep: FactEnvelope doc and activation red-flag tests in place; activation simulation is descriptive only and identity-neutral.

--- a/docs/sources_contract.md
+++ b/docs/sources_contract.md
@@ -49,7 +49,7 @@ No adapter tokenises, parses, deduplicates, or infers. Semantics begin only afte
   case URL or a neutral citation that is deterministically resolved to the
   canonical AustLII case URL before fetch, then perform paragraph/location
   isolation locally on the fetched artifact.
-- `sensiblaw jade-search` is allowed as a secondary operator seam when a user
+- `python -m src.cli jade-search` is allowed as a secondary operator seam when a user
   starts from free text or when the query itself contains the neutral citation;
   exact `jade-fetch` remains the stable recommended core.
 - Use search only to select a concrete authority URL; once bytes are fetched,
@@ -57,9 +57,9 @@ No adapter tokenises, parses, deduplicates, or infers. Semantics begin only afte
   artifact or persisted document, not through repeated live queries.
 - Optional persisted bounded ingest is now allowed for operator-selected
   authorities:
-  `sensiblaw austlii-search --db-path ...` and
-  `sensiblaw jade-fetch --db-path ...` and
-  `sensiblaw jade-search --db-path ...` persist a canonical sqlite receipt with
+  `python -m src.cli austlii-search --db-path ...` and
+  `python -m src.cli jade-fetch --db-path ...` and
+  `python -m src.cli jade-search --db-path ...` persist a canonical sqlite receipt with
   whole-fetch provenance plus bounded selected paragraph segments.
 - Normal AU semantic/fact-review runtime may reuse those persisted receipts as
   a read-only authority-context lane. The intended ordering is:

--- a/docs/sqlite_migrations.md
+++ b/docs/sqlite_migrations.md
@@ -1,4 +1,11 @@
-# SQLite Migrations (Ontology DB)
+# Deprecated SQLite Migrations (Ontology DB)
+
+Status: deprecated compatibility track.
+
+PostgreSQL under `database/postgres_migrations/` is the sole active semantic
+persistence and migration authority. The SQLite ontology track remains only
+for bounded historical import/replay fixtures and tests. Do not add new
+runtime semantic features here.
 
 SensibLaw has multiple SQLite schemas in the repo:
 
@@ -15,6 +22,11 @@ This doc references all three so you don't confuse them, but it covers only the
 - Migrations directory: `database/migrations/`
 - Runner: `src/sensiblaw/db/migrations.py` (`MigrationRunner`)
 - Entry point: `src/sensiblaw/db/dao.py` (`ensure_database(connection)`)
+
+The directory currently contains multiple `002_*` files. Lexical execution is
+deterministic, but the duplicated numeric identity is unsafe for human review,
+tooling, and backports. Do not introduce another duplicate prefix or rename an
+already-applied file in place.
 
 ## Idempotency contract
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -35,7 +35,7 @@ Use the `snapshot(doc_id, as_at)` method to retrieve the version of a document
 in effect on a given date.  The CLI exposes this via:
 
 ```bash
-sensiblaw get --id 1 --as-at 2023-01-01
+python -m src.cli get --id 1 --as-at 2023-01-01
 ```
 
 The returned JSON includes the provenance metadata captured for the selected

--- a/docs/wikidata/README.md
+++ b/docs/wikidata/README.md
@@ -28,14 +28,14 @@ Installed form:
 ```bash
 cd SensibLaw
 ../.venv/bin/pip install -e .
-../.venv/bin/sensiblaw wikidata --help
+../.venv/bin/python -m src.cli wikidata --help
 ```
 
 Checkout fallback form, which works even when the console script is not present:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata --help
+../.venv/bin/python -m src.cli wikidata --help
 ```
 
 The commands below use the fallback form to avoid assuming the `sensiblaw`
@@ -143,7 +143,7 @@ Start with the pinned pilot pack:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata build-migration-pack \
+../.venv/bin/python -m src.cli wikidata build-migration-pack \
   --input data/ontology/wikidata_migration_packs/p5991_p14143_climate_pilot_20260328/slice.json \
   --source-property P5991 \
   --target-property P14143 \
@@ -154,7 +154,7 @@ Review all rows in a flat CSV:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata export-migration-pack-openrefine \
+../.venv/bin/python -m src.cli wikidata export-migration-pack-openrefine \
   --input /tmp/p5991_p14143_migration_pack.json \
   --output /tmp/p5991_p14143_openrefine.csv
 ```
@@ -163,7 +163,7 @@ Stage only locally checked-safe rows:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata export-migration-pack-checked-safe \
+../.venv/bin/python -m src.cli wikidata export-migration-pack-checked-safe \
   --input /tmp/p5991_p14143_migration_pack.json \
   --output /tmp/p5991_p14143_checked_safe.csv
 ```
@@ -172,7 +172,7 @@ If rows need splitting, build the review-only split plan:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata build-split-plan \
+../.venv/bin/python -m src.cli wikidata build-split-plan \
   --input /tmp/p5991_p14143_migration_pack.json \
   --output /tmp/p5991_p14143_split_plan.json
 ```
@@ -182,7 +182,7 @@ verify the checked-safe subset:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata verify-migration-pack \
+../.venv/bin/python -m src.cli wikidata verify-migration-pack \
   --input /tmp/p5991_p14143_migration_pack.json \
   --after path/to/after_state_slice.json \
   --output /tmp/p5991_p14143_verification.json
@@ -201,7 +201,7 @@ Run the demonstrator over the pinned Akademiska Hus case:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata climate-review-demonstrator \
+../.venv/bin/python -m src.cli wikidata climate-review-demonstrator \
   --migration-pack data/ontology/wikidata_migration_packs/p5991_p14143_climate_pilot_20260328/migration_pack.json \
   --climate-text data/ontology/wikidata_migration_packs/p5991_p14143_climate_pilot_20260328/climate_text_source_q10403939_akademiska_hus_scope1_2018_2020.json \
   --review-packet tests/fixtures/wikidata/wikidata_nat_review_packet_20260401.json \
@@ -226,7 +226,7 @@ property migration.
 Generate all hotspot clusters from the current manifest:
 
 ```bash
-PYTHONPATH=SensibLaw .venv/bin/python -m cli.__main__ wikidata hotspot-generate-clusters \
+PYTHONPATH=SensibLaw .venv/bin/python -m src.cli wikidata hotspot-generate-clusters \
   --manifest docs/planning/wikidata_hotspot_pilot_pack_v1.manifest.json \
   --output /tmp/wikidata_hotspot_clusters.json
 ```
@@ -234,7 +234,7 @@ PYTHONPATH=SensibLaw .venv/bin/python -m cli.__main__ wikidata hotspot-generate-
 To focus on one pack:
 
 ```bash
-PYTHONPATH=SensibLaw .venv/bin/python -m cli.__main__ wikidata hotspot-generate-clusters \
+PYTHONPATH=SensibLaw .venv/bin/python -m src.cli wikidata hotspot-generate-clusters \
   --manifest docs/planning/wikidata_hotspot_pilot_pack_v1.manifest.json \
   --pack-id software_entity_kind_collapse_pack_v0 \
   --output /tmp/software_entity_kind_collapse_clusters.json
@@ -254,7 +254,7 @@ Run the report against the pilot fixture:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata disjointness-report \
+../.venv/bin/python -m src.cli wikidata disjointness-report \
   --input tests/fixtures/wikidata/disjointness_p2738_pilot_pack_v1/slice.json \
   --output /tmp/wikidata_disjointness_report.json
 ```
@@ -282,7 +282,7 @@ Run the synthetic `Q27968055` packet fixture:
 
 ```bash
 cd SensibLaw
-../.venv/bin/python -m cli.__main__ wikidata compare-candidates \
+../.venv/bin/python -m src.cli wikidata compare-candidates \
   --packet tests/fixtures/wikidata/q27968055_change_review_packet.json \
   --output /tmp/q27968055_change_review_report.json
 ```

--- a/docs/wikidata_working_group_status.md
+++ b/docs/wikidata_working_group_status.md
@@ -12,14 +12,14 @@ Wikidata task stories, start with:
 
 If you need one machine-runnable snapshot of the current executable Wikidata
 lanes, start with:
-- `../.venv/bin/python -m cli.__main__ wikidata lane-status`
-- `../.venv/bin/python -m cli.__main__ wikidata lane-bundle --lane disjointness_report`
-- `../.venv/bin/python -m cli.__main__ wikidata lane-graph --lane disjointness_report`
-- `../.venv/bin/python -m cli.__main__ wikidata lane-flatness`
-- `../.venv/bin/python -m cli.__main__ wikidata linkage-depth`
-- `../.venv/bin/python -m cli.__main__ wikidata lane-plan --lane climate_review_demonstrator`
-- `../.venv/bin/python -m cli.__main__ wikidata lane-plan --lane nat_live_follow_preflight`
-- `../.venv/bin/python -m cli.__main__ wikidata lane-proof --lane disjointness_report`
+- `../.venv/bin/python -m src.cli wikidata lane-status`
+- `../.venv/bin/python -m src.cli wikidata lane-bundle --lane disjointness_report`
+- `../.venv/bin/python -m src.cli wikidata lane-graph --lane disjointness_report`
+- `../.venv/bin/python -m src.cli wikidata lane-flatness`
+- `../.venv/bin/python -m src.cli wikidata linkage-depth`
+- `../.venv/bin/python -m src.cli wikidata lane-plan --lane climate_review_demonstrator`
+- `../.venv/bin/python -m src.cli wikidata lane-plan --lane nat_live_follow_preflight`
+- `../.venv/bin/python -m src.cli wikidata lane-proof --lane disjointness_report`
 - `../../docs/planning/wikidata_lane_architecture_and_roadmap_20260703.md`
 - `../../docs/planning/wikidata_lanes_zelph_096_status_20260703.md`
 
@@ -60,7 +60,7 @@ If you need one executable bounded packet showing:
 - final held/promotable disposition
 
 use:
-- `../.venv/bin/python -m cli.__main__ wikidata climate-review-demonstrator \
+- `../.venv/bin/python -m src.cli wikidata climate-review-demonstrator \
   --migration-pack data/ontology/wikidata_migration_packs/p5991_p14143_climate_pilot_20260328/migration_pack.json \
   --climate-text data/ontology/wikidata_migration_packs/p5991_p14143_climate_pilot_20260328/climate_text_source_q10403939_akademiska_hus_scope1_2018_2020.json \
   --review-packet tests/fixtures/wikidata/wikidata_nat_review_packet_20260401.json \
@@ -71,7 +71,7 @@ If you want the same runtime as one compact diagram, use:
 
 If you need the first executable bounded ontology-repair candidate comparison
 surface, use:
-- `../.venv/bin/python -m cli.__main__ wikidata compare-candidates \
+- `../.venv/bin/python -m src.cli wikidata compare-candidates \
   --packet tests/fixtures/wikidata/q27968055_change_review_packet.json \
   --output /tmp/q27968055_change_review_report.json`
 
@@ -189,7 +189,7 @@ shared handoff.
     WikiProject Climate change is treated as an upstream proposal/coordination
     layer, not as the semantic truth layer or promotion lattice
   - a first executable migration-review surface now exists:
-    `sensiblaw wikidata build-migration-pack`
+    `python -m src.cli wikidata build-migration-pack`
   - the immediate next promotion gate is now concrete:
     a bounded live `P5991 -> P14143` pilot pack is now pinned at:
     `SensibLaw/data/ontology/wikidata_migration_packs/p5991_p14143_climate_pilot_20260328/`
@@ -203,16 +203,16 @@ shared handoff.
     - explicit QIDs when the editor already has a candidate set
     - bounded live discovery from the source property when they do not
   - the first OpenRefine bridge now exists:
-    `sensiblaw wikidata export-migration-pack-openrefine`
+    `python -m src.cli wikidata export-migration-pack-openrefine`
     for flat CSV review surfaces over existing migration packs
   - the first checked-safe export now also exists:
-    `sensiblaw wikidata export-migration-pack-checked-safe`
+    `python -m src.cli wikidata export-migration-pack-checked-safe`
     for flat CSV staging over only the already-safe subset
   - the first bounded post-edit verifier now also exists:
-    `sensiblaw wikidata verify-migration-pack`
+    `python -m src.cli wikidata verify-migration-pack`
     to compare the checked-safe subset against an after-state slice/export
   - the first split-row followthrough artifact now also exists:
-    `sensiblaw wikidata build-split-plan`
+    `python -m src.cli wikidata build-split-plan`
     for review-only `1 -> N` plans over structurally decomposable
     `split_required` slots
   - that split-plan lane is now explicitly treated as the first concrete
@@ -339,7 +339,7 @@ shared handoff.
       can compare the checked-safe candidate set against the after-state slice
       or export before calling the write path complete
     - the lane now also has a bounded sandbox adapter for that same proof step:
-      `sensiblaw wikidata nat-sandbox-post-write-verification`
+      `python -m src.cli wikidata nat-sandbox-post-write-verification`
       verifies a sandbox microbatch packet directly against an observed
       sandbox after-state capture
     - current recommended write-path order:
@@ -353,7 +353,7 @@ shared handoff.
       surfaces beyond packet-only notes:
       - grounding depth:
         `src/ontology/wikidata_grounding_depth.py`
-        plus `sensiblaw wikidata grounding-depth`
+        plus `python -m src.cli wikidata grounding-depth`
       - Cohort B:
         `src/ontology/wikidata_nat_cohort_b_operator_packet.py`,
         `src/ontology/wikidata_nat_cohort_b_operator_queue.py`, and
@@ -363,14 +363,14 @@ shared handoff.
         `src/ontology/wikidata_cohort_c_operator_report_batch.py`
       - Cohort D:
         `src/ontology/wikidata_nat_cohort_d_review.py` plus
-        `sensiblaw wikidata cohort-d-operator-report`
+        `python -m src.cli wikidata cohort-d-operator-report`
       - Cohort E:
         `src/ontology/wikidata_cohort_e_diagnostics.py` plus
         `cli/cohort_e_diagnostics.py`
       - automation graduation:
         `src/ontology/wikidata_nat_automation_graduation.py` plus
-        `sensiblaw wikidata automation-graduation-eval` and
-        `sensiblaw wikidata automation-graduation-eval-batch`
+        `python -m src.cli wikidata automation-graduation-eval` and
+        `python -m src.cli wikidata automation-graduation-eval-batch`
     - current packet coverage now has a first multi-row attachment index:
       `tests/fixtures/wikidata/wikidata_nat_review_packet_attachment_coverage_20260401.json`
       records `15 / 53` packetized held split rows, with the original packet
@@ -460,9 +460,9 @@ shared handoff.
       and report builder:
       `build_nat_automation_graduation_report(...)`
       plus CLI:
-      `sensiblaw wikidata automation-graduation-eval`
+      `python -m src.cli wikidata automation-graduation-eval`
       plus repeated-run evidence CLI:
-      `sensiblaw wikidata automation-graduation-evidence-report`
+      `python -m src.cli wikidata automation-graduation-evidence-report`
   - current honest read:
     - the moonshot gap is now decomposed into real lane-local evidence work,
       not only roadmap language
@@ -707,12 +707,12 @@ shared handoff.
 - Primary local slice:
   - `tests/fixtures/wikidata/live_p31_p279_slice_20260307.json`
 - Current CLI paths:
-  - `sensiblaw wikidata build-slice`
-  - `sensiblaw wikidata project`
-  - `sensiblaw wikidata find-qualifier-drift`
-  - `sensiblaw wikidata hotspot-generate-clusters`
-  - `sensiblaw wikidata hotspot-eval`
-  - `sensiblaw wikidata disjointness-report`
+  - `python -m src.cli wikidata build-slice`
+  - `python -m src.cli wikidata project`
+  - `python -m src.cli wikidata find-qualifier-drift`
+  - `python -m src.cli wikidata hotspot-generate-clusters`
+  - `python -m src.cli wikidata hotspot-eval`
+  - `python -m src.cli wikidata disjointness-report`
 - Current test-suite interface (flag this as the primary local debug surface for
   the sprint):
   - `tests/test_wikidata_cli.py`

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,14 +1,15 @@
-"""Legacy wrapper for the :mod:`cli` package.
+"""Canonical source-tree gateway for the SensibLaw command line.
 
-This module provides a tiny shim so that existing entry points which
-referenced ``src.cli`` continue to operate.  The real command line
-interface now lives in the top-level :mod:`cli` package.
+Users and repository automation invoke ``python -m src.cli``. The top-level
+:mod:`cli` package contains the command implementation, but is not a separate
+public entry point.
 """
 
 from __future__ import annotations
 
+
 def main() -> None:
-    """Entry point that defers loading the heavy ``cli`` package."""
+    """Load and run the internal command implementation."""
     from cli import main as real_main
 
     real_main()
@@ -19,4 +20,3 @@ __all__ = ["main"]
 
 if __name__ == "__main__":  # pragma: no cover - manual execution helper
     main()
-

--- a/tests/rules/test_rules.py
+++ b/tests/rules/test_rules.py
@@ -7,7 +7,7 @@ from src.rules.reasoner import check_rules
 
 
 def run_cli(*args: str) -> str:
-    cmd = ["python", "-m", "cli", *args]
+    cmd = ["python", "-m", "src.cli", *args]
     completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
     return completed.stdout.strip()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,7 @@ def setup_db(tmp_path: Path) -> tuple[str, int]:
 
 
 def run_cli(db_path: str, *args: str) -> str:
-    cmd = ["python", "-m", "cli", "get", "--db", db_path, *args]
+    cmd = ["python", "-m", "src.cli", "get", "--db", db_path, *args]
     completed = subprocess.run(cmd, capture_output=True, text=True, check=True)
     return completed.stdout.strip()
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -33,7 +33,7 @@ def run_sensiblaw(tmp_path: Path, *args: str) -> subprocess.CompletedProcess:
     )
     env = os.environ.copy()
     env["PYTHONPATH"] = f"{stubs}:{env.get('PYTHONPATH', '')}"
-    cmd = ["python", "-m", "cli", *args]
+    cmd = ["python", "-m", "src.cli", *args]
     return subprocess.run(cmd, capture_output=True, text=True, env=env)
 
 

--- a/tests/test_code_observer_cli.py
+++ b/tests/test_code_observer_cli.py
@@ -16,7 +16,7 @@ ROOT = Path(__file__).resolve().parents[1]
 def test_code_observer_cli_observe_outputs_jsonl(tmp_path: Path) -> None:
     (tmp_path / "example.py").write_text("def main():\n    print('ok')\n", encoding="utf-8")
     proc = subprocess.run(
-        [sys.executable, "-m", "cli", "code-observer", "observe", "--root", str(tmp_path), "--include-glob", "**/*.py"],
+        [sys.executable, "-m", "src.cli", "code-observer", "observe", "--root", str(tmp_path), "--include-glob", "**/*.py"],
         cwd=ROOT,
         check=True,
         text=True,
@@ -38,7 +38,7 @@ def test_code_observer_cli_observe_writes_output_file(tmp_path: Path) -> None:
         [
             sys.executable,
             "-m",
-            "cli",
+            "src.cli",
             "code-observer",
             "observe",
             "--root",

--- a/tests/test_documented_authority_surfaces.py
+++ b/tests/test_documented_authority_surfaces.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_active_docs_do_not_invoke_internal_cli_module() -> None:
+    paths = [
+        ROOT / "README.md",
+        ROOT / "AGENTS.md",
+        *sorted((ROOT / "docs").rglob("*.md")),
+    ]
+
+    internal_invocation = re.compile(
+        r"(?m)^\s*(?:[-*]\s+`?)?(?:\S*/)?python -m cli\.__main__\b"
+    )
+    offenders = []
+    for path in paths:
+        if internal_invocation.search(path.read_text(encoding="utf-8")):
+            offenders.append(str(path.relative_to(ROOT)))
+
+    assert offenders == []
+
+
+def test_active_docs_do_not_advertise_console_alias_as_command() -> None:
+    paths = [
+        ROOT / "README.md",
+        ROOT / "AGENTS.md",
+        *sorted((ROOT / "docs").rglob("*.md")),
+    ]
+
+    console_invocation = re.compile(r"(?m)^\s*(?:[-*]\s+`?)?sensiblaw\s+[a-z]")
+    offenders = []
+    for path in paths:
+        if console_invocation.search(path.read_text(encoding="utf-8")):
+            offenders.append(str(path.relative_to(ROOT)))
+
+    assert offenders == []
+
+
+def test_authority_map_records_all_migration_tracks() -> None:
+    text = (ROOT / "docs" / "authority_surfaces.md").read_text(encoding="utf-8")
+
+    for path in (
+        "database/postgres_migrations/",
+        "database/migrations/",
+        "migrations/",
+        "schemas/migrations/",
+    ):
+        assert path in text

--- a/tests/test_research_health_cli.py
+++ b/tests/test_research_health_cli.py
@@ -35,7 +35,15 @@ def _build_store(tmp_path: Path) -> Path:
 
 
 def _run_cli(db_path: Path) -> dict:
-    cmd = ["python", "-m", "cli", "report", "research-health", "--db", str(db_path)]
+    cmd = [
+        "python",
+        "-m",
+        "src.cli",
+        "report",
+        "research-health",
+        "--db",
+        str(db_path),
+    ]
     completed = subprocess.run(cmd, check=True, capture_output=True, text=True)
     return json.loads(completed.stdout.strip())
 

--- a/tests/test_wikidata_benchmark_matrix_cli.py
+++ b/tests/test_wikidata_benchmark_matrix_cli.py
@@ -10,7 +10,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_wikidata_benchmark_matrix_cli_defaults_cache_only() -> None:
     proc = subprocess.run(
-        [sys.executable, "-m", "cli", "wikidata", "benchmark-matrix", "--lane", "projection"],
+        [sys.executable, "-m", "src.cli", "wikidata", "benchmark-matrix", "--lane", "projection"],
         cwd=ROOT,
         check=True,
         text=True,


### PR DESCRIPTION
## Summary

- add a normative runtime authority map for the competing compiler, parser, package, API, follow, linkage, world-model, utility, UI, and migration surfaces
- establish `python -m src.cli` / `src.cli:main` as the sole source-tree CLI gateway and rewrite runnable documentation and subprocess tests to use it
- classify `src.section_parser` as deprecated compatibility projection and distinguish the two `parse_canonical_text` operations
- document PostgreSQL as active, SQLite as deprecated, and the root/schema SQL directories as superseded reference tracks
- record the duplicate `006_*` / `007_*` PostgreSQL and `002_*` SQLite prefix hazards without renaming applied migrations
- make the optional code-observer import lazy so the canonical CLI can render help without the extra installed

## Why

The repository has repeatedly allowed execution policy, persistence policy, lane identity, and compatibility history to produce competing top-level implementations. Several existing docs then advertised those surfaces as interchangeable even where their semantic compiler contracts and materialized products differ.

This change freezes the authority boundaries before structural consolidation. It does not pretend the operational and fibred compiler paths already have parity, and it does not perform the larger package/router/compiler migrations.

## Validation

- `18 passed` across the authority guardrails and all modified subprocess CLI tests
- Ruff passed for all modified Python files
- `python -m src.cli --help` succeeds without the optional code-observer extra
- `git diff --check` passed
- remote comparison confirms one commit, 55 files, directly ahead of `main` with no divergence
