### PR TITLE
Add deterministic constraint fixed-point diagnostics

### DIFF
--- a/scripts/inspect_constraint_fixed_point.py
+++ b/scripts/inspect_constraint_fixed_point.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Inspect constraint fixed-point diagnostics from a compilation JSON artefact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+from typing import Any, Mapping
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.policy.constraint_fixed_point_diagnostics import (  # noqa: E402
+    build_diagnostics_from_artifacts,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Compilation or artefact JSON file")
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def _mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def main() -> int:
+    args = _parse_args()
+    payload = _mapping(json.loads(args.input.read_text(encoding="utf-8")), "input")
+    artifacts = payload.get("artifacts")
+    if artifacts is None and isinstance(payload.get("compilation"), Mapping):
+        artifacts = payload["compilation"].get("artifacts")
+    if artifacts is None:
+        artifacts = payload
+    receipt = build_diagnostics_from_artifacts(
+        _mapping(artifacts, "compilation artifacts")
+    ).to_dict()
+    rendered = json.dumps(receipt, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        sys.stdout.write(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/policy/constraint_fixed_point_diagnostics.py
+++ b/src/policy/constraint_fixed_point_diagnostics.py
@@ -1,0 +1,322 @@
+"""Deterministic diagnostics for document-local constraint refinement.
+
+The operational compiler owns semantic state.  This module only observes the
+compiler's durable artefacts and produces a non-authoritative diagnostic receipt.
+It deliberately does not perform refinement, replace factors, resolve demands,
+or alter convergence policy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+
+DIAGNOSTIC_CONTRACT_REF = "constraint-fixed-point-diagnostics:v0_1"
+
+
+def _canonical(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _canonical(value[key]) for key in sorted(value, key=str)}
+    if isinstance(value, (list, tuple)):
+        return [_canonical(item) for item in value]
+    if isinstance(value, set):
+        return [_canonical(item) for item in sorted(value, key=repr)]
+    return value
+
+
+def _fingerprint(value: Any) -> str:
+    payload = json.dumps(
+        _canonical(value),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _rows(value: Any) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return ()
+    return tuple(row for row in value if isinstance(row, Mapping))
+
+
+def _factor_rows(graph: Mapping[str, Any] | None) -> tuple[Mapping[str, Any], ...]:
+    return _rows((graph or {}).get("factors") or ())
+
+
+def _factor_ref(row: Mapping[str, Any]) -> str:
+    return str(row.get("factor_ref") or "")
+
+
+def _factor_map(graph: Mapping[str, Any] | None) -> dict[str, Mapping[str, Any]]:
+    return {
+        ref: row
+        for row in _factor_rows(graph)
+        if (ref := _factor_ref(row))
+    }
+
+
+def _residual_count(graph: Mapping[str, Any] | None) -> int:
+    return sum(len(tuple(row.get("residuals") or ())) for row in _factor_rows(graph))
+
+
+def _alternative_refs(row: Mapping[str, Any]) -> set[str]:
+    return {
+        str(item.get("alternative_ref") or "")
+        for item in _rows(row.get("alternatives") or ())
+        if item.get("alternative_ref")
+    }
+
+
+def _binding_candidate_count(rows: Sequence[Mapping[str, Any]]) -> int:
+    total = 0
+    for row in rows:
+        candidates = row.get("candidate_factor_refs")
+        if candidates is None:
+            candidates = row.get("candidates")
+        if isinstance(candidates, Sequence) and not isinstance(
+            candidates, (str, bytes, bytearray)
+        ):
+            total += len(candidates)
+    return total
+
+
+def _stage_elapsed_ms(
+    semantic_stage_timing: Mapping[str, Any] | None,
+    stage_name: str,
+) -> int:
+    timing = semantic_stage_timing or {}
+    totals = timing.get("stage_totals_ms") or {}
+    if isinstance(totals, Mapping):
+        value = totals.get(stage_name)
+        if value is not None:
+            return max(0, int(value))
+    return sum(
+        max(0, int(row.get("elapsed_ms") or 0))
+        for row in _rows(timing.get("timings") or ())
+        if str(row.get("stage") or "") == stage_name
+    )
+
+
+def _persistence_elapsed_ms(semantic_stage_timing: Mapping[str, Any] | None) -> int:
+    return _stage_elapsed_ms(semantic_stage_timing, "postgres_persistence")
+
+
+@dataclass(frozen=True)
+class ConstraintFixedPointDiagnostics:
+    receipt: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self.receipt)
+
+
+def build_constraint_fixed_point_diagnostics(
+    *,
+    pnf_graph: Mapping[str, Any],
+    refined_pnf_graph: Mapping[str, Any],
+    constraint_assessments: Sequence[Mapping[str, Any]] = (),
+    local_meet_plan: Sequence[Mapping[str, Any]] = (),
+    typed_meets: Sequence[Mapping[str, Any]] = (),
+    factor_refinements: Sequence[Mapping[str, Any]] = (),
+    resolution_demands: Sequence[Mapping[str, Any]] = (),
+    binding_candidate_sets_before: Sequence[Mapping[str, Any]] = (),
+    binding_candidate_sets_after: Sequence[Mapping[str, Any]] = (),
+    semantic_stage_timing: Mapping[str, Any] | None = None,
+    iteration: int = 1,
+) -> ConstraintFixedPointDiagnostics:
+    """Build a diagnostic receipt from authoritative compiler artefacts.
+
+    The current operational compiler performs one document-local assessment / meet /
+    refinement pass.  ``iteration`` is therefore explicit and defaults to one rather
+    than pretending that an unobserved iterative loop exists.
+    """
+
+    before = _factor_map(pnf_graph)
+    after = _factor_map(refined_pnf_graph)
+    assessment_rows = tuple(constraint_assessments)
+    plan_rows = tuple(local_meet_plan)
+    meet_rows = tuple(typed_meets)
+    refinement_rows = tuple(factor_refinements)
+    demand_rows = tuple(resolution_demands)
+    binding_before_rows = tuple(binding_candidate_sets_before)
+    binding_after_rows = tuple(binding_candidate_sets_after)
+
+    rewritten_refs = tuple(
+        sorted(
+            ref
+            for ref in before.keys() & after.keys()
+            if _fingerprint(before[ref]) != _fingerprint(after[ref])
+        )
+    )
+    added_factor_refs = tuple(sorted(after.keys() - before.keys()))
+    removed_factor_refs = tuple(sorted(before.keys() - after.keys()))
+
+    added_alternative_refs = {
+        str(ref)
+        for row in refinement_rows
+        for ref in row.get("added_alternative_refs") or ()
+        if ref
+    }
+    rejected_candidate_refs = {
+        str(ref)
+        for row in refinement_rows
+        for ref in row.get("rejected_candidate_refs") or ()
+        if ref
+    }
+    refinement_refs = [
+        str(row.get("refinement_ref") or "") for row in refinement_rows
+    ]
+    duplicate_refinement_count = len(refinement_refs) - len(set(refinement_refs))
+    effective_refinement_count = len(rewritten_refs) + len(added_factor_refs)
+    proposed_refinement_count = len(refinement_rows)
+    rejected_refinement_count = max(
+        0,
+        proposed_refinement_count
+        - effective_refinement_count
+        - duplicate_refinement_count,
+    )
+
+    candidate_meets_considered = len(plan_rows)
+    accepted_meets = sum(
+        1
+        for row in meet_rows
+        if str(row.get("state") or "")
+        not in {"", "incompatible", "rejected", "violated"}
+    )
+
+    residuals_before = _residual_count(pnf_graph)
+    residuals_after = _residual_count(refined_pnf_graph)
+    resolved_demands = max(0, residuals_before - residuals_after)
+    residuals_emitted = max(0, residuals_after - residuals_before)
+    new_accepted_facts = len(added_factor_refs) + len(added_alternative_refs)
+
+    elapsed_ms = _stage_elapsed_ms(semantic_stage_timing, "constraint_fixed_point")
+    elapsed_seconds = elapsed_ms / 1_000.0
+    semantic_progress = (
+        new_accepted_facts + effective_refinement_count + resolved_demands
+    )
+    semantic_yield_per_second = (
+        semantic_progress / elapsed_seconds if elapsed_seconds > 0 else None
+    )
+
+    assessment_to_effective_ratio = (
+        len(assessment_rows) / max(1, effective_refinement_count)
+    )
+    meet_acceptance_ratio = accepted_meets / max(1, candidate_meets_considered)
+    same_semantic_state = _fingerprint(pnf_graph) == _fingerprint(refined_pnf_graph)
+    syntactic_change_without_semantic_progress = (
+        bool(refinement_rows) and semantic_progress == 0
+    )
+
+    if syntactic_change_without_semantic_progress or (
+        same_semantic_state and proposed_refinement_count > 0
+    ):
+        classification = "fixed_point_churn"
+    elif (
+        len(assessment_rows) >= 100
+        and assessment_to_effective_ratio >= 20
+    ) or (
+        candidate_meets_considered >= 100 and meet_acceptance_ratio <= 0.05
+    ):
+        classification = "combinatorial_candidate_explosion"
+    else:
+        classification = "legitimate_high_volume_closure"
+
+    receipt = {
+        "contract_ref": DIAGNOSTIC_CONTRACT_REF,
+        "authority": "diagnostic_only",
+        "iteration": int(iteration),
+        "iteration_elapsed_ms": elapsed_ms,
+        "cumulative_database_read_write_ms": _persistence_elapsed_ms(
+            semantic_stage_timing
+        ),
+        "factors_before": len(before),
+        "factors_after": len(after),
+        "constraint_assessments_evaluated": len(assessment_rows),
+        "candidate_meets_considered": candidate_meets_considered,
+        "candidate_meets_accepted": accepted_meets,
+        "refinements_proposed": proposed_refinement_count,
+        "refinements_applied": effective_refinement_count,
+        "refinements_deduplicated": duplicate_refinement_count,
+        "refinements_rejected": rejected_refinement_count,
+        "factors_rewritten": len(rewritten_refs),
+        "factor_refs_rewritten": list(rewritten_refs),
+        "factor_refs_added": list(added_factor_refs),
+        "factor_refs_removed": list(removed_factor_refs),
+        "residuals_before": residuals_before,
+        "residuals_after": residuals_after,
+        "residuals_emitted": residuals_emitted,
+        "unresolved_demands_produced": len(demand_rows),
+        "resolved_demands": resolved_demands,
+        "binding_candidates_before_compaction": _binding_candidate_count(
+            binding_before_rows
+        ),
+        "binding_candidates_after_compaction": _binding_candidate_count(
+            binding_after_rows
+        ),
+        "new_accepted_facts": new_accepted_facts,
+        "effective_refinements": effective_refinement_count,
+        "semantic_progress_units": semantic_progress,
+        "semantic_yield_per_second": semantic_yield_per_second,
+        "graph_fingerprint_before": _fingerprint(pnf_graph),
+        "graph_fingerprint_after": _fingerprint(refined_pnf_graph),
+        "semantic_state_stable": same_semantic_state,
+        "assessment_to_effective_refinement_ratio": assessment_to_effective_ratio,
+        "meet_acceptance_ratio": meet_acceptance_ratio,
+        "classification": classification,
+        "classification_contract": {
+            "legitimate_high_volume_closure": (
+                "semantic progress remains material relative to assessed candidates"
+            ),
+            "combinatorial_candidate_explosion": (
+                "candidate or assessment volume is high relative to accepted work"
+            ),
+            "fixed_point_churn": (
+                "syntactic refinement activity produces no semantic progress"
+            ),
+        },
+        "zelph_boundary": {
+            "eligible_shape": "(immutable_fact_set, versioned_rule_pack) -> additive_delta",
+            "compiler_retains": [
+                "factor_replacement",
+                "non_monotone_refinement_choices",
+                "residual_and_demand_state",
+                "graph_identity",
+                "transactional_persistence",
+                "convergence_and_resource_limit_policy",
+            ],
+        },
+    }
+    return ConstraintFixedPointDiagnostics(_canonical(receipt))
+
+
+def build_diagnostics_from_artifacts(
+    artifacts: Mapping[str, Any],
+) -> ConstraintFixedPointDiagnostics:
+    """Build diagnostics directly from a document compilation artefact mapping."""
+
+    candidate_sets = tuple(
+        row
+        for row in artifacts.get("binding_candidate_sets") or ()
+        if isinstance(row, Mapping)
+    )
+    candidate_builds = tuple(
+        row
+        for row in artifacts.get("binding_candidate_set_builds") or ()
+        if isinstance(row, Mapping)
+    )
+    return build_constraint_fixed_point_diagnostics(
+        pnf_graph=dict(artifacts.get("pnf_graph") or {}),
+        refined_pnf_graph=dict(artifacts.get("refined_pnf_graph") or {}),
+        constraint_assessments=_rows(artifacts.get("constraint_assessments") or ()),
+        local_meet_plan=_rows(artifacts.get("local_meet_plan") or ()),
+        typed_meets=_rows(artifacts.get("typed_meets") or ()),
+        factor_refinements=_rows(artifacts.get("factor_refinements") or ()),
+        resolution_demands=_rows(artifacts.get("resolution_demands") or ()),
+        binding_candidate_sets_before=candidate_builds,
+        binding_candidate_sets_after=candidate_sets,
+        semantic_stage_timing=dict(artifacts.get("semantic_stage_timing") or {}),
+    )

--- a/src/runtime/document_stage_metrics.py
+++ b/src/runtime/document_stage_metrics.py
@@ -1,0 +1,129 @@
+"""Named throughput measures for document compilation stages.
+
+The registry is descriptive only.  Compiler loops remain authoritative for the
+observed counters and must update them while work is in progress.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+DOCUMENT_STAGE_MEASURES: dict[str, tuple[tuple[str, str], ...]] = {
+    "canonical_normalization": (
+        ("input_chars", "chars"),
+        ("output_chars", "chars"),
+        ("input_bytes", "bytes"),
+        ("output_bytes", "bytes"),
+    ),
+    "parser_annotation": (
+        ("chars", "chars"),
+        ("fibres", "fibres"),
+        ("sentences", "sentences"),
+        ("tokens", "tokens"),
+        ("dependencies", "dependencies"),
+    ),
+    "coordinate_validation": (
+        ("tokens_checked", "tokens"),
+        ("spans_checked", "spans"),
+        ("coordinates_rejected", "coordinates"),
+    ),
+    "mention_licensing": (
+        ("tokens_scanned", "tokens"),
+        ("mentions_considered", "mentions"),
+        ("mentions_licensed", "mentions"),
+        ("recurrences_derived", "recurrences"),
+        ("forms_derived", "forms"),
+    ),
+    "parser_observation_projection": (
+        ("sentences_projected", "sentences"),
+        ("observations_emitted", "observations"),
+        ("deltas_emitted", "deltas"),
+        ("relations_projected", "relations"),
+    ),
+    "base_proposal_generation": (
+        ("atoms_scanned", "atoms"),
+        ("relations_scanned", "relations"),
+        ("proposals_generated", "proposals"),
+        ("factors_emitted", "factors"),
+        ("constraints_emitted", "constraints"),
+    ),
+    "streaming_closure": (
+        ("jobs_completed", "jobs"),
+        ("input_refs_processed", "input_refs"),
+        ("proposals_emitted", "proposals"),
+        ("dirty_groups_reduced", "groups"),
+        ("duplicates_collapsed", "proposals"),
+        ("residuals_emitted", "residuals"),
+    ),
+    "pnf_graph_construction": (
+        ("factors_materialized", "factors"),
+        ("constraints_materialized", "constraints"),
+        ("relations_materialized", "relations"),
+        ("residuals_materialized", "residuals"),
+    ),
+    "constraint_assessment": (
+        ("factors_scanned", "factors"),
+        ("constraints_evaluated", "constraints"),
+        ("assessments_emitted", "assessments"),
+        ("satisfied", "assessments"),
+        ("violated", "assessments"),
+        ("undetermined", "assessments"),
+        ("inapplicable", "assessments"),
+    ),
+    "meet_refinement": (
+        ("candidate_meets_considered", "candidates"),
+        ("typed_meets_accepted", "meets"),
+        ("refinements_proposed", "refinements"),
+        ("refinements_applied", "refinements"),
+        ("refinements_deduplicated", "refinements"),
+        ("refinements_rejected", "refinements"),
+        ("factors_rewritten", "factors"),
+        ("residual_transitions", "transitions"),
+        ("semantic_yield", "semantic_changes"),
+    ),
+    "demand_derivation": (
+        ("factors_scanned", "factors"),
+        ("demands_emitted", "demands"),
+        ("demands_resolved", "demands"),
+        ("demands_unresolved", "demands"),
+    ),
+    "binding_candidate_compaction": (
+        ("candidates_before", "candidates"),
+        ("candidates_after", "candidates"),
+        ("candidates_removed", "candidates"),
+        ("candidate_sets", "sets"),
+    ),
+    "postgres_persistence": (
+        ("rows_written", "rows"),
+        ("bytes_written", "bytes"),
+        ("tables_touched", "tables"),
+        ("statements_executed", "statements"),
+        ("conflicts_avoided", "rows"),
+    ),
+}
+
+
+def stage_measure_declaration(
+    stage: str,
+    *,
+    totals: Mapping[str, int | float | None] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Build the initial measure vector for one declared stage."""
+
+    totals = dict(totals or {})
+    try:
+        definitions = DOCUMENT_STAGE_MEASURES[stage]
+    except KeyError as error:
+        raise ValueError(f"undeclared document progress stage: {stage}") from error
+    return {
+        name: {
+            "completed": 0,
+            "unit": unit,
+            **({"total": totals[name]} if totals.get(name) is not None else {}),
+        }
+        for name, unit in definitions
+    }
+
+
+__all__ = ["DOCUMENT_STAGE_MEASURES", "stage_measure_declaration"]

--- a/src/runtime/progress.py
+++ b/src/runtime/progress.py
@@ -13,7 +13,7 @@ from threading import Event, Lock, Thread
 from typing import Any, Iterator, Mapping, TextIO
 
 
-PROGRESS_SCHEMA_VERSION = "sl.progress_event.v0_2"
+PROGRESS_SCHEMA_VERSION = "sl.progress_event.v0_3"
 PHASE_LEDGER_SCHEMA_VERSION = "sl.phase_ledger.v0_1"
 
 
@@ -26,6 +26,12 @@ def _format_duration_ms(value_ms: int | None) -> str:
         return ""
     seconds = max(0, int(round(value_ms / 1000)))
     return str(timedelta(seconds=seconds))
+
+
+def _rate(completed: int | float, elapsed_ms: int) -> float | None:
+    if completed <= 0 or elapsed_ms <= 0:
+        return None
+    return round(float(completed) / (elapsed_ms / 1_000), 3)
 
 
 @dataclass(frozen=True)
@@ -48,6 +54,13 @@ class ProgressEvent:
     tokens_per_second: float | None = None
     worker: str | None = None
     reused: bool | None = None
+    work_completed: int | None = None
+    work_total: int | None = None
+    work_unit: str | None = None
+    work_elapsed_ms: int | None = None
+    work_units_per_second: float | None = None
+    work_estimated_remaining_ms: int | None = None
+    work_estimated_completion_at: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         payload = asdict(self)
@@ -95,7 +108,10 @@ class PhaseRecorder:
         try:
             yield handle
         except BaseException as error:
-            handle.finish(state="failed", details={"error_type": type(error).__name__, "error": str(error)})
+            handle.finish(
+                state="failed",
+                details={"error_type": type(error).__name__, "error": str(error)},
+            )
             raise
         else:
             handle.finish(state="completed")
@@ -104,7 +120,9 @@ class PhaseRecorder:
         by_phase: dict[str, dict[str, int]] = {}
         for event in self.events:
             phase = str(event["phase"])
-            row = by_phase.setdefault(phase, {"events": 0, "elapsed_ms": 0, "failed": 0})
+            row = by_phase.setdefault(
+                phase, {"events": 0, "elapsed_ms": 0, "failed": 0}
+            )
             row["events"] += 1
             row["elapsed_ms"] += int(event.get("elapsed_ms") or 0)
             row["failed"] += int(event.get("state") == "failed")
@@ -118,7 +136,10 @@ class PhaseRecorder:
     def write_json(self, path: str | Path) -> None:
         target = Path(path)
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(json.dumps(self.to_dict(), indent=2, ensure_ascii=False, sort_keys=True) + "\n")
+        target.write_text(
+            json.dumps(self.to_dict(), indent=2, ensure_ascii=False, sort_keys=True)
+            + "\n"
+        )
 
 
 @dataclass
@@ -134,29 +155,23 @@ class PhaseHandle:
     reused: int = 0
     processed_tokens: int = 0
     total_tokens: int | None = None
+    heartbeat_seconds: float | None = 30.0
+    work_completed: int | None = None
+    work_total: int | None = None
+    work_unit: str | None = None
     _started_at: str | None = None
     _started_ns: int | None = None
+    _work_started_ns: int | None = None
     _finished: bool = False
-    heartbeat_seconds: float | None = 30.0
     _heartbeat_stop: Event = field(default_factory=Event, init=False, repr=False)
     _heartbeat_thread: Thread | None = field(default=None, init=False, repr=False)
+    _state_lock: Lock = field(default_factory=Lock, init=False, repr=False)
 
     def start(self) -> None:
         self._started_at = _utc_now()
         self._started_ns = monotonic_ns()
-        self.recorder.emit(
-            ProgressEvent(
-                phase=self.phase,
-                state="started",
-                completed=self.completed,
-                total=self.total,
-                message=self.message,
-                subject_ref=self.subject_ref,
-                details=self.details or None,
-                started_at=self._started_at,
-                worker=self.worker,
-            )
-        )
+        self._work_started_ns = self._started_ns
+        self.recorder.emit(self._event(state="started", elapsed_ms=0))
         if self.heartbeat_seconds is not None and self.heartbeat_seconds > 0:
             self._heartbeat_thread = Thread(
                 target=self._run_heartbeat,
@@ -170,31 +185,68 @@ class PhaseHandle:
         while not self._heartbeat_stop.wait(self.heartbeat_seconds):
             self.heartbeat()
 
+    def begin_stage(
+        self,
+        stage: str,
+        *,
+        work_total: int | None = None,
+        work_unit: str | None = None,
+        details: Mapping[str, Any] | None = None,
+        subject_ref: str | None = None,
+        worker: str | None = None,
+    ) -> None:
+        """Declare the current inner stage without advancing the outer phase."""
+
+        with self._state_lock:
+            self.message = stage
+            self.details = {"document_stage": stage, **dict(details or {})}
+            self.work_completed = 0
+            self.work_total = work_total
+            self.work_unit = work_unit
+            self._work_started_ns = monotonic_ns()
+            if subject_ref is not None:
+                self.subject_ref = subject_ref
+            if worker is not None:
+                self.worker = worker
+        self.recorder.emit(self._event(state="running", elapsed_ms=self.elapsed_ms))
+
+    def observe(
+        self,
+        *,
+        message: str | None = None,
+        work_completed: int | None = None,
+        work_total: int | None = None,
+        work_unit: str | None = None,
+        details: Mapping[str, Any] | None = None,
+        subject_ref: str | None = None,
+        worker: str | None = None,
+    ) -> None:
+        """Emit current inner work and throughput without completing an outer unit."""
+
+        with self._state_lock:
+            if message is not None:
+                self.message = message
+            if details is not None:
+                self.details = {**self.details, **dict(details)}
+            if work_completed is not None:
+                self.work_completed = max(0, work_completed)
+            if work_total is not None:
+                self.work_total = max(0, work_total)
+            if work_unit is not None:
+                self.work_unit = work_unit
+            if subject_ref is not None:
+                self.subject_ref = subject_ref
+            if worker is not None:
+                self.worker = worker
+        self.recorder.emit(self._event(state="running", elapsed_ms=self.elapsed_ms))
+
     def heartbeat(self) -> None:
         if self._finished:
             return
-        elapsed_ms = self.elapsed_ms
+        with self._state_lock:
+            details = {**self.details, "heartbeat": True}
         self.recorder.emit(
-            ProgressEvent(
-                phase=self.phase,
-                state="heartbeat",
-                completed=self.completed,
-                total=self.total,
-                message=self.message,
-                subject_ref=self.subject_ref,
-                details={**self.details, "heartbeat": True} or None,
-                started_at=self._started_at,
-                elapsed_ms=elapsed_ms,
-                worker=self.worker,
-                **self._estimate(elapsed_ms),
-                processed_tokens=self.processed_tokens or None,
-                total_tokens=self.total_tokens,
-                tokens_per_second=(
-                    round(self.processed_tokens / (elapsed_ms / 1_000), 3)
-                    if self.processed_tokens and elapsed_ms > 0
-                    else None
-                ),
-            )
+            self._event(state="heartbeat", elapsed_ms=self.elapsed_ms, details=details)
         )
 
     def advance(
@@ -208,37 +260,28 @@ class PhaseHandle:
         processed_tokens: int = 0,
         worker: str | None = None,
     ) -> None:
-        self.completed += amount
-        if reused:
-            self.reused += amount
-        self.processed_tokens += max(0, processed_tokens)
-        elapsed_ms = self.elapsed_ms
-        estimate = self._estimate(elapsed_ms)
+        with self._state_lock:
+            self.completed += amount
+            if reused:
+                self.reused += amount
+            self.processed_tokens += max(0, processed_tokens)
+            if message:
+                self.message = message
+            if details is not None:
+                self.details = dict(details)
+            if subject_ref is not None:
+                self.subject_ref = subject_ref
+            if worker is not None:
+                self.worker = worker
         self.recorder.emit(
-            ProgressEvent(
-                phase=self.phase,
+            self._event(
                 state="running",
-                completed=self.completed,
-                total=self.total,
-                message=message,
-                subject_ref=subject_ref or self.subject_ref,
-                details=dict(details or {}) or None,
-                started_at=self._started_at,
-                elapsed_ms=elapsed_ms,
-                worker=worker or self.worker,
+                elapsed_ms=self.elapsed_ms,
                 reused=reused,
-                processed_tokens=self.processed_tokens or None,
-                total_tokens=self.total_tokens,
-                tokens_per_second=(
-                    round(self.processed_tokens / (elapsed_ms / 1_000), 3)
-                    if self.processed_tokens and elapsed_ms > 0
-                    else None
-                ),
-                **estimate,
             )
         )
 
-    def _estimate(self, elapsed_ms: int) -> dict[str, Any]:
+    def _outer_estimate(self, elapsed_ms: int) -> dict[str, Any]:
         if self.total is None or self.total <= 0 or self.completed <= 0 or elapsed_ms <= 0:
             return {}
         throughput = self.completed / (elapsed_ms / 1_000)
@@ -251,11 +294,69 @@ class PhaseHandle:
             ).isoformat(),
         }
 
+    def _work_estimate(self) -> dict[str, Any]:
+        completed = self.work_completed
+        elapsed_ms = self.work_elapsed_ms
+        rate = _rate(completed or 0, elapsed_ms)
+        result: dict[str, Any] = {
+            "work_completed": completed,
+            "work_total": self.work_total,
+            "work_unit": self.work_unit,
+            "work_elapsed_ms": elapsed_ms if self._work_started_ns is not None else None,
+            "work_units_per_second": rate,
+        }
+        if (
+            rate is not None
+            and self.work_total is not None
+            and completed is not None
+            and self.work_total >= completed
+        ):
+            remaining_ms = round((self.work_total - completed) / rate * 1_000)
+            result["work_estimated_remaining_ms"] = max(0, remaining_ms)
+            result["work_estimated_completion_at"] = (
+                datetime.now(UTC) + timedelta(milliseconds=max(0, remaining_ms))
+            ).isoformat()
+        return result
+
+    def _event(
+        self,
+        *,
+        state: str,
+        elapsed_ms: int,
+        details: Mapping[str, Any] | None = None,
+        reused: bool | None = None,
+    ) -> ProgressEvent:
+        token_rate = _rate(self.processed_tokens, elapsed_ms)
+        return ProgressEvent(
+            phase=self.phase,
+            state=state,
+            completed=self.completed,
+            total=self.total,
+            message=self.message,
+            subject_ref=self.subject_ref,
+            details=dict(details if details is not None else self.details) or None,
+            started_at=self._started_at,
+            elapsed_ms=elapsed_ms,
+            worker=self.worker,
+            reused=reused,
+            processed_tokens=self.processed_tokens or None,
+            total_tokens=self.total_tokens,
+            tokens_per_second=token_rate,
+            **self._outer_estimate(elapsed_ms),
+            **self._work_estimate(),
+        )
+
     @property
     def elapsed_ms(self) -> int:
         if self._started_ns is None:
             return 0
         return max(0, (monotonic_ns() - self._started_ns) // 1_000_000)
+
+    @property
+    def work_elapsed_ms(self) -> int:
+        if self._work_started_ns is None:
+            return 0
+        return max(0, (monotonic_ns() - self._work_started_ns) // 1_000_000)
 
     def finish(self, *, state: str, details: Mapping[str, Any] | None = None) -> None:
         if self._finished:
@@ -264,20 +365,13 @@ class PhaseHandle:
         self._heartbeat_stop.set()
         if self._heartbeat_thread is not None:
             self._heartbeat_thread.join(timeout=0.1)
-        merged_details = {**self.details, **dict(details or {}), "reused_units": self.reused}
+        merged_details = {
+            **self.details,
+            **dict(details or {}),
+            "reused_units": self.reused,
+        }
         self.recorder.emit(
-            ProgressEvent(
-                phase=self.phase,
-                state=state,
-                completed=self.completed,
-                total=self.total,
-                message=self.message,
-                subject_ref=self.subject_ref,
-                details=merged_details,
-                started_at=self._started_at,
-                elapsed_ms=self.elapsed_ms,
-                worker=self.worker,
-            )
+            self._event(state=state, elapsed_ms=self.elapsed_ms, details=merged_details)
         )
 
 
@@ -291,7 +385,11 @@ def emit_progress(
 
     target = stream or sys.stderr
     if json_lines:
-        print(json.dumps(event.to_dict(), ensure_ascii=False, sort_keys=True), file=target, flush=True)
+        print(
+            json.dumps(event.to_dict(), ensure_ascii=False, sort_keys=True),
+            file=target,
+            flush=True,
+        )
         return
     total = f"/{event.total}" if event.total is not None else ""
     subject = f" {event.subject_ref}" if event.subject_ref else ""
@@ -303,13 +401,38 @@ def emit_progress(
     )
     worker = f" worker={event.worker}" if event.worker else ""
     reuse = " reused" if event.reused else ""
+    outer_rate = (
+        f" rate={event.throughput_units_per_second:.3f}/s"
+        if event.throughput_units_per_second is not None
+        else ""
+    )
     eta_at = (
         f" eta_at={event.estimated_completion_at}"
         if event.estimated_completion_at
         else ""
     )
+    work = ""
+    if event.work_completed is not None:
+        work_total = f"/{event.work_total}" if event.work_total is not None else ""
+        unit = event.work_unit or "units"
+        work_rate = (
+            f" {event.work_units_per_second:.3f}/{unit}/s"
+            if event.work_units_per_second is not None
+            else ""
+        )
+        work_eta = (
+            f" work_eta={_format_duration_ms(event.work_estimated_remaining_ms)}"
+            if event.work_estimated_remaining_ms is not None
+            else ""
+        )
+        work = f" work={event.work_completed}{work_total} {unit}{work_rate}{work_eta}"
+    token_rate = (
+        f" tokens={event.processed_tokens} ({event.tokens_per_second:.3f}/s)"
+        if event.processed_tokens is not None and event.tokens_per_second is not None
+        else ""
+    )
     print(
-        f"[{event.phase}] {event.state} {event.completed}{total}{subject}{elapsed}{worker}{reuse}{eta_at}{message}",
+        f"[{event.phase}] {event.state} {event.completed}{total}{subject}{elapsed}{worker}{reuse}{outer_rate}{eta_at}{work}{token_rate}{message}",
         file=target,
         flush=True,
     )

--- a/src/runtime/progress.py
+++ b/src/runtime/progress.py
@@ -1,4 +1,13 @@
-"""Deterministic progress and timing events shared by long-running runtime lanes."""
+"""Deterministic progress and timing events shared by long-running runtime lanes.
+
+Progress has two independent coordinates:
+
+* ``completed`` counts closed outer boundaries only;
+* ``active_stage`` names work that has begun but has not yet closed.
+
+Inner throughput is a named measure vector.  Anonymous ``rate=/s`` values are not
+emitted because a rate without a semantic unit is not interpretable.
+"""
 
 from __future__ import annotations
 
@@ -8,12 +17,12 @@ from datetime import UTC, datetime, timedelta
 import json
 from pathlib import Path
 import sys
-from time import monotonic_ns
 from threading import Event, Lock, Thread
+from time import monotonic_ns
 from typing import Any, Iterator, Mapping, TextIO
 
 
-PROGRESS_SCHEMA_VERSION = "sl.progress_event.v0_3"
+PROGRESS_SCHEMA_VERSION = "sl.progress_event.v0_4"
 PHASE_LEDGER_SCHEMA_VERSION = "sl.phase_ledger.v0_1"
 
 
@@ -24,8 +33,7 @@ def _utc_now() -> str:
 def _format_duration_ms(value_ms: int | None) -> str:
     if value_ms is None:
         return ""
-    seconds = max(0, int(round(value_ms / 1000)))
-    return str(timedelta(seconds=seconds))
+    return str(timedelta(seconds=max(0, int(round(value_ms / 1000)))))
 
 
 def _rate(completed: int | float, elapsed_ms: int) -> float | None:
@@ -34,12 +42,43 @@ def _rate(completed: int | float, elapsed_ms: int) -> float | None:
     return round(float(completed) / (elapsed_ms / 1_000), 3)
 
 
+def _measure_snapshot(
+    measures: Mapping[str, Mapping[str, Any]], elapsed_ms: int
+) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for name in sorted(measures):
+        source = dict(measures[name])
+        completed = float(source.get("completed") or 0)
+        total_raw = source.get("total")
+        total = float(total_raw) if total_raw is not None else None
+        unit = str(source.get("unit") or name)
+        rate = _rate(completed, elapsed_ms)
+        row: dict[str, Any] = {
+            "completed": int(completed) if completed.is_integer() else completed,
+            "unit": unit,
+        }
+        if total is not None:
+            row["total"] = int(total) if total.is_integer() else total
+        if rate is not None:
+            row["per_second"] = rate
+            if total is not None and total >= completed:
+                remaining_ms = round((total - completed) / rate * 1_000)
+                row["estimated_remaining_ms"] = max(0, remaining_ms)
+                row["estimated_completion_at"] = (
+                    datetime.now(UTC)
+                    + timedelta(milliseconds=max(0, remaining_ms))
+                ).isoformat()
+        result[name] = row
+    return result
+
+
 @dataclass(frozen=True)
 class ProgressEvent:
     phase: str
     state: str
     completed: int = 0
     total: int | None = None
+    phase_unit: str = "units"
     message: str = ""
     subject_ref: str | None = None
     details: Mapping[str, Any] | None = None
@@ -54,13 +93,9 @@ class ProgressEvent:
     tokens_per_second: float | None = None
     worker: str | None = None
     reused: bool | None = None
-    work_completed: int | None = None
-    work_total: int | None = None
-    work_unit: str | None = None
-    work_elapsed_ms: int | None = None
-    work_units_per_second: float | None = None
-    work_estimated_remaining_ms: int | None = None
-    work_estimated_completion_at: str | None = None
+    active_stage: str | None = None
+    stage_elapsed_ms: int | None = None
+    measures: Mapping[str, Mapping[str, Any]] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         payload = asdict(self)
@@ -88,6 +123,7 @@ class PhaseRecorder:
         phase: str,
         *,
         total: int | None = None,
+        phase_unit: str = "units",
         subject_ref: str | None = None,
         message: str = "",
         worker: str | None = None,
@@ -98,6 +134,7 @@ class PhaseRecorder:
             recorder=self,
             phase=phase,
             total=total,
+            phase_unit=phase_unit,
             subject_ref=subject_ref,
             message=message,
             worker=worker,
@@ -147,6 +184,7 @@ class PhaseHandle:
     recorder: PhaseRecorder
     phase: str
     total: int | None = None
+    phase_unit: str = "units"
     subject_ref: str | None = None
     message: str = ""
     worker: str | None = None
@@ -156,12 +194,11 @@ class PhaseHandle:
     processed_tokens: int = 0
     total_tokens: int | None = None
     heartbeat_seconds: float | None = 30.0
-    work_completed: int | None = None
-    work_total: int | None = None
-    work_unit: str | None = None
+    active_stage: str | None = None
+    measures: dict[str, dict[str, Any]] = field(default_factory=dict)
     _started_at: str | None = None
     _started_ns: int | None = None
-    _work_started_ns: int | None = None
+    _stage_started_ns: int | None = None
     _finished: bool = False
     _heartbeat_stop: Event = field(default_factory=Event, init=False, repr=False)
     _heartbeat_thread: Thread | None = field(default=None, init=False, repr=False)
@@ -170,7 +207,6 @@ class PhaseHandle:
     def start(self) -> None:
         self._started_at = _utc_now()
         self._started_ns = monotonic_ns()
-        self._work_started_ns = self._started_ns
         self.recorder.emit(self._event(state="started", elapsed_ms=0))
         if self.heartbeat_seconds is not None and self.heartbeat_seconds > 0:
             self._heartbeat_thread = Thread(
@@ -189,30 +225,47 @@ class PhaseHandle:
         self,
         stage: str,
         *,
+        measures: Mapping[str, Mapping[str, Any]] | None = None,
         work_total: int | None = None,
         work_unit: str | None = None,
         details: Mapping[str, Any] | None = None,
         subject_ref: str | None = None,
         worker: str | None = None,
     ) -> None:
-        """Declare the current inner stage without advancing the outer phase."""
+        """Open an inner stage without advancing any completion counter.
 
+        ``work_total``/``work_unit`` remain as a compatibility shorthand for one
+        named measure.  New call sites should pass ``measures``.
+        """
+
+        declared = {name: dict(value) for name, value in (measures or {}).items()}
+        if work_total is not None or work_unit is not None:
+            unit = str(work_unit or "work_items")
+            declared.setdefault(
+                unit,
+                {"completed": 0, "total": work_total, "unit": unit},
+            )
         with self._state_lock:
-            self.message = stage
-            self.details = {"document_stage": stage, **dict(details or {})}
-            self.work_completed = 0
-            self.work_total = work_total
-            self.work_unit = work_unit
-            self._work_started_ns = monotonic_ns()
+            if self.active_stage is not None:
+                raise RuntimeError(
+                    f"cannot begin {stage!r}; stage {self.active_stage!r} is still active"
+                )
+            self.active_stage = stage
+            self.measures = declared
+            self._stage_started_ns = monotonic_ns()
+            self.details = {**self.details, **dict(details or {})}
             if subject_ref is not None:
                 self.subject_ref = subject_ref
             if worker is not None:
                 self.worker = worker
-        self.recorder.emit(self._event(state="running", elapsed_ms=self.elapsed_ms))
+        self.recorder.emit(
+            self._event(state="stage_started", elapsed_ms=self.elapsed_ms, message=stage)
+        )
 
     def observe(
         self,
         *,
+        measures: Mapping[str, int | float | Mapping[str, Any]] | None = None,
         message: str | None = None,
         work_completed: int | None = None,
         work_total: int | None = None,
@@ -221,24 +274,64 @@ class PhaseHandle:
         subject_ref: str | None = None,
         worker: str | None = None,
     ) -> None:
-        """Emit current inner work and throughput without completing an outer unit."""
+        """Update named inner measures without closing a stage or outer unit."""
 
         with self._state_lock:
-            if message is not None:
-                self.message = message
+            if self.active_stage is None:
+                raise RuntimeError("cannot observe inner work without an active stage")
+            for name, value in (measures or {}).items():
+                if isinstance(value, Mapping):
+                    self.measures[name] = {**self.measures.get(name, {}), **dict(value)}
+                else:
+                    self.measures.setdefault(name, {"unit": name})["completed"] = value
+            if work_completed is not None:
+                unit = str(work_unit or next(iter(self.measures), "work_items"))
+                row = self.measures.setdefault(unit, {"unit": unit})
+                row["completed"] = max(0, work_completed)
+                if work_total is not None:
+                    row["total"] = max(0, work_total)
             if details is not None:
                 self.details = {**self.details, **dict(details)}
-            if work_completed is not None:
-                self.work_completed = max(0, work_completed)
-            if work_total is not None:
-                self.work_total = max(0, work_total)
-            if work_unit is not None:
-                self.work_unit = work_unit
             if subject_ref is not None:
                 self.subject_ref = subject_ref
             if worker is not None:
                 self.worker = worker
-        self.recorder.emit(self._event(state="running", elapsed_ms=self.elapsed_ms))
+        self.recorder.emit(
+            self._event(
+                state="running",
+                elapsed_ms=self.elapsed_ms,
+                message=message or self.active_stage or "",
+            )
+        )
+
+    def complete_stage(
+        self,
+        *,
+        advance_outer: bool = False,
+        amount: int = 1,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Close the active stage; optionally close an outer boundary too."""
+
+        with self._state_lock:
+            if self.active_stage is None:
+                raise RuntimeError("cannot complete a stage when none is active")
+            stage = self.active_stage
+            snapshot = _measure_snapshot(self.measures, self.stage_elapsed_ms)
+            if advance_outer:
+                self.completed += amount
+            self.active_stage = None
+            self._stage_started_ns = None
+            self.measures = {}
+            merged = {**self.details, **dict(details or {}), "completed_stage": stage}
+        self.recorder.emit(
+            self._event(
+                state="stage_completed",
+                elapsed_ms=self.elapsed_ms,
+                details={**merged, "final_measures": snapshot},
+                message=stage,
+            )
+        )
 
     def heartbeat(self) -> None:
         if self._finished:
@@ -260,24 +353,25 @@ class PhaseHandle:
         processed_tokens: int = 0,
         worker: str | None = None,
     ) -> None:
+        """Close outer units only; never overwrite the active-stage identity."""
+
         with self._state_lock:
             self.completed += amount
             if reused:
                 self.reused += amount
             self.processed_tokens += max(0, processed_tokens)
-            if message:
-                self.message = message
-            if details is not None:
-                self.details = dict(details)
             if subject_ref is not None:
                 self.subject_ref = subject_ref
             if worker is not None:
                 self.worker = worker
+            event_details = dict(details or {})
         self.recorder.emit(
             self._event(
                 state="running",
                 elapsed_ms=self.elapsed_ms,
                 reused=reused,
+                details=event_details,
+                message=message,
             )
         )
 
@@ -294,30 +388,6 @@ class PhaseHandle:
             ).isoformat(),
         }
 
-    def _work_estimate(self) -> dict[str, Any]:
-        completed = self.work_completed
-        elapsed_ms = self.work_elapsed_ms
-        rate = _rate(completed or 0, elapsed_ms)
-        result: dict[str, Any] = {
-            "work_completed": completed,
-            "work_total": self.work_total,
-            "work_unit": self.work_unit,
-            "work_elapsed_ms": elapsed_ms if self._work_started_ns is not None else None,
-            "work_units_per_second": rate,
-        }
-        if (
-            rate is not None
-            and self.work_total is not None
-            and completed is not None
-            and self.work_total >= completed
-        ):
-            remaining_ms = round((self.work_total - completed) / rate * 1_000)
-            result["work_estimated_remaining_ms"] = max(0, remaining_ms)
-            result["work_estimated_completion_at"] = (
-                datetime.now(UTC) + timedelta(milliseconds=max(0, remaining_ms))
-            ).isoformat()
-        return result
-
     def _event(
         self,
         *,
@@ -325,14 +395,22 @@ class PhaseHandle:
         elapsed_ms: int,
         details: Mapping[str, Any] | None = None,
         reused: bool | None = None,
+        message: str | None = None,
     ) -> ProgressEvent:
         token_rate = _rate(self.processed_tokens, elapsed_ms)
+        stage_elapsed = self.stage_elapsed_ms if self.active_stage is not None else None
+        measures = (
+            _measure_snapshot(self.measures, stage_elapsed or 0)
+            if self.active_stage is not None
+            else None
+        )
         return ProgressEvent(
             phase=self.phase,
             state=state,
             completed=self.completed,
             total=self.total,
-            message=self.message,
+            phase_unit=self.phase_unit,
+            message=self.message if message is None else message,
             subject_ref=self.subject_ref,
             details=dict(details if details is not None else self.details) or None,
             started_at=self._started_at,
@@ -342,8 +420,10 @@ class PhaseHandle:
             processed_tokens=self.processed_tokens or None,
             total_tokens=self.total_tokens,
             tokens_per_second=token_rate,
+            active_stage=self.active_stage,
+            stage_elapsed_ms=stage_elapsed,
+            measures=measures,
             **self._outer_estimate(elapsed_ms),
-            **self._work_estimate(),
         )
 
     @property
@@ -353,14 +433,18 @@ class PhaseHandle:
         return max(0, (monotonic_ns() - self._started_ns) // 1_000_000)
 
     @property
-    def work_elapsed_ms(self) -> int:
-        if self._work_started_ns is None:
+    def stage_elapsed_ms(self) -> int:
+        if self._stage_started_ns is None:
             return 0
-        return max(0, (monotonic_ns() - self._work_started_ns) // 1_000_000)
+        return max(0, (monotonic_ns() - self._stage_started_ns) // 1_000_000)
 
     def finish(self, *, state: str, details: Mapping[str, Any] | None = None) -> None:
         if self._finished:
             return
+        if self.active_stage is not None:
+            raise RuntimeError(
+                f"cannot finish phase while stage {self.active_stage!r} is active"
+            )
         self._finished = True
         self._heartbeat_stop.set()
         if self._heartbeat_thread is not None:
@@ -402,7 +486,7 @@ def emit_progress(
     worker = f" worker={event.worker}" if event.worker else ""
     reuse = " reused" if event.reused else ""
     outer_rate = (
-        f" rate={event.throughput_units_per_second:.3f}/s"
+        f" {event.phase_unit}_rate={event.throughput_units_per_second:.3f}/s"
         if event.throughput_units_per_second is not None
         else ""
     )
@@ -411,28 +495,28 @@ def emit_progress(
         if event.estimated_completion_at
         else ""
     )
-    work = ""
-    if event.work_completed is not None:
-        work_total = f"/{event.work_total}" if event.work_total is not None else ""
-        unit = event.work_unit or "units"
-        work_rate = (
-            f" {event.work_units_per_second:.3f}/{unit}/s"
-            if event.work_units_per_second is not None
-            else ""
-        )
-        work_eta = (
-            f" work_eta={_format_duration_ms(event.work_estimated_remaining_ms)}"
-            if event.work_estimated_remaining_ms is not None
-            else ""
-        )
-        work = f" work={event.work_completed}{work_total} {unit}{work_rate}{work_eta}"
-    token_rate = (
-        f" tokens={event.processed_tokens} ({event.tokens_per_second:.3f}/s)"
-        if event.processed_tokens is not None and event.tokens_per_second is not None
-        else ""
-    )
+    stage = f" active_stage={event.active_stage}" if event.active_stage else ""
+    measure_text = ""
+    if event.measures:
+        chunks = []
+        for name, row in event.measures.items():
+            total_value = f"/{row['total']}" if "total" in row else ""
+            rate_value = (
+                f" {row['per_second']:.3f}/{row['unit']}/s"
+                if "per_second" in row
+                else ""
+            )
+            eta_value = (
+                f" eta={_format_duration_ms(row['estimated_remaining_ms'])}"
+                if "estimated_remaining_ms" in row
+                else ""
+            )
+            chunks.append(
+                f"{name}={row['completed']}{total_value} {row['unit']}{rate_value}{eta_value}"
+            )
+        measure_text = " measures=[" + "; ".join(chunks) + "]"
     print(
-        f"[{event.phase}] {event.state} {event.completed}{total}{subject}{elapsed}{worker}{reuse}{outer_rate}{eta_at}{work}{token_rate}{message}",
+        f"[{event.phase}] {event.state} {event.completed}{total}{subject}{elapsed}{worker}{reuse}{outer_rate}{eta_at}{stage}{measure_text}{message}",
         file=target,
         flush=True,
     )

--- a/tests/policy/test_constraint_fixed_point_diagnostics.py
+++ b/tests/policy/test_constraint_fixed_point_diagnostics.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from src.policy.constraint_fixed_point_diagnostics import (
+    DIAGNOSTIC_CONTRACT_REF,
+    build_constraint_fixed_point_diagnostics,
+)
+
+
+def _factor(ref: str, *, residuals=(), alternatives=()):
+    return {
+        "factor_ref": ref,
+        "factor_type": "semantic.test",
+        "alternatives": list(alternatives),
+        "constraints": [],
+        "residuals": list(residuals),
+        "closure_state": "open" if residuals else "locally_closed",
+        "metadata": {},
+    }
+
+
+def _graph(*factors):
+    return {
+        "graph_ref": "pnf:test",
+        "document_ref": "document:test",
+        "factors": list(factors),
+        "constraints": [],
+        "relation_refs": [],
+        "residuals": [],
+    }
+
+
+def test_diagnostics_reports_semantic_yield_and_fingerprints() -> None:
+    before = _graph(_factor("factor:a", residuals=("open",)))
+    after = _graph(
+        _factor(
+            "factor:a",
+            alternatives=(
+                {
+                    "alternative_ref": "alternative:new",
+                    "value": {"role": "agent"},
+                    "type_ref": "semantic.role_candidate",
+                },
+            ),
+        )
+    )
+    receipt = build_constraint_fixed_point_diagnostics(
+        pnf_graph=before,
+        refined_pnf_graph=after,
+        constraint_assessments=({"assessment_ref": "assessment:1"},),
+        local_meet_plan=({"plan_ref": "plan:1"},),
+        typed_meets=({"meet_ref": "meet:1", "state": "compatible_with_refinement"},),
+        factor_refinements=(
+            {
+                "refinement_ref": "refinement:1",
+                "added_alternative_refs": ["alternative:new"],
+                "rejected_candidate_refs": [],
+            },
+        ),
+        semantic_stage_timing={
+            "stage_totals_ms": {
+                "constraint_fixed_point": 2_000,
+                "postgres_persistence": 300,
+            }
+        },
+    ).to_dict()
+
+    assert receipt["contract_ref"] == DIAGNOSTIC_CONTRACT_REF
+    assert receipt["iteration"] == 1
+    assert receipt["factors_before"] == 1
+    assert receipt["factors_after"] == 1
+    assert receipt["factors_rewritten"] == 1
+    assert receipt["refinements_applied"] == 1
+    assert receipt["resolved_demands"] == 1
+    assert receipt["new_accepted_facts"] == 1
+    assert receipt["semantic_progress_units"] == 3
+    assert receipt["semantic_yield_per_second"] == 1.5
+    assert receipt["cumulative_database_read_write_ms"] == 300
+    assert receipt["graph_fingerprint_before"].startswith("sha256:")
+    assert receipt["graph_fingerprint_after"].startswith("sha256:")
+    assert receipt["graph_fingerprint_before"] != receipt["graph_fingerprint_after"]
+    assert receipt["classification"] == "legitimate_high_volume_closure"
+
+
+def test_diagnostics_detects_candidate_explosion() -> None:
+    graph = _graph(_factor("factor:a", residuals=("open",)))
+    receipt = build_constraint_fixed_point_diagnostics(
+        pnf_graph=graph,
+        refined_pnf_graph=graph,
+        constraint_assessments=tuple(
+            {"assessment_ref": f"assessment:{index}"} for index in range(200)
+        ),
+        local_meet_plan=tuple(
+            {"plan_ref": f"plan:{index}"} for index in range(200)
+        ),
+        typed_meets=tuple(
+            {"meet_ref": f"meet:{index}", "state": "rejected"}
+            for index in range(200)
+        ),
+    ).to_dict()
+
+    assert receipt["constraint_assessments_evaluated"] == 200
+    assert receipt["candidate_meets_considered"] == 200
+    assert receipt["candidate_meets_accepted"] == 0
+    assert receipt["classification"] == "combinatorial_candidate_explosion"
+
+
+def test_diagnostics_detects_fixed_point_churn() -> None:
+    graph = _graph(_factor("factor:a", residuals=("open",)))
+    duplicate = {
+        "refinement_ref": "refinement:duplicate",
+        "added_alternative_refs": [],
+        "rejected_candidate_refs": [],
+    }
+    receipt = build_constraint_fixed_point_diagnostics(
+        pnf_graph=graph,
+        refined_pnf_graph=graph,
+        factor_refinements=(duplicate, duplicate),
+    ).to_dict()
+
+    assert receipt["semantic_state_stable"] is True
+    assert receipt["refinements_proposed"] == 2
+    assert receipt["refinements_deduplicated"] == 1
+    assert receipt["semantic_progress_units"] == 0
+    assert receipt["classification"] == "fixed_point_churn"

--- a/tests/runtime/test_progress_instrumentation.py
+++ b/tests/runtime/test_progress_instrumentation.py
@@ -4,6 +4,9 @@ from io import StringIO
 import json
 from time import sleep
 
+import pytest
+
+from src.runtime.document_stage_metrics import stage_measure_declaration
 from src.runtime.progress import PhaseRecorder
 
 
@@ -11,7 +14,9 @@ def test_phase_recorder_emits_durable_timing_and_reuse_events(tmp_path) -> None:
     stream = StringIO()
     recorder = PhaseRecorder(stream=stream, json_lines=True)
 
-    with recorder.phase("compile_pnf", total=2, details={"workers": 2}) as phase:
+    with recorder.phase(
+        "compile_pnf", total=2, phase_unit="documents", details={"workers": 2}
+    ) as phase:
         sleep(0.001)
         phase.advance(
             subject_ref="document:a",
@@ -43,18 +48,14 @@ def test_phase_recorder_emits_durable_timing_and_reuse_events(tmp_path) -> None:
     lines = [json.loads(line) for line in stream.getvalue().splitlines()]
     assert lines[0]["state"] == "started"
     assert lines[-1]["state"] == "completed"
-    assert all(row["schema_version"] == "sl.progress_event.v0_3" for row in lines)
+    assert all(row["schema_version"] == "sl.progress_event.v0_4" for row in lines)
 
 
 def test_failed_phase_records_error_without_hiding_exception() -> None:
     recorder = PhaseRecorder(stream=StringIO(), json_lines=True)
-    try:
+    with pytest.raises(ValueError, match="bad projection"):
         with recorder.phase("project_legal_ir"):
             raise ValueError("bad projection")
-    except ValueError:
-        pass
-    else:
-        raise AssertionError("expected ValueError")
 
     event = recorder.events[-1]
     assert event["state"] == "failed"
@@ -64,70 +65,104 @@ def test_failed_phase_records_error_without_hiding_exception() -> None:
 
 def test_phase_heartbeat_reports_estimate_while_no_units_finish() -> None:
     recorder = PhaseRecorder(stream=StringIO(), json_lines=True)
-    with recorder.phase("compile_pnf", total=2, heartbeat_seconds=0.001) as phase:
+    with recorder.phase(
+        "compile_pnf", total=2, phase_unit="documents", heartbeat_seconds=0.001
+    ) as phase:
         phase.advance(subject_ref="document:a")
         sleep(0.003)
 
     heartbeat = next(event for event in recorder.events if event["state"] == "heartbeat")
     assert heartbeat["completed"] == 1
     assert heartbeat["estimated_remaining_ms"] >= 0
+    assert "active_stage" not in heartbeat
 
 
-def test_inner_stage_throughput_is_independent_of_outer_document_progress() -> None:
+def test_last_completion_label_never_becomes_active_stage() -> None:
+    recorder = PhaseRecorder(stream=StringIO(), json_lines=True)
+    with recorder.phase("document_compile", total=8, heartbeat_seconds=None) as phase:
+        phase.advance(message="coordinate_validation")
+        phase.heartbeat()
+
+    heartbeat = next(event for event in recorder.events if event["state"] == "heartbeat")
+    assert heartbeat["completed"] == 1
+    assert "active_stage" not in heartbeat
+    assert heartbeat.get("message") != "coordinate_validation"
+
+
+def test_named_measure_vector_is_independent_of_outer_progress() -> None:
     stream = StringIO()
     recorder = PhaseRecorder(stream=stream, json_lines=False)
 
     with recorder.phase(
         "postgres_demand_planning_compile",
         total=10,
+        phase_unit="documents",
         subject_ref="document:0007",
         heartbeat_seconds=None,
     ) as phase:
-        phase.advance(message="documents", details={"document_stage": "document_start"})
+        phase.advance(message="reused_document")
         phase.begin_stage(
-            "constraint_assessments",
-            work_total=100,
-            work_unit="assessments",
-            details={"factor_count": 40},
+            "constraint_assessment",
+            measures=stage_measure_declaration(
+                "constraint_assessment",
+                totals={
+                    "factors_scanned": 40,
+                    "constraints_evaluated": 100,
+                    "assessments_emitted": 100,
+                },
+            ),
         )
         sleep(0.001)
         phase.observe(
-            work_completed=25,
-            details={"accepted": 4, "rejected": 21},
+            measures={
+                "factors_scanned": 20,
+                "constraints_evaluated": 25,
+                "assessments_emitted": 25,
+                "satisfied": 4,
+                "violated": 3,
+                "undetermined": 18,
+            }
         )
+        phase.heartbeat()
+        phase.complete_stage()
 
-    event = next(
+    heartbeat = next(
         row
         for row in recorder.events
-        if row.get("message") == "constraint_assessments"
-        and row.get("work_completed") == 25
+        if row.get("state") == "heartbeat"
+        and row.get("active_stage") == "constraint_assessment"
     )
-    assert event["completed"] == 1
-    assert event["work_total"] == 100
-    assert event["work_unit"] == "assessments"
-    assert event["work_units_per_second"] > 0
-    assert event["work_estimated_remaining_ms"] >= 0
-    assert event["details"]["factor_count"] == 40
-    assert event["details"]["accepted"] == 4
-    assert "work=25/100 assessments" in stream.getvalue()
-    assert "constraint_assessments" in stream.getvalue()
+    assert heartbeat["completed"] == 1
+    assert heartbeat["measures"]["constraints_evaluated"]["total"] == 100
+    assert heartbeat["measures"]["constraints_evaluated"]["per_second"] > 0
+    assert heartbeat["measures"]["satisfied"]["completed"] == 4
+    assert "constraints_evaluated=25/100 constraints" in stream.getvalue()
+    assert "active_stage=constraint_assessment" in stream.getvalue()
 
 
-def test_heartbeat_preserves_current_inner_stage_and_rate() -> None:
+def test_stage_lifecycle_cannot_overlap_or_leak_at_phase_finish() -> None:
     recorder = PhaseRecorder(stream=StringIO(), json_lines=True)
-    with recorder.phase("compile_pnf", heartbeat_seconds=None) as phase:
-        phase.begin_stage(
-            "closure_executor_evaluation",
-            work_total=8,
-            work_unit="jobs",
-        )
-        sleep(0.001)
-        phase.observe(work_completed=3)
-        phase.heartbeat()
+    phase_context = recorder.phase("compile_pnf", heartbeat_seconds=None)
+    phase = phase_context.__enter__()
+    phase.begin_stage("parser_annotation", measures={"tokens": {"unit": "tokens"}})
+    with pytest.raises(RuntimeError, match="still active"):
+        phase.begin_stage("coordinate_validation")
+    with pytest.raises(RuntimeError, match="cannot finish phase"):
+        phase_context.__exit__(None, None, None)
+    phase.complete_stage()
+    phase.finish(state="completed")
 
-    heartbeat = next(event for event in recorder.events if event["state"] == "heartbeat")
-    assert heartbeat["message"] == "closure_executor_evaluation"
-    assert heartbeat["work_completed"] == 3
-    assert heartbeat["work_total"] == 8
-    assert heartbeat["work_units_per_second"] > 0
-    assert heartbeat["details"]["heartbeat"] is True
+
+def test_stage_completion_may_close_exactly_one_outer_boundary() -> None:
+    recorder = PhaseRecorder(stream=StringIO(), json_lines=True)
+    with recorder.phase("document_compile", total=8, heartbeat_seconds=None) as phase:
+        phase.begin_stage("canonical_normalization")
+        phase.complete_stage(advance_outer=True)
+        phase.begin_stage("parser_annotation")
+        phase.complete_stage(advance_outer=True)
+
+    completed = [
+        event for event in recorder.events if event["state"] == "stage_completed"
+    ]
+    assert [event["completed"] for event in completed] == [1, 2]
+    assert all("active_stage" not in event for event in completed)

--- a/tests/runtime/test_progress_instrumentation.py
+++ b/tests/runtime/test_progress_instrumentation.py
@@ -43,7 +43,7 @@ def test_phase_recorder_emits_durable_timing_and_reuse_events(tmp_path) -> None:
     lines = [json.loads(line) for line in stream.getvalue().splitlines()]
     assert lines[0]["state"] == "started"
     assert lines[-1]["state"] == "completed"
-    assert all(row["schema_version"] == "sl.progress_event.v0_2" for row in lines)
+    assert all(row["schema_version"] == "sl.progress_event.v0_3" for row in lines)
 
 
 def test_failed_phase_records_error_without_hiding_exception() -> None:
@@ -71,3 +71,63 @@ def test_phase_heartbeat_reports_estimate_while_no_units_finish() -> None:
     heartbeat = next(event for event in recorder.events if event["state"] == "heartbeat")
     assert heartbeat["completed"] == 1
     assert heartbeat["estimated_remaining_ms"] >= 0
+
+
+def test_inner_stage_throughput_is_independent_of_outer_document_progress() -> None:
+    stream = StringIO()
+    recorder = PhaseRecorder(stream=stream, json_lines=False)
+
+    with recorder.phase(
+        "postgres_demand_planning_compile",
+        total=10,
+        subject_ref="document:0007",
+        heartbeat_seconds=None,
+    ) as phase:
+        phase.advance(message="documents", details={"document_stage": "document_start"})
+        phase.begin_stage(
+            "constraint_assessments",
+            work_total=100,
+            work_unit="assessments",
+            details={"factor_count": 40},
+        )
+        sleep(0.001)
+        phase.observe(
+            work_completed=25,
+            details={"accepted": 4, "rejected": 21},
+        )
+
+    event = next(
+        row
+        for row in recorder.events
+        if row.get("message") == "constraint_assessments"
+        and row.get("work_completed") == 25
+    )
+    assert event["completed"] == 1
+    assert event["work_total"] == 100
+    assert event["work_unit"] == "assessments"
+    assert event["work_units_per_second"] > 0
+    assert event["work_estimated_remaining_ms"] >= 0
+    assert event["details"]["factor_count"] == 40
+    assert event["details"]["accepted"] == 4
+    assert "work=25/100 assessments" in stream.getvalue()
+    assert "constraint_assessments" in stream.getvalue()
+
+
+def test_heartbeat_preserves_current_inner_stage_and_rate() -> None:
+    recorder = PhaseRecorder(stream=StringIO(), json_lines=True)
+    with recorder.phase("compile_pnf", heartbeat_seconds=None) as phase:
+        phase.begin_stage(
+            "closure_executor_evaluation",
+            work_total=8,
+            work_unit="jobs",
+        )
+        sleep(0.001)
+        phase.observe(work_completed=3)
+        phase.heartbeat()
+
+    heartbeat = next(event for event in recorder.events if event["state"] == "heartbeat")
+    assert heartbeat["message"] == "closure_executor_evaluation"
+    assert heartbeat["work_completed"] == 3
+    assert heartbeat["work_total"] == 8
+    assert heartbeat["work_units_per_second"] > 0
+    assert heartbeat["details"]["heartbeat"] is True


### PR DESCRIPTION
## Summary

Adds deterministic diagnostics for the document-local constraint refinement pass and upgrades the shared progress recorder for granular inner-stage throughput.

### Constraint diagnostics

Reports:

- pass/iteration number and elapsed time
- factors before and after
- constraint assessments evaluated
- candidate meets considered and accepted
- refinements proposed, applied, deduplicated, and rejected
- factors rewritten, added, and removed
- residuals before/after/emitted
- unresolved and resolved demands
- binding candidates before/after compaction when present
- stable graph fingerprints
- cumulative PostgreSQL persistence time when present
- semantic yield per second
- classification as productive closure, candidate explosion, or fixed-point churn
- the narrow monotone ZELPH extraction boundary while preserving compiler ownership

### Granular progress and throughput

`PhaseHandle` now separates outer phase progress from current inner work:

- `begin_stage(stage, work_total, work_unit, details)` declares the exact active substage
- `observe(work_completed, ...)` updates live work without falsely advancing the outer document counter
- heartbeats preserve the active stage, counts, unit, rate, and stage ETA
- text output shows both outer units/sec and inner stage units/sec
- JSON progress schema is now `sl.progress_event.v0_3`

This supports metrics such as documents/sec, chars/sec, tokens/sec, sentences/sec, observations/sec, proposals/sec, closure jobs/sec, assessments/sec, candidate meets/sec, refinements/sec, demands/sec, and persisted rows/sec without conflating those units.

## Architectural note

The current `constraint_fixed_point` implementation is one assessment/meet/refinement pass, not an explicit iterative loop. The receipt therefore defaults to `iteration = 1` rather than inventing unobserved iteration semantics.

## Files

- `src/policy/constraint_fixed_point_diagnostics.py`
- `src/runtime/progress.py`
- `scripts/inspect_constraint_fixed_point.py`
- `tests/policy/test_constraint_fixed_point_diagnostics.py`
- `tests/runtime/test_progress_instrumentation.py`

## Usage

```bash
python scripts/inspect_constraint_fixed_point.py compilation.json
```

## Integration requirement before ready-for-review

The recorder substrate is implemented. Each long-running compiler loop must now call `begin_stage` before work starts and `observe` periodically from the loop itself. Completion-only callbacks are insufficient. The intended live lanes are:

1. canonical normalisation — chars
2. parser fibres — chars, sentences, tokens, fibres
3. coordinate validation — tokens
4. mention licensing/recurrence/forms — tokens and mentions
5. parser observation projection — sentences and observations
6. base proposal reduction — atoms, relations, proposals
7. streaming closure — jobs, proposals, dirty groups
8. PNF construction — factors and constraints
9. constraint assessment — assessments
10. meet/refinement — candidates, accepted meets, refinements, residual transitions
11. demand derivation — factors and demands
12. PostgreSQL persistence — rows and bytes by table family

The PR remains draft until those call sites are wired and exercised end-to-end.