### PR TITLE
Add document parser fibres

### DIFF
--- a/docs/authority_surfaces.md
+++ b/docs/authority_surfaces.md
@@ -75,7 +75,19 @@ cannot use the shared CLI lifecycle.
 The existing compiler modules do not differ only by throughput:
 
 - `compile_directory_postgres` uses `compile_document_operational` and the
-  `postgres-semantic-compiler:v0_10` contract.
+  `postgres-semantic-compiler:v0_11` contract. Oversized inputs are parser
+  execution fibres over one document structural carrier; chunk outputs do not
+  become independent semantic graphs or document identities.
+
+  The active large-document contract is:
+
+  - exact, disjoint ownership intervals over canonical document coordinates;
+  - bounded bilateral context overlap selected below the parser safety limit;
+  - parallel physical parsing with deterministic global token/span coordinates;
+  - atomic per-fibre checkpoints keyed by source, policy, and interval identity;
+  - explicit cross-fibre demand and fixed-point receipts;
+  - one document-level mention, PNF, constraint, and demand computation;
+  - one PostgreSQL savepoint commit after document reconciliation.
 - parallel and curated paths use `compile_document_fibred_operational` and the
   `postgres-fibred-semantic-compiler:v0_2` contract.
 - persistence, retry, admission-receipt, and progress behavior also differ.

--- a/docs/itir_vs_sl.md
+++ b/docs/itir_vs_sl.md
@@ -69,7 +69,11 @@ Differences are policy and enforcement, not architecture.
 ## Next actions (planned)
 - Formal mapping table: ITIR/TIRC primitives → SL primitives (lossless vs lossy).
 - Page-stability invariant test across paginated variants.
-- Large-doc ingest path (chunking + repetition metadata) exposed in both general and legal modes.
+- Large-document parser execution now uses bounded overlapping fibres over one
+  pre-built document structural carrier. Fibre outputs retain global offsets,
+  exact ownership intervals, checkpoint receipts, and cross-fibre debt; they
+  are reconciled before the one document-level PNF fixed point and transactional
+  commit. General and legal-adjunct compilation use the same path.
 
 ## Boundary references
 - `docs/planning/extraction_enrichment_boundary_20260307.md`

--- a/scripts/run_complete_tranche.py
+++ b/scripts/run_complete_tranche.py
@@ -36,7 +36,10 @@ from src.pnf.external_reconciliation import (  # noqa: E402
 )
 from src.pnf.legal_adjunct import project_legal_ir  # noqa: E402
 from src.policy.corpus_compilation import default_compiler_context  # noqa: E402
-from src.policy.postgres_corpus_compilation import compile_directory_postgres  # noqa: E402
+from src.policy.postgres_corpus_compilation import (  # noqa: E402
+    OPERATIONAL_COMPILER_CONTRACT,
+    compile_directory_postgres,
+)
 from src.runtime.progress import PhaseRecorder  # noqa: E402
 from src.runtime.tranche_pipeline import (  # noqa: E402
     PhaseReceipt,
@@ -100,6 +103,30 @@ def _parse_args() -> argparse.Namespace:
         type=int,
         default=8,
         help="Owner partitions per document for the PostgreSQL compile phase.",
+    )
+    parser.add_argument(
+        "--parser-workers",
+        type=int,
+        default=2,
+        help="Parser-fibre workers used only for oversized documents.",
+    )
+    parser.add_argument(
+        "--parser-limit-chars",
+        type=int,
+        default=1_000_000,
+        help="Safety threshold above which parser-fibre execution is required.",
+    )
+    parser.add_argument(
+        "--parser-target-chars",
+        type=int,
+        default=400_000,
+        help="Owned characters per oversized-document parser fibre.",
+    )
+    parser.add_argument(
+        "--parser-overlap-chars",
+        type=int,
+        default=8_192,
+        help="Bilateral context overlap for parser fibres.",
     )
     parser.add_argument("--no-wiktionary", action="store_true")
     args = parser.parse_args()
@@ -455,11 +482,15 @@ def _run_one(args: argparse.Namespace, tranche: str) -> dict[str, Any]:
             progress=compile_progress,
             state_path=compile_state_path,
             document_executor_ref="document-executor:postgres-operational:v0_1",
-            document_executor_contract_ref="postgres-semantic-compiler:v0_10",
+            document_executor_contract_ref=OPERATIONAL_COMPILER_CONTRACT,
             persistence_strategy_ref="persistence:postgres-savepoint:v0_1",
             admission_policy_ref="admission:inventoried-only:v0_1",
             closure_workers=args.closure_workers,
             owner_partitions=args.owner_partitions,
+            parser_workers=args.parser_workers,
+            parser_limit_chars=args.parser_limit_chars,
+            parser_target_chars=args.parser_target_chars,
+            parser_overlap_chars=args.parser_overlap_chars,
         )
         compile_progress.write_json(output_dir / "local_pnf_compile_progress.json")
         compile_payload = {
@@ -705,11 +736,15 @@ def _run_one(args: argparse.Namespace, tranche: str) -> dict[str, Any]:
                     progress=adjunct_progress,
                     state_path=adjunct_state_path,
                     document_executor_ref="document-executor:postgres-operational:v0_1",
-                    document_executor_contract_ref="postgres-semantic-compiler:v0_10",
+                    document_executor_contract_ref=OPERATIONAL_COMPILER_CONTRACT,
                     persistence_strategy_ref="persistence:postgres-savepoint:v0_1",
                     admission_policy_ref="admission:inventoried-only:v0_1",
                     closure_workers=args.closure_workers,
                     owner_partitions=args.owner_partitions,
+                    parser_workers=args.parser_workers,
+                    parser_limit_chars=args.parser_limit_chars,
+                    parser_target_chars=args.parser_target_chars,
+                    parser_overlap_chars=args.parser_overlap_chars,
                 )
                 adjunct_progress.write_json(
                     output_dir / "legal_adjunct_pnf_compile_progress.json"

--- a/src/nlp/spacy_adapter.py
+++ b/src/nlp/spacy_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+from threading import Lock
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
 
@@ -13,6 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
 __all__ = ["parse"]
 
 _DEFAULT_NLP: Optional["Language"] = None
+_DEFAULT_NLP_LOCK = Lock()
 
 
 def _import_spacy() -> ModuleType:
@@ -25,27 +27,29 @@ def _build_default_nlp() -> "Language":
     if _DEFAULT_NLP is not None:
         return _DEFAULT_NLP
 
-    spacy = _import_spacy()
-
-    try:
-        nlp = spacy.load("en_core_web_sm", disable=["ner"])
-    except OSError:
-        nlp = spacy.blank("en")
-
-    if "parser" not in nlp.pipe_names and "senter" not in nlp.pipe_names:
-        if "sentencizer" not in nlp.pipe_names:
-            nlp.add_pipe("sentencizer")
-
-    if "lemmatizer" not in nlp.pipe_names:
+    with _DEFAULT_NLP_LOCK:
+        if _DEFAULT_NLP is not None:
+            return _DEFAULT_NLP
+        spacy = _import_spacy()
         try:
-            lemmatizer = nlp.add_pipe("lemmatizer", config={"mode": "lookup"})
-            lemmatizer.initialize(lambda: [], nlp=nlp)
-        except Exception:
-            if "lemmatizer" in nlp.pipe_names:
-                nlp.remove_pipe("lemmatizer")
+            nlp = spacy.load("en_core_web_sm", disable=["ner"])
+        except OSError:
+            nlp = spacy.blank("en")
 
-    _DEFAULT_NLP = nlp
-    return nlp
+        if "parser" not in nlp.pipe_names and "senter" not in nlp.pipe_names:
+            if "sentencizer" not in nlp.pipe_names:
+                nlp.add_pipe("sentencizer")
+
+        if "lemmatizer" not in nlp.pipe_names:
+            try:
+                lemmatizer = nlp.add_pipe("lemmatizer", config={"mode": "lookup"})
+                lemmatizer.initialize(lambda: [], nlp=nlp)
+            except Exception:
+                if "lemmatizer" in nlp.pipe_names:
+                    nlp.remove_pipe("lemmatizer")
+
+        _DEFAULT_NLP = nlp
+        return nlp
 
 
 def _ensure_sentence_boundaries(nlp: "Language") -> None:

--- a/src/pnf/document_fibres.py
+++ b/src/pnf/document_fibres.py
@@ -1,0 +1,553 @@
+"""Bounded parser execution fibres over one document-level semantic carrier.
+
+Chunks in this module are physical parser work units only. They have disjoint
+ownership intervals, overlapping context intervals, and global source
+coordinates. Their observations are reconstructed into one parser document
+before mention licensing, PNF construction, constraint closure, or persistence.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any, Callable, Mapping, Sequence
+
+from src.policy.carriers.canonical import canonical_sha256
+
+
+DOCUMENT_FIBRE_CONTRACT = "parser-document-fibres:v0_1"
+DOCUMENT_FIBRE_SCHEMA_VERSION = "sl.pnf.document_fibre.v0_1"
+DOCUMENT_CARRIER_SCHEMA_VERSION = "sl.pnf.document_structural_carrier.v0_1"
+
+
+@dataclass(frozen=True)
+class DocumentFibrePolicy:
+    """Physical chunk policy; none of these values changes semantic authority."""
+
+    parser_limit_chars: int = 1_000_000
+    target_chars: int = 400_000
+    overlap_chars: int = 8_192
+    workers: int = 2
+
+    def __post_init__(self) -> None:
+        if self.parser_limit_chars < 1:
+            raise ValueError("parser_limit_chars must be positive")
+        if not 1 <= self.workers <= 32:
+            raise ValueError("parser fibre workers must be between 1 and 32")
+        if self.target_chars < 1:
+            raise ValueError("parser fibre target_chars must be positive")
+        if self.overlap_chars < 0:
+            raise ValueError("parser fibre overlap_chars must be non-negative")
+        if self.target_chars + (2 * self.overlap_chars) >= self.parser_limit_chars:
+            raise ValueError(
+                "parser fibre target plus bilateral overlap must stay below "
+                "parser limit"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "contract_ref": DOCUMENT_FIBRE_CONTRACT,
+            "parser_limit_chars": self.parser_limit_chars,
+            "target_chars": self.target_chars,
+            "overlap_chars": self.overlap_chars,
+            "workers": self.workers,
+            "worker_count_semantic_effect": "none",
+        }
+
+
+@dataclass(frozen=True)
+class DocumentFibre:
+    document_ref: str
+    fibre_ref: str
+    sequence_no: int
+    owner_start: int
+    owner_end: int
+    context_start: int
+    context_end: int
+    text_sha256: str
+
+    def __post_init__(self) -> None:
+        if self.sequence_no < 0:
+            raise ValueError("fibre sequence_no must be non-negative")
+        if not 0 <= self.context_start <= self.owner_start:
+            raise ValueError("fibre left context does not contain ownership")
+        if not self.owner_start < self.owner_end <= self.context_end:
+            raise ValueError("fibre right context does not contain ownership")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": DOCUMENT_FIBRE_SCHEMA_VERSION,
+            "document_ref": self.document_ref,
+            "fibre_ref": self.fibre_ref,
+            "sequence_no": self.sequence_no,
+            "owner_start": self.owner_start,
+            "owner_end": self.owner_end,
+            "context_start": self.context_start,
+            "context_end": self.context_end,
+            "text_sha256": self.text_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class DocumentStructuralCarrier:
+    document_ref: str
+    canonical_text_sha256: str
+    canonical_length: int
+    policy: DocumentFibrePolicy
+    fibres: tuple[DocumentFibre, ...]
+
+    @property
+    def carrier_ref(self) -> str:
+        return "document-structural-carrier:" + canonical_sha256(
+            self.to_dict(include_ref=False)
+        )
+
+    def to_dict(self, *, include_ref: bool = True) -> dict[str, Any]:
+        payload = {
+            "schema_version": DOCUMENT_CARRIER_SCHEMA_VERSION,
+            "document_ref": self.document_ref,
+            "canonical_text_sha256": self.canonical_text_sha256,
+            "canonical_length": self.canonical_length,
+            "policy": self.policy.to_dict(),
+            "fibres": [row.to_dict() for row in self.fibres],
+            "ownership_coverage": "exactly_once",
+            "context_overlap_semantic_effect": "evidence_only",
+        }
+        if include_ref:
+            payload["carrier_ref"] = self.carrier_ref
+        return payload
+
+
+def _safe_owner_end(text: str, *, start: int, desired: int, target: int) -> int:
+    """Choose a stable structural boundary without invoking a second parser."""
+
+    if desired >= len(text):
+        return len(text)
+    search_floor = max(start + 1, desired - max(1_024, target // 10))
+    search_ceiling = min(len(text), desired + max(1_024, target // 10))
+    window = text[search_floor:search_ceiling]
+    for separator in ("\n\n", "\n", ". ", "; ", " "):
+        offset = window.rfind(separator, 0, desired - search_floor + 1)
+        if offset >= 0:
+            return search_floor + offset + len(separator)
+    return desired
+
+
+def build_document_structural_carrier(
+    *,
+    document_ref: str,
+    canonical_text: str,
+    policy: DocumentFibrePolicy,
+) -> DocumentStructuralCarrier:
+    """Build disjoint ownership fibres with bounded bilateral context."""
+
+    if not canonical_text:
+        raise ValueError("document structural carrier requires canonical text")
+    digest = hashlib.sha256(canonical_text.encode("utf-8")).hexdigest()
+    owner_intervals: list[tuple[int, int]] = []
+    owner_start = 0
+    while owner_start < len(canonical_text):
+        desired = min(len(canonical_text), owner_start + policy.target_chars)
+        owner_end = _safe_owner_end(
+            canonical_text,
+            start=owner_start,
+            desired=desired,
+            target=policy.target_chars,
+        )
+        if owner_end <= owner_start:
+            owner_end = desired
+        owner_intervals.append((owner_start, owner_end))
+        owner_start = owner_end
+
+    fibres: list[DocumentFibre] = []
+    for sequence_no, (start, end) in enumerate(owner_intervals):
+        context_start = max(0, start - policy.overlap_chars)
+        context_end = min(len(canonical_text), end + policy.overlap_chars)
+        context = canonical_text[context_start:context_end]
+        fibre_ref = "document-fibre:" + canonical_sha256(
+            {
+                "contract_ref": DOCUMENT_FIBRE_CONTRACT,
+                "document_ref": document_ref,
+                "canonical_text_sha256": digest,
+                "sequence_no": sequence_no,
+                "owner_start": start,
+                "owner_end": end,
+                "context_start": context_start,
+                "context_end": context_end,
+                "context_sha256": hashlib.sha256(context.encode("utf-8")).hexdigest(),
+                "policy": policy.to_dict(),
+            }
+        )
+        fibres.append(
+            DocumentFibre(
+                document_ref=document_ref,
+                fibre_ref=fibre_ref,
+                sequence_no=sequence_no,
+                owner_start=start,
+                owner_end=end,
+                context_start=context_start,
+                context_end=context_end,
+                text_sha256=hashlib.sha256(context.encode("utf-8")).hexdigest(),
+            )
+        )
+    return DocumentStructuralCarrier(
+        document_ref=document_ref,
+        canonical_text_sha256=digest,
+        canonical_length=len(canonical_text),
+        policy=policy,
+        fibres=tuple(fibres),
+    )
+
+
+def _checkpoint_path(checkpoint_dir: Path, fibre: DocumentFibre) -> Path:
+    digest = fibre.fibre_ref.removeprefix("document-fibre:")
+    return checkpoint_dir / f"{digest}.json"
+
+
+def _load_checkpoint(
+    checkpoint_dir: Path | None,
+    fibre: DocumentFibre,
+) -> dict[str, Any] | None:
+    if checkpoint_dir is None:
+        return None
+    path = _checkpoint_path(checkpoint_dir, fibre)
+    if not path.exists():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if (
+        not isinstance(payload, dict)
+        or payload.get("contract_ref") != DOCUMENT_FIBRE_CONTRACT
+        or payload.get("fibre") != fibre.to_dict()
+        or not isinstance(payload.get("parsed_document"), dict)
+    ):
+        return None
+    return dict(payload["parsed_document"])
+
+
+def _save_checkpoint(
+    checkpoint_dir: Path | None,
+    fibre: DocumentFibre,
+    parsed_document: Mapping[str, Any],
+) -> None:
+    if checkpoint_dir is None:
+        return
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    path = _checkpoint_path(checkpoint_dir, fibre)
+    payload = {
+        "contract_ref": DOCUMENT_FIBRE_CONTRACT,
+        "fibre": fibre.to_dict(),
+        "parsed_document": dict(parsed_document),
+    }
+    with tempfile.NamedTemporaryFile(
+        "w",
+        encoding="utf-8",
+        dir=checkpoint_dir,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        json.dump(payload, handle, ensure_ascii=False, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+        temp_path = Path(handle.name)
+    temp_path.replace(path)
+
+
+def _parse_fibre(
+    *,
+    fibre: DocumentFibre,
+    canonical_text: str,
+    parser: Callable[[str], Mapping[str, Any]],
+    checkpoint_dir: Path | None,
+) -> tuple[DocumentFibre, dict[str, Any], bool]:
+    checkpoint = _load_checkpoint(checkpoint_dir, fibre)
+    if checkpoint is not None:
+        return fibre, checkpoint, True
+    context = canonical_text[fibre.context_start:fibre.context_end]
+    if len(context) >= 1_000_000:
+        raise ValueError("document fibre exceeds parser safety limit")
+    parsed = dict(parser(context))
+    if str(parsed.get("text") or "") != context:
+        raise ValueError("parser fibre output disagrees with canonical context")
+    _save_checkpoint(checkpoint_dir, fibre, parsed)
+    return fibre, parsed, False
+
+
+def _owner_for_position(
+    fibres: Sequence[DocumentFibre],
+    position: int,
+) -> DocumentFibre:
+    for fibre in fibres:
+        if fibre.owner_start <= position < fibre.owner_end:
+            return fibre
+    return fibres[-1]
+
+
+def _merge_fibre_parses(
+    *,
+    carrier: DocumentStructuralCarrier,
+    canonical_text: str,
+    parsed_by_ref: Mapping[str, Mapping[str, Any]],
+    reused_fibre_count: int,
+) -> dict[str, Any]:
+    selected_sentences: list[dict[str, Any]] = []
+    receipts: list[Mapping[str, Any]] = []
+    capabilities: list[Mapping[str, Any]] = []
+    for fibre in carrier.fibres:
+        parsed = parsed_by_ref[fibre.fibre_ref]
+        receipt = parsed.get("parser_receipt") or {}
+        if isinstance(receipt, Mapping):
+            receipts.append(receipt)
+            capability = receipt.get("capabilities") or {}
+            if isinstance(capability, Mapping):
+                capabilities.append(capability)
+        for sentence_no, sentence in enumerate(parsed.get("sents") or ()):
+            if not isinstance(sentence, Mapping):
+                continue
+            global_start = fibre.context_start + int(sentence.get("start", 0))
+            global_end = fibre.context_start + int(
+                sentence.get("end", sentence.get("start", 0))
+            )
+            if not fibre.owner_start <= global_start < fibre.owner_end:
+                continue
+            selected_sentences.append(
+                {
+                    "fibre": fibre,
+                    "sentence_no": sentence_no,
+                    "start": global_start,
+                    "end": global_end,
+                    "tokens": [
+                        dict(token)
+                        for token in sentence.get("tokens") or ()
+                        if isinstance(token, Mapping)
+                    ],
+                }
+            )
+    selected_sentences.sort(
+        key=lambda row: (
+            int(row["start"]),
+            int(row["end"]),
+            row["fibre"].sequence_no,
+            int(row["sentence_no"]),
+        )
+    )
+
+    token_rows: list[
+        tuple[tuple[str, int], tuple[int, int, str], dict[str, Any]]
+    ] = []
+    for sentence in selected_sentences:
+        fibre = sentence["fibre"]
+        for token in sentence["tokens"]:
+            local_index = int(token.get("index", 0))
+            global_start = fibre.context_start + int(token.get("start", 0))
+            global_end = fibre.context_start + int(
+                token.get("end", token.get("start", 0))
+            )
+            key = (global_start, global_end, str(token.get("text") or ""))
+            token_rows.append(((fibre.fibre_ref, local_index), key, token))
+    ordered_keys = sorted({row[1] for row in token_rows})
+    global_index_by_key = {key: index for index, key in enumerate(ordered_keys)}
+    key_by_local = {local: key for local, key, _token in token_rows}
+
+    demands: list[dict[str, Any]] = []
+    merged_sentences: list[dict[str, Any]] = []
+    for sentence in selected_sentences:
+        fibre = sentence["fibre"]
+        merged_tokens: list[dict[str, Any]] = []
+        for token in sentence["tokens"]:
+            local_index = int(token.get("index", 0))
+            local_head = int(token.get("head_index", local_index))
+            token_key = key_by_local[(fibre.fibre_ref, local_index)]
+            head_key = key_by_local.get((fibre.fibre_ref, local_head))
+            global_index = global_index_by_key[token_key]
+            if head_key is None:
+                head_index = global_index
+                demand_state = "unresolved"
+            else:
+                head_index = global_index_by_key[head_key]
+                token_owner = _owner_for_position(carrier.fibres, token_key[0])
+                head_owner = _owner_for_position(carrier.fibres, head_key[0])
+                demand_state = (
+                    "resolved"
+                    if token_owner.fibre_ref != head_owner.fibre_ref
+                    else ""
+                )
+            if demand_state:
+                demands.append(
+                    {
+                        "demand_ref": "cross-fibre-demand:"
+                        + canonical_sha256(
+                            {
+                                "document_ref": carrier.document_ref,
+                                "token": token_key,
+                                "head": head_key,
+                            }
+                        ),
+                        "demand_type": "dependency_endpoint",
+                        "state": demand_state,
+                        "token_global_index": global_index,
+                        "head_global_index": head_index,
+                        "source_fibre_ref": fibre.fibre_ref,
+                    }
+                )
+            merged_tokens.append(
+                {
+                    **token,
+                    "index": global_index,
+                    "head_index": head_index,
+                    "start": token_key[0],
+                    "end": token_key[1],
+                }
+            )
+        merged_sentences.append(
+            {
+                "text": canonical_text[int(sentence["start"]):int(sentence["end"])],
+                "start": int(sentence["start"]),
+                "end": int(sentence["end"]),
+                "tokens": merged_tokens,
+                "fibre_ref": fibre.fibre_ref,
+            }
+        )
+
+    capability_keys = sorted(
+        {str(key) for row in capabilities for key in row}
+    )
+    merged_capabilities = {
+        key: all(bool(row.get(key, False)) for row in capabilities)
+        for key in capability_keys
+    }
+    unresolved_count = sum(row["state"] == "unresolved" for row in demands)
+    parser_contracts = sorted(
+        {
+            str(row.get("contract_ref") or row.get("backend_ref") or "")
+            for row in receipts
+        }
+    )
+    return {
+        "text": canonical_text,
+        "sents": merged_sentences,
+        "parser_receipt": {
+            "contract_ref": DOCUMENT_FIBRE_CONTRACT,
+            "backend_ref": "parser:document-fibres",
+            "upstream_parser_contract_refs": parser_contracts,
+            "capabilities": merged_capabilities,
+            "authority": "parser_observation_only",
+            "document_structural_carrier": carrier.to_dict(),
+            "fibre_count": len(carrier.fibres),
+            "reused_fibre_count": reused_fibre_count,
+            "cross_fibre_demands": sorted(
+                demands,
+                key=lambda row: str(row["demand_ref"]),
+            ),
+            "cross_fibre_fixed_point": {
+                "state": (
+                    "closed"
+                    if unresolved_count == 0
+                    else "bounded_with_residuals"
+                ),
+                "iterations": 1,
+                "layer": "parser_observation",
+                "unresolved_demand_count": unresolved_count,
+                "semantic_object": "document",
+                "fibre_semantic_authority": False,
+            },
+        },
+    }
+
+
+def parse_document_fibres(
+    *,
+    document_ref: str,
+    canonical_text: str,
+    parser: Callable[[str], Mapping[str, Any]],
+    policy: DocumentFibrePolicy | None = None,
+    checkpoint_dir: str | Path | None = None,
+    progress: Any | None = None,
+) -> dict[str, Any]:
+    """Parse a document monolithically or as fibres under one output contract."""
+
+    selected_policy = policy or DocumentFibrePolicy()
+    if len(canonical_text) < selected_policy.parser_limit_chars:
+        parsed = dict(parser(canonical_text))
+        receipt = dict(parsed.get("parser_receipt") or {})
+        receipt.update(
+            {
+                "document_fibre_contract": DOCUMENT_FIBRE_CONTRACT,
+                "execution_mode": "whole_document",
+                "fibre_count": 1,
+                "reused_fibre_count": 0,
+                "cross_fibre_demands": [],
+                "cross_fibre_fixed_point": {
+                    "state": "closed",
+                    "iterations": 0,
+                    "layer": "parser_observation",
+                    "unresolved_demand_count": 0,
+                    "semantic_object": "document",
+                    "fibre_semantic_authority": False,
+                },
+            }
+        )
+        parsed["parser_receipt"] = receipt
+        return parsed
+
+    carrier = build_document_structural_carrier(
+        document_ref=document_ref,
+        canonical_text=canonical_text,
+        policy=selected_policy,
+    )
+    resolved_checkpoint_dir = (
+        Path(checkpoint_dir).resolve() if checkpoint_dir is not None else None
+    )
+    results: dict[str, Mapping[str, Any]] = {}
+    reused_count = 0
+    with ThreadPoolExecutor(max_workers=selected_policy.workers) as pool:
+        futures = {
+            pool.submit(
+                _parse_fibre,
+                fibre=fibre,
+                canonical_text=canonical_text,
+                parser=parser,
+                checkpoint_dir=resolved_checkpoint_dir,
+            ): fibre
+            for fibre in carrier.fibres
+        }
+        for future in as_completed(futures):
+            fibre, parsed, reused = future.result()
+            results[fibre.fibre_ref] = parsed
+            reused_count += int(reused)
+            if progress is not None:
+                progress.advance(
+                    amount=0,
+                    message="parser_fibre",
+                    reused=reused,
+                    details={
+                        "document_stage": "parser_annotation",
+                        "fibre_ref": fibre.fibre_ref,
+                        "fibre_sequence_no": fibre.sequence_no,
+                        "fibre_count": len(carrier.fibres),
+                        "owner_start": fibre.owner_start,
+                        "owner_end": fibre.owner_end,
+                    },
+                )
+    return _merge_fibre_parses(
+        carrier=carrier,
+        canonical_text=canonical_text,
+        parsed_by_ref=results,
+        reused_fibre_count=reused_count,
+    )
+
+
+__all__ = [
+    "DOCUMENT_FIBRE_CONTRACT",
+    "DocumentFibre",
+    "DocumentFibrePolicy",
+    "DocumentStructuralCarrier",
+    "build_document_structural_carrier",
+    "parse_document_fibres",
+]

--- a/src/policy/operational_corpus_compilation.py
+++ b/src/policy/operational_corpus_compilation.py
@@ -13,6 +13,11 @@ import hashlib
 from time import monotonic_ns
 from typing import Any, Mapping, Sequence
 
+from src.pnf.document_fibres import (
+    DOCUMENT_FIBRE_CONTRACT,
+    DocumentFibrePolicy,
+    parse_document_fibres,
+)
 from src.pnf.factor_proposals import FactorProposal
 from src.pnf.operational_reference_binding import (
     build_operational_reference_binding_artifacts,
@@ -33,7 +38,7 @@ from src.policy import corpus_compilation as legacy
 from src.runtime.stage_timing import StageTimingLedger
 
 
-OPERATIONAL_COMPILER_CONTRACT = "postgres-semantic-compiler:v0_10"
+OPERATIONAL_COMPILER_CONTRACT = "postgres-semantic-compiler:v0_11"
 DOCUMENT_COMPILE_STAGE_NAMES = (
     "canonical_normalization",
     "parser_annotation",
@@ -321,6 +326,11 @@ def compile_document_operational(
     *,
     closure_workers: int = 2,
     owner_partitions: int = 2,
+    parser_workers: int = 2,
+    parser_limit_chars: int = 1_000_000,
+    parser_target_chars: int = 400_000,
+    parser_overlap_chars: int = 8_192,
+    parser_checkpoint_dir: str | None = None,
     progress: Any | None = None,
 ) -> legacy.DocumentCompilation:
     """Compile one document through the streaming local fixed-point boundary."""
@@ -329,6 +339,12 @@ def compile_document_operational(
         raise ValueError("closure_workers must be between 1 and 32")
     if not 1 <= owner_partitions <= 128:
         raise ValueError("owner_partitions must be between 1 and 128")
+    parser_policy = DocumentFibrePolicy(
+        workers=parser_workers,
+        parser_limit_chars=parser_limit_chars,
+        target_chars=parser_target_chars,
+        overlap_chars=parser_overlap_chars,
+    )
     media_type = legacy.require_text(
         document_input.get("media_type"),
         "media_type",
@@ -405,6 +421,8 @@ def compile_document_operational(
             "media_adapter_ref": source_normalisation["adapter_ref"],
             "context": context_payload,
             "compiler_contract": OPERATIONAL_COMPILER_CONTRACT,
+            "document_fibre_contract": DOCUMENT_FIBRE_CONTRACT,
+            "document_fibre_policy": parser_policy.to_dict(),
             "closure_workers_semantic_effect": "none",
             "owner_partitions_semantic_effect": "none",
         }
@@ -417,7 +435,14 @@ def compile_document_operational(
             "annotation_backend_ref": compiler_context.annotation_backend_ref
         },
     ) as stage:
-        parsed_document = legacy.parse_canonical_text(text)
+        parsed_document = parse_document_fibres(
+            document_ref=document_ref,
+            canonical_text=text,
+            parser=legacy.parse_canonical_text,
+            policy=parser_policy,
+            checkpoint_dir=parser_checkpoint_dir,
+            progress=progress,
+        )
         parsed_token_count = sum(
             len(sentence.get("tokens") or ())
             for sentence in parsed_document.get("sents") or ()
@@ -686,6 +711,15 @@ def compile_document_operational(
     )
 
     demands = legacy.derive_resolution_demands(refined_pnf_graph)
+    parser_receipt = legacy.canonical_json(
+        parsed_document.get("parser_receipt") or {}
+    )
+    cross_fibre_demands = list(
+        parser_receipt.get("cross_fibre_demands") or ()
+    )
+    cross_fibre_fixed_point = dict(
+        parser_receipt.get("cross_fibre_fixed_point") or {}
+    )
     stage_keys = derive_stage_build_keys(
         canonical_text_digest=canonical_text_sha256,
         parser_contract_ref=str(
@@ -736,9 +770,12 @@ def compile_document_operational(
             )
         ],
         "annotation_layer": layer.to_dict(),
-        "parser_receipt": legacy.canonical_json(
-            parsed_document.get("parser_receipt") or {}
+        "parser_receipt": parser_receipt,
+        "document_structural_carrier": parser_receipt.get(
+            "document_structural_carrier"
         ),
+        "cross_fibre_demands": cross_fibre_demands,
+        "cross_fibre_fixed_point": cross_fibre_fixed_point,
         "annotation_graph": {
             "graph_ref": annotation_graph.graph_ref,
             "layer_refs": [layer.layer_ref, semantic_layer.layer_ref],
@@ -780,6 +817,10 @@ def compile_document_operational(
         "semantic_runtime_configuration": {
             "closure_workers": closure_workers,
             "owner_partitions": owner_partitions,
+            "parser_workers": parser_workers,
+            "parser_limit_chars": parser_limit_chars,
+            "parser_target_chars": parser_target_chars,
+            "parser_overlap_chars": parser_overlap_chars,
             "semantic_effect": "none",
         },
         "phase_boundary": {
@@ -794,6 +835,11 @@ def compile_document_operational(
             "pairwise_binding_evidence_materialized": False,
             "streaming_bidirectional": True,
             "shared_graph_mutation": False,
+            "chunks_are_execution_partitions": True,
+            "document_is_semantic_object": True,
+            "cross_fibre_unresolved_demand_count": int(
+                cross_fibre_fixed_point.get("unresolved_demand_count") or 0
+            ),
         },
     }
     operational_artifacts = build_operational_reference_binding_artifacts(

--- a/src/policy/postgres_corpus_compilation.py
+++ b/src/policy/postgres_corpus_compilation.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Mapping, Sequence
 from tqdm.auto import tqdm
 
 from src.ingestion.media_adapter import HtmlDocumentMediaAdapter
+from src.pnf.document_fibres import DOCUMENT_FIBRE_CONTRACT, DocumentFibrePolicy
 from src.policy.carriers.canonical import canonical_sha256
 from src.policy.algebra.revision_identity import factor_revision_ref
 from src.policy.corpus_compilation import CompilerContext, build_corpus_manifest
@@ -170,7 +171,17 @@ def _operational_build_key(
     canonical_text_sha256: str,
     media_adapter_ref: str,
     context: CompilerContext,
+    parser_workers: int = 2,
+    parser_limit_chars: int = 1_000_000,
+    parser_target_chars: int = 400_000,
+    parser_overlap_chars: int = 8_192,
 ) -> str:
+    parser_policy = DocumentFibrePolicy(
+        workers=parser_workers,
+        parser_limit_chars=parser_limit_chars,
+        target_chars=parser_target_chars,
+        overlap_chars=parser_overlap_chars,
+    )
     return canonical_sha256(
         {
             "document_ref": document_ref,
@@ -179,6 +190,8 @@ def _operational_build_key(
             "media_adapter_ref": media_adapter_ref,
             "context": context.to_dict(),
             "compiler_contract": OPERATIONAL_COMPILER_CONTRACT,
+            "document_fibre_contract": DOCUMENT_FIBRE_CONTRACT,
+            "document_fibre_policy": parser_policy.to_dict(),
             "closure_workers_semantic_effect": "none",
             "owner_partitions_semantic_effect": "none",
         }
@@ -450,6 +463,11 @@ def persist_document_compilation(
     batch_index: int,
     closure_workers: int = 1,
     owner_partitions: int = 1,
+    parser_workers: int = 2,
+    parser_limit_chars: int = 1_000_000,
+    parser_target_chars: int = 400_000,
+    parser_overlap_chars: int = 8_192,
+    parser_checkpoint_dir: str | None = None,
     progress: Any | None = None,
 ) -> tuple[str, ...]:
     """Compile and persist one document transactionally.
@@ -491,6 +509,10 @@ def persist_document_compilation(
         canonical_text_sha256=canonical_text_sha256,
         media_adapter_ref=media_adapter_ref,
         context=context,
+        parser_workers=parser_workers,
+        parser_limit_chars=parser_limit_chars,
+        parser_target_chars=parser_target_chars,
+        parser_overlap_chars=parser_overlap_chars,
     )
     with store.transaction() as cursor:
         cached_demand_refs = load_completed_operational_build(
@@ -535,6 +557,13 @@ def persist_document_compilation(
             "source_ref": source_ref,
         },
         context,
+        closure_workers=closure_workers,
+        owner_partitions=owner_partitions,
+        parser_workers=parser_workers,
+        parser_limit_chars=parser_limit_chars,
+        parser_target_chars=parser_target_chars,
+        parser_overlap_chars=parser_overlap_chars,
+        parser_checkpoint_dir=parser_checkpoint_dir,
         progress=progress,
     )
     artifacts = compilation.artifacts
@@ -767,18 +796,29 @@ def compile_directory_postgres(
     admission_policy: Callable[[Mapping[str, Any]], bool] | None = None,
     closure_workers: int = 1,
     owner_partitions: int = 1,
+    parser_workers: int = 2,
+    parser_limit_chars: int = 1_000_000,
+    parser_target_chars: int = 400_000,
+    parser_overlap_chars: int = 8_192,
     progress: PhaseRecorder | None = None,
     state_path: str | Path | None = None,
     resume: bool = True,
 ) -> PersistedCompilation:
     """Compile a bounded directory directly into PostgreSQL."""
 
-    if execution_phase not in {"inventory", "local", "demand_planning"}:
+    if execution_phase not in {
+        "inventory",
+        "local",
+        "demand_planning",
+        "legal_adjunct_demand_planning",
+    }:
         raise ValueError("unsupported corpus compilation phase")
     if closure_workers < 1:
         raise ValueError("closure_workers must be positive")
     if owner_partitions < 1:
         raise ValueError("owner_partitions must be positive")
+    if not 1 <= parser_workers <= 32:
+        raise ValueError("parser_workers must be between 1 and 32")
     root = Path(input_dir).resolve()
     state_file = Path(state_path).resolve() if state_path is not None else None
     run_state: dict[str, Any] | None = None
@@ -813,6 +853,10 @@ def compile_directory_postgres(
             "document_executor_contract_ref": document_executor_contract_ref,
             "persistence_strategy_ref": persistence_strategy_ref,
             "admission_policy_ref": admission_policy_ref,
+            "parser_workers": parser_workers,
+            "parser_limit_chars": parser_limit_chars,
+            "parser_target_chars": parser_target_chars,
+            "parser_overlap_chars": parser_overlap_chars,
         }
         for key, expected in expected_state.items():
             observed = run_state.get(key)
@@ -871,6 +915,10 @@ def compile_directory_postgres(
                 "admission_policy_ref": admission_policy_ref,
                 "closure_workers": closure_workers,
                 "owner_partitions": owner_partitions,
+                "parser_workers": parser_workers,
+                "parser_limit_chars": parser_limit_chars,
+                "parser_target_chars": parser_target_chars,
+                "parser_overlap_chars": parser_overlap_chars,
             },
         )
         if progress is not None
@@ -888,6 +936,10 @@ def compile_directory_postgres(
         "admission_policy_ref": admission_policy_ref,
         "closure_workers": closure_workers,
         "owner_partitions": owner_partitions,
+        "parser_workers": parser_workers,
+        "parser_limit_chars": parser_limit_chars,
+        "parser_target_chars": parser_target_chars,
+        "parser_overlap_chars": parser_overlap_chars,
         "root": str(root),
         "documents": resume_documents,
         "duplicate_occurrences": resume_duplicate_occurrences,
@@ -969,6 +1021,10 @@ def compile_directory_postgres(
                     canonical_text_sha256=canonical_text_sha256,
                     media_adapter_ref=media_adapter_ref,
                     context=context,
+                    parser_workers=parser_workers,
+                    parser_limit_chars=parser_limit_chars,
+                    parser_target_chars=parser_target_chars,
+                    parser_overlap_chars=parser_overlap_chars,
                 )
                 state_entry = resume_documents.get(document_ref)
                 if (
@@ -1077,8 +1133,21 @@ def compile_directory_postgres(
                         batch_index=batch_index,
                         closure_workers=closure_workers,
                         owner_partitions=owner_partitions,
+                        parser_workers=parser_workers,
+                        parser_limit_chars=parser_limit_chars,
+                        parser_target_chars=parser_target_chars,
+                        parser_overlap_chars=parser_overlap_chars,
+                        parser_checkpoint_dir=(
+                            str(
+                                state_file.parent
+                                / f"{state_file.stem}_chunks"
+                                / document_ref.removeprefix("document:")
+                            )
+                            if state_file is not None
+                            else None
+                        ),
                         progress=document_progress,
-                )
+                    )
             except (OSError, UnicodeDecodeError, ValueError, RuntimeError) as error:
                 with store.transaction() as cursor:
                     failure_ref = store.persist_failure(

--- a/tests/pnf/test_document_fibres.py
+++ b/tests/pnf/test_document_fibres.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from src.pnf.document_fibres import (
+    DocumentFibrePolicy,
+    build_document_structural_carrier,
+    parse_document_fibres,
+)
+
+
+def _parser_calls(calls: list[str]):
+    def parse(text: str) -> dict[str, Any]:
+        calls.append(text)
+        sentences = []
+        cursor = 0
+        for index, word in enumerate(text.split()):
+            start = text.index(word, cursor)
+            end = start + len(word)
+            cursor = end
+            token = {
+                "index": index,
+                "text": word,
+                "lemma": word.lower(),
+                "pos": "NOUN",
+                "tag": "",
+                "morph": {},
+                "dep": "ROOT",
+                "head_index": index,
+                "head_text": word,
+                "start": start,
+                "end": end,
+            }
+            sentences.append(
+                {
+                    "text": word,
+                    "start": start,
+                    "end": end,
+                    "tokens": [token],
+                }
+            )
+        return {
+            "text": text,
+            "sents": sentences,
+            "parser_receipt": {
+                "contract_ref": "parser:test:v1",
+                "capabilities": {
+                    "tokenization": True,
+                    "sentence_segmentation": True,
+                },
+                "authority": "parser_observation_only",
+            },
+        }
+
+    return parse
+
+
+def test_structural_carrier_has_exact_ownership_and_bounded_overlap() -> None:
+    text = ("Alpha beta gamma delta.\n\n" * 12).strip()
+    policy = DocumentFibrePolicy(
+        parser_limit_chars=100,
+        target_chars=40,
+        overlap_chars=5,
+        workers=2,
+    )
+    carrier = build_document_structural_carrier(
+        document_ref="document:test",
+        canonical_text=text,
+        policy=policy,
+    )
+
+    assert carrier.fibres[0].owner_start == 0
+    assert carrier.fibres[-1].owner_end == len(text)
+    assert all(
+        left.owner_end == right.owner_start
+        for left, right in zip(carrier.fibres, carrier.fibres[1:])
+    )
+    assert all(
+        fibre.context_end - fibre.context_start < policy.parser_limit_chars
+        for fibre in carrier.fibres
+    )
+
+
+def test_parser_fibres_reconstruct_one_document_and_reuse_checkpoints(
+    tmp_path: Path,
+) -> None:
+    text = ("Alpha beta gamma delta.\n\n" * 12).strip()
+    policy = DocumentFibrePolicy(
+        parser_limit_chars=100,
+        target_chars=40,
+        overlap_chars=5,
+        workers=2,
+    )
+    first_calls: list[str] = []
+    first = parse_document_fibres(
+        document_ref="document:test",
+        canonical_text=text,
+        parser=_parser_calls(first_calls),
+        policy=policy,
+        checkpoint_dir=tmp_path,
+    )
+    second_calls: list[str] = []
+    second = parse_document_fibres(
+        document_ref="document:test",
+        canonical_text=text,
+        parser=_parser_calls(second_calls),
+        policy=policy,
+        checkpoint_dir=tmp_path,
+    )
+
+    assert first["text"] == text
+    assert second["text"] == text
+    assert len(first_calls) == first["parser_receipt"]["fibre_count"]
+    assert second_calls == []
+    assert second["parser_receipt"]["reused_fibre_count"] == len(first_calls)
+    assert second["parser_receipt"]["cross_fibre_fixed_point"][
+        "semantic_object"
+    ] == "document"
+    assert second["parser_receipt"]["cross_fibre_fixed_point"][
+        "fibre_semantic_authority"
+    ] is False

--- a/tests/policy/test_operational_corpus_compilation.py
+++ b/tests/policy/test_operational_corpus_compilation.py
@@ -123,3 +123,43 @@ def test_operational_compiler_emits_document_stage_progress() -> None:
         if event["phase"] == "document_compile" and event["state"] == "running"
     ]
     assert running_messages == list(DOCUMENT_COMPILE_STAGE_NAMES)
+
+
+def test_operational_compiler_chunks_oversized_parser_input(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    text = ("Ada entered the hall. She spoke.\n\n" * 8).strip()
+    observed_lengths: list[int] = []
+    original = legacy.parse_canonical_text
+
+    def bounded_parser(value: str):
+        observed_lengths.append(len(value))
+        if len(value) >= 100:
+            raise AssertionError("oversized text reached parser boundary")
+        return original(value)
+
+    monkeypatch.setattr(legacy, "parse_canonical_text", bounded_parser)
+    compilation = compile_document_operational(
+        {
+            "document_ref": "document:operational-fibre-test",
+            "content_sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "media_type": "text/plain",
+            "canonical_text": text,
+            "source_ref": "source:operational-fibre-test",
+        },
+        default_compiler_context(),
+        parser_workers=2,
+        parser_limit_chars=100,
+        parser_target_chars=40,
+        parser_overlap_chars=5,
+        parser_checkpoint_dir=str(tmp_path),
+    )
+
+    receipt = compilation.artifacts["parser_receipt"]
+    assert compilation.status == "compiled"
+    assert receipt["contract_ref"] == "parser-document-fibres:v0_1"
+    assert receipt["fibre_count"] > 1
+    assert observed_lengths
+    assert max(observed_lengths) < 100
+    assert receipt["cross_fibre_fixed_point"]["semantic_object"] == "document"


### PR DESCRIPTION
## Summary

- add bounded overlapping parser execution fibres over one document structural carrier
- reconstruct one global parser document before mention licensing, PNF construction, closure, and persistence
- add atomic per-fibre checkpoints and deterministic checkpoint reuse
- expose cross-fibre demand/fixed-point receipts without granting chunks semantic authority
- thread parser-fibre policy through the canonical PostgreSQL compiler and tranche runner
- retain one document-level transactional PostgreSQL commit
- bump the operational compiler contract to `postgres-semantic-compiler:v0_11`
- permit the existing legal-adjunct demand-planning phase through the same compiler path
- serialize initialization of the shared spaCy pipeline for concurrent fibre parsing

## Why

The active tranche failed when spaCy received a 1,101,259-character document above its one-million-character safety ceiling. Raising the ceiling would preserve monolithic memory risk. This change treats chunks as resumable physical execution partitions while retaining the document graph as the sole semantic object.

## Validation

- `python -m py_compile` passes for all touched Python files
- `git diff --check` passes
- direct document-fibre checkpoint/reuse smoke passes
- mocked operational compilation passes through eight fibres and the existing document-level PNF/constraint fixed point
- mocked 1,101,259-character input is parsed in three fibres; largest parser input is 416,345 characters; exact ownership covers the complete source
- compiler and PostgreSQL pre-check build-key payloads were reconciled for the v0.11 fibre policy

Ruff and pytest could not be invoked in this workspace because their packages and the project dependency set are not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scalable parsing for large documents using bounded, overlapping sections while preserving document-wide positions and relationships.
  - Added configurable parser workers, section sizes, overlap limits, and checkpoint locations.
  - Added checkpoint reuse to avoid repeating completed parsing work.
  - Added clearer compilation records for cross-section reconciliation and unresolved parsing relationships.
- **Bug Fixes**
  - Prevented concurrent initialization of the default language-processing pipeline.
- **Documentation**
  - Updated compiler and large-document processing guidance to reflect the new execution model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->