### PR TITLE
Plan unified source adapters and PNF-to-proof IR fibres

### DIFF
--- a/docs/planning/pnf_to_proof_ir_projection_20260729.md
+++ b/docs/planning/pnf_to_proof_ir_projection_20260729.md
@@ -1,0 +1,976 @@
+# ITIR PNF to Proof IR projection
+
+Date: 2026-07-29  
+Status: planning contract; companion to
+`unified_source_adapters_and_proof_fibres_20260729.md`; no runtime authority
+change
+
+## Purpose
+
+This document refines the proof-language portion of the unified source-adapter
+plan. It defines the relationship between the canonical ITIR partial-normal-form
+(PNF) carrier and proof-oriented intermediate representations without creating a
+second compiler, PNF implementation, lifecycle, graph authority, or CLI entry
+point.
+
+The central distinction is:
+
+```text
+PNF records what the source may mean and what remains unresolved.
+Proof IR records what, under a named theory and explicit assumptions, is
+sufficiently coherent to present to a proof checker or target realiser.
+```
+
+The proof path is therefore:
+
+```text
+source observations
+-> one PNF carrier and fixed point
+-> formal-role and theory-indexed candidates
+-> proof-fibre assessment and admission
+-> Proof IR plus typed obligations
+-> target-native or logical-framework projections
+-> external checking
+-> evidence and demands returned to the same lifecycle
+```
+
+It is not:
+
+```text
+source text -> guessed theorem -> proof assistant
+```
+
+and it is not:
+
+```text
+proof source -> separate proof-specific PNF compiler
+```
+
+## Authority boundary
+
+The existing SensibLaw/ITIR semantic lifecycle remains authoritative:
+
+```text
+observation
+-> proposal
+-> reduction
+-> factor/constraint graph
+-> fixed point
+-> assessment
+-> admissibility
+-> resolution
+-> projection applicability
+-> execution/checking
+-> receipts
+```
+
+Proof support extends that lifecycle with proof-domain declarations and
+projection contracts. It does not add a parallel semantic flow.
+
+The three representation levels are distinct:
+
+1. `SourceObservationEnvelope`: what the selected frontend directly observed.
+2. `PNFGraph`: branch-preserving semantic possibilities, constraints, residuals,
+   demands, evidence, and authority state.
+3. `ProofIRModule`: an applicability-backed, theory-indexed formal development
+   containing declarations, judgments, definitions, holes, and obligations.
+
+Target-specific Lean, Rocq, Dedukti, Lambdapi, or other IRs are downstream
+realisations of `ProofIRModule`, not replacements for PNF.
+
+## Canonical PNF object
+
+For proof projection, treat the durable PNF state as:
+
+\[
+P = (F, A, C, R, D, E, \Pi)
+\]
+
+where:
+
+- \(F\) is the factor set;
+- \(A\) is the family of typed alternatives;
+- \(C\) is the constraint set;
+- \(R\) is the relation and residual set;
+- \(D\) is the unresolved demand set;
+- \(E\) is the evidence and derivation set;
+- \(\Pi\) is provenance and authority metadata.
+
+PNF remains partial and branch-preserving. It may contain several incompatible
+formal interpretations at once. No ambiguity is silently converted into a
+logical connective or a target declaration.
+
+A proof-relevant factor may represent:
+
+```text
+theory
+sort or universe
+type
+term
+predicate
+relation
+definition
+assumption
+axiom
+theorem claim
+lemma claim
+witness
+constraint
+computation rule
+recursion scheme
+equality notion
+rewrite rule
+module or namespace
+alignment candidate
+meta-claim about a proof
+informal-only material
+```
+
+The presence of one of these factor kinds does not establish that its contents
+are true, accepted assumptions, well typed, or proved.
+
+## Proof IR object
+
+An admitted proof module is:
+
+\[
+Q = (T, \Sigma, \Gamma, J, \Delta, \Omega, \mathcal{R}, \mathcal{X}, \Pi_Q)
+\]
+
+where:
+
+- \(T\) is the selected object theory or explicitly retained theory alternative;
+- \(\Sigma\) is the formal signature;
+- \(\Gamma\) is the local context and assumptions;
+- \(J\) is the set of judgments and theorem targets;
+- \(\Delta\) is the set of definitions and declarations;
+- \(\Omega\) is the typed proof/formalisation obligation graph;
+- \(\mathcal{R}\) is recursion and computation evidence;
+- \(\mathcal{X}\) is the extension, universe, and axiom boundary;
+- \(\Pi_Q\) is source-to-proof provenance.
+
+A `ProofIRModule` is not necessarily a completed proof. It may be:
+
+```text
+kernel-checked
+externally checked
+proved but not target-native
+a theorem statement with typed holes
+conditional on explicit axioms
+encoded through a theory morphism
+a family of competing formalisation candidates
+bounded incomplete
+unavailable for a requested theory or target
+```
+
+## Projection relation
+
+For a proposed theory \(T\), define:
+
+\[
+\Phi_T : P \longrightarrow \mathcal{P}(Q_T \times \Omega_T)
+\]
+
+The powerset is deliberate. One PNF state may yield zero, one, or several
+formalisation candidates. Competing candidates remain separate fibre elements
+until the shared lifecycle has evidence sufficient to admit or reject them.
+
+Operationally:
+
+```text
+PNF graph
+-> formal-role candidate generation
+-> theory-profile candidate generation
+-> signature synthesis
+-> judgment synthesis
+-> obligation generation
+-> applicability assessment
+-> zero or more admitted ProofIRModule values
+```
+
+A projection result may contain:
+
+```text
+admitted Proof IR
+typed unresolved obligations
+explicitly unavailable result
+projection loss receipt
+competing unselected candidates
+```
+
+Projection success is not proof success. Proof success is not semantic
+correspondence. A target kernel may check a proof of the wrong theorem; that is a
+translation failure.
+
+## Six projection stages
+
+### 1. Formal-role recognition
+
+Each eligible PNF factor receives zero or more `FormalRoleCandidate` values:
+
+```text
+type
+term
+predicate
+relation
+definition
+assumption
+axiom
+theorem
+lemma
+witness
+constraint
+computation_rule
+meta_claim
+informal_only
+```
+
+Examples:
+
+```text
+“Let G be a group”
+  -> type/class declaration candidate plus structure assumptions
+
+“Suppose f is continuous”
+  -> local hypothesis candidate
+
+“Then f is bounded”
+  -> theorem-target candidate
+
+“By compactness”
+  -> proof-strategy/evidence reference, not automatically a proof term
+```
+
+Role recognition is candidate generation. It does not promote an observed claim
+to an axiom or theorem.
+
+### 2. Theory selection
+
+A formalisation must be indexed by a named theory profile or retain several
+theory alternatives.
+
+Candidate profiles may include:
+
+```text
+agda_mltt
+agda_cubical
+lean4
+rocq_cic
+constructive_dependent_type_theory
+classical_simple_type_theory
+lambda_pi_modulo
+first_order_logic
+set_theory
+domain_specific_theory
+```
+
+Theory selection may itself remain unresolved. The same semantic claim can
+require different encodings, axioms, elimination rules, and computation
+relations in different theories.
+
+A theory profile declares at least:
+
+```text
+sort and universe policy
+typing judgments
+conversion/computation relation
+inductive and elimination policy
+recursion/productivity policy
+equality families
+proof relevance/irrelevance policy
+available axioms
+supported extension constructs
+```
+
+### 3. Signature synthesis
+
+Eligible PNF factors and alignments produce candidate declarations:
+
+```text
+sort declarations
+constant declarations
+inductive blocks
+record blocks
+constructors
+eliminators
+definitions
+rewrite declarations
+module declarations
+concept alignments
+```
+
+For example, a factor representing the natural numbers may be:
+
+```text
+aligned to a protected native concept
+derived from an existing target library
+encoded as a Peano inductive
+retained as an unresolved external concept
+unavailable in the requested theory
+```
+
+Every candidate declaration retains source factor, alternative, evidence, and
+alignment references.
+
+### 4. Judgment synthesis
+
+PNF relations produce candidate theory-indexed judgments.
+
+Examples:
+
+```text
+predication(x, P)
+  -> Γ ⊢ P x : Prop
+
+universal(x, A, P)
+  -> Γ ⊢ Π (x : A), P x
+
+existential(x, A, P)
+  -> Γ ⊢ Σ (x : A), P x
+  or a theory-specific existential proposition
+
+same(x, y)
+  -> Γ ⊢ Eq_e A x y
+```
+
+The equality family \(e\) remains explicit. Propositional equality,
+heterogeneous equality, path equality, setoid equivalence, quotient equality,
+and definitional conversion must not be collapsed by spelling.
+
+Semantic parser ambiguity is not logical disjunction:
+
+```text
+candidate A versus candidate B
+```
+
+must remain separate proof fibres unless the source itself supports:
+
+```text
+A ∨ B
+```
+
+### 5. Obligation generation
+
+Every required but unresolved distinction becomes a typed obligation.
+
+Initial obligation kinds include:
+
+```text
+formal_role_selection
+theory_selection
+type_selection
+reference_resolution
+scope_resolution
+quantifier_resolution
+equality_kind
+signature_alignment
+universe_constraint
+termination
+productivity
+constructivity
+axiom_acceptance
+computation_preservation
+dependency_preservation
+proof_completion
+target_library_alignment
+native_reconstruction
+external_checker_correspondence
+```
+
+A PNF residual maps to a typed hole only when an expected proof-IR type or role is
+known. Otherwise it remains a pre-IR formalisation obligation.
+
+Typed hole classes include:
+
+```text
+unknown_type
+unknown_term
+unresolved_referent
+missing_definition
+missing_proof
+missing_computation_law
+missing_target_encoding
+unsupported_theory_construct
+```
+
+No generic `sorry` may erase the distinction.
+
+### 6. Applicability and admission
+
+A candidate \(Q\) is admitted only with an applicability witness:
+
+\[
+\mathsf{Applicable}_T(P, Q, w)
+\]
+
+Admission means the module is coherent enough to present to a proof checker,
+theorem search engine, logical-framework translator, or native target realiser.
+It does not mean its theorem targets are proved.
+
+The applicability witness records:
+
+```text
+source factors and alternatives consumed
+formal-role selections
+theory profile
+declaration and judgment synthesis rules
+constraints satisfied or retained
+obligations emitted
+material alternatives rejected or left competing
+projection losses
+axiom and universe delta
+required target capabilities
+```
+
+## PNF to Proof IR correspondence
+
+| ITIR PNF | Proof IR |
+| --- | --- |
+| factor | declaration, term, judgment, or formal-role candidate |
+| typed alternative | candidate formal encoding |
+| constraint | typing condition, premise, side condition, or compatibility rule |
+| relation | application, equality, dependency, logical connective, or module edge |
+| residual | formalisation obligation or typed hole |
+| demand | proof obligation, alignment lookup, theorem search, or external check |
+| evidence | proof term, derivation, citation, checker result, or source witness |
+| authority state | observed/assumed/axiomatic/derived/checked status |
+| fibre element | one theory-indexed formalisation candidate |
+| resolution | selected encoding or discharged obligation |
+| domain projection | admitted `ProofIRModule` |
+| execution result | checker/realiser evidence returned to PNF |
+
+## Proof authority states
+
+Introduce a proof-domain authority algebra that does not replace the generic
+authority field but refines it:
+
+```text
+observed
+candidate_formalisation
+assumed
+axiomatic
+derived
+kernel_checked
+externally_checked
+refuted
+unresolved
+```
+
+Required separations:
+
+```text
+observed claim != assumption
+assumption != axiom
+axiom != theorem
+well-typed statement != proved theorem
+kernel-checked proof != semantically corresponding translation
+external citation != locally checked proof
+```
+
+A paper saying “we prove P” yields an observed attribution and a candidate theorem
+statement. It becomes `kernel_checked` only after a named checker validates the
+corresponding proof object under a recorded theory and axiom surface.
+
+## Realisation classes
+
+For each source construct \(c\), theory \(T\), and target \(U\), a fibre
+realisation is:
+
+```text
+native
+derived
+encoded
+conditional
+unavailable
+```
+
+These statuses are target-relative.
+
+- `native`: realised by a canonical target primitive or library concept.
+- `derived`: definable in the target with reviewed evidence of the intended laws.
+- `encoded`: represented through an explicit encoding and adequacy claim.
+- `conditional`: valid only under an explicit axiom or assumption delta.
+- `unavailable`: no reviewed realisation exists.
+
+Each realisation also records a computation relationship:
+
+```text
+definitional
+propositional
+observational
+opaque
+none
+```
+
+Logical preservation and computation preservation are independent axes.
+
+## Formalisation assessment
+
+Each candidate receives a tetralemma-style formalisation assessment:
+
+```text
+satisfied
+violated
+undetermined
+inapplicable
+```
+
+Examples:
+
+- `satisfied`: required source distinctions and typing constraints are preserved.
+- `violated`: a material source assumption, quantifier, dependency, or equality
+  distinction was lost or contradicted.
+- `undetermined`: a required theory, scope, referent, alignment, or capability is
+  unresolved.
+- `inapplicable`: the requested property does not apply, such as definitional
+  computation preservation for an intentionally opaque theorem.
+
+Formalisation assessment is separate from proof completion:
+
+```text
+formalisation = satisfied
+proof = unresolved
+```
+
+is valid, while:
+
+```text
+formalisation = violated
+proof = kernel_checked
+```
+
+is a translation failure.
+
+## Fixed-point and demand return
+
+Projection is iterative:
+
+\[
+P_0 \xrightarrow{\Phi_T} (Q_0, \Omega_0)
+\]
+
+Unresolved obligations return as typed PNF demands:
+
+\[
+P_{n+1} = \mathsf{refine}(P_n, \Omega_n, E_{n+1})
+\]
+
+and projection may run again:
+
+\[
+P_{n+1} \xrightarrow{\Phi_T} (Q_{n+1}, \Omega_{n+1})
+\]
+
+Stop at:
+
+```text
+all required obligations discharged
+bounded stable unresolved set
+explicitly unavailable result
+contradiction or violated formalisation
+resource/policy stop with receipt
+```
+
+The target projection cannot mutate source observations or silently rewrite the
+base PNF identity. New evidence produces immutable factor revisions through the
+normal lifecycle.
+
+## Required data contracts
+
+### FormalRoleCandidate
+
+```text
+candidate_ref
+factor_ref
+alternative_ref
+formal_role
+theory_profile_ref?
+evidence_refs
+constraint_refs
+authority_state
+producer_declaration_ref
+```
+
+### TheoryProfile
+
+```text
+theory_ref
+meta_theory_ref?
+sort_universe_policy
+judgment_declarations
+conversion_policy
+computation_policy
+inductive_elimination_policy
+recursion_policy
+equality_families
+axiom_surface
+extension_capabilities
+version_and_digest
+```
+
+### ProofProjectionCandidate
+
+```text
+candidate_ref
+pnf_graph_ref
+theory_ref
+formal_role_candidate_refs
+signature_candidate_refs
+judgment_candidate_refs
+obligation_refs
+axiom_delta
+universe_delta
+computation_requirements
+provenance_refs
+```
+
+### ProofIRModule
+
+```text
+module_ref
+pnf_graph_ref
+theory_ref
+signature
+context
+declarations
+definitions
+judgments
+theorem_targets
+proof_terms
+typed_holes
+obligation_refs
+recursion_computation_evidence
+extension_axiom_boundary
+applicability_witness_ref
+provenance_refs
+```
+
+### ProofObligation
+
+```text
+obligation_ref
+obligation_kind
+source_factor_refs
+proof_ir_subject_refs
+expected_type_or_judgment?
+required_evidence
+admissible_solver_classes
+status
+provenance_refs
+```
+
+### ProofApplicabilityWitness
+
+```text
+witness_ref
+projection_candidate_ref
+consumed_factor_revisions
+selected_alternatives
+satisfied_constraints
+retained_constraints
+rejected_alternatives
+projection_losses
+required_capabilities
+axiom_delta
+universe_delta
+computation_relation
+```
+
+### ProofProjectionReceipt
+
+```text
+receipt_ref
+source_artifact_ref
+source_envelope_ref
+pnf_graph_ref
+proof_ir_module_ref?
+theory_ref
+target_ref?
+morphism_path
+formalisation_assessment
+proof_status
+realisation_status
+computation_relation
+axiom_delta
+universe_delta
+obligation_refs
+checker_receipt_refs
+loss_receipt_refs
+```
+
+All contracts are immutable, deterministic, revisioned, and content addressed.
+
+## Placement of existing agda2lean components
+
+The current agda2lean IR spans several future layers and should be separated by
+role rather than discarded.
+
+| Current component | PNF-to-Proof-IR role |
+| --- | --- |
+| Agda compiler backend | elaborated source observation producer |
+| snapshot/CBOR | immutable Agda source-fibre payload |
+| canonical names and declarations | source identity and signature observations |
+| typed DAG terms | proof observation payload and initial proof-term algebra |
+| `BuiltinId` | protected proof concept identity |
+| `Feature` | source capability observation and demand trigger |
+| `MappingMode` | early target realisation classification |
+| `body = Nothing` | reconstruction/formalisation residual |
+| support survey | factor/capability proposal producer |
+| platform registry | target alignment declaration |
+| checked Lean emitter | Lean target realiser |
+| correspondence harness | formalisation and target validation evidence |
+| receipts | source/projection/target provenance |
+
+The migration boundary should be:
+
+```text
+Agda elaboration
+-> agda2lean source snapshot
+-> proof PNF factors and constraints
+-> ProofProjectionCandidate
+-> admitted ProofIRModule
+-> Lean/Dedukti/Rocq target fibre
+```
+
+The existing typed DAG remains useful, but it must not be treated simultaneously
+as source observation, canonical PNF, and every target IR.
+
+## External proof systems
+
+### Dedukti, Lambdapi, and Logipedia
+
+These remain external logical-framework and translation substrates:
+
+```text
+ProofIRModule
+-> applicable λΠ-modulo projection
+-> external check or theory translation
+-> checker evidence, target proposals, and obligations
+-> ITIR reconciliation
+```
+
+Reuse their object-theory encodings and translation paths. Do not implement a
+second universal proof kernel inside SensibLaw.
+
+Persist:
+
+```text
+source theory
+target theory
+morphism path
+checker and version
+axiom delta
+universe delta
+computation relation
+translation obligations
+```
+
+### Lean and Rocq
+
+Native reconstruction occurs after Proof IR admission:
+
+```text
+ProofIRModule
+-> target capability assessment
+-> target fibre
+-> native source or checked target object
+-> target diagnostics and correspondence receipt
+```
+
+A target may accept a generic encoded proof while native reconstruction remains
+unresolved. These are different outcomes.
+
+### Zelph
+
+Zelph may consume applicable graph/rule projections and return proposals or
+evidence. It does not establish proof validity unless a declared proof obligation
+explicitly accepts the relevant Zelph result class, and even then the authority
+effect must be recorded.
+
+## Revised implementation tranches
+
+### P0: authority and terminology
+
+- adopt this document as the normative proof-projection companion;
+- retain one compiler and one CLI;
+- define the terminology `observation`, `PNF`, `formalisation candidate`,
+  `Proof IR`, and `target IR`;
+- prohibit treating the current agda2lean IR as all layers at once.
+
+Acceptance:
+
+- documentation uses the three-level distinction consistently;
+- no proof-specific PNF compiler or CLI appears;
+- no runtime behaviour changes.
+
+### P1: source-kind and observation envelope
+
+Retain P1 from the unified source-adapter plan.
+
+Acceptance additions:
+
+- source observations have no target-realisation status except source capability
+  and omission reports;
+- an Agda source artifact can be compiled without requesting a target.
+
+### P2: proof PNF domain signature
+
+- define proof factor, relation, constraint, residual, and demand declarations;
+- ingest agda2lean CBOR as source observations;
+- reduce observations into proof PNF without selecting a target;
+- define proof authority-state refinements;
+- preserve branch alternatives for equality, theory, recursion, and alignment.
+
+Acceptance:
+
+- deterministic proof PNF hashes;
+- no target registry required to build the source PNF;
+- unsupported source constructs become typed residuals;
+- parser ambiguity is not emitted as logical disjunction.
+
+### P3: PNF-to-Proof-IR candidate synthesis
+
+- implement `FormalRoleCandidate`;
+- implement theory-profile declarations;
+- implement signature and judgment synthesis declarations;
+- generate typed formalisation obligations;
+- add formalisation assessments;
+- do not invoke target emitters yet.
+
+Acceptance:
+
+- one PNF may produce multiple competing proof candidates;
+- candidates preserve source factor and alternative provenance;
+- observed claims cannot become axioms or theorems without an authority transition;
+- typed holes distinguish missing type, term, proof, alignment, and capability.
+
+### P4: Proof IR admission and Lean target fibre
+
+- implement `ProofIRModule` and applicability witnesses;
+- represent Lean capability/alignment declarations downstream of Proof IR;
+- invoke the existing checked Lean emitter as an external target realiser;
+- compare target elaboration with the admitted source judgment;
+- preserve fail-on-reconstruction and axiom-delta policy.
+
+Acceptance:
+
+- an admitted Proof IR can exist without Lean output;
+- target failure does not invalidate source PNF or a target-neutral Proof IR;
+- kernel success and formalisation correspondence are independently assessed;
+- all native/derived/encoded/conditional/unavailable statuses are receipted.
+
+### P5: Dedukti/Lambdapi differential projection
+
+- project admitted Proof IR into the existing logical-framework ecosystem;
+- compare with Agda2Dedukti on shared fixtures;
+- record theory and morphism paths;
+- return checker disagreement as typed obligations;
+- retain Logipedia exports as semantic or fallback target fibres rather than
+  automatically native reconstructions.
+
+Acceptance:
+
+- independent semantic path exists for shared fixtures;
+- checker success cannot bypass Proof IR applicability;
+- axiom, universe, and computation deltas are explicit.
+
+### P6: Zelph and mixed-domain evidence
+
+Retain the existing Zelph tranche, but require proof-obligation declarations to
+state whether and how a graph result can contribute evidence.
+
+Acceptance additions:
+
+- no Zelph result directly sets `kernel_checked`;
+- cross-domain evidence retains source and theory scope.
+
+### P7: consolidation and promotion
+
+- consolidate operational/fibred execution strategies after parity;
+- make source adapters, domain signatures, theory profiles, and target
+  capabilities declarative;
+- add end-to-end promotion cases for natural language to Proof IR and Agda to
+  Proof IR to Lean/Dedukti;
+- retire proof-of-concept surfaces that bypass the generic envelope or PNF;
+- document versioning and migration for agda2lean CBOR and Proof IR schemas.
+
+## Required tests and invariants
+
+### Layer separation
+
+- source observations contain no silently selected target interpretation;
+- PNF preserves material alternatives and unresolved distinctions;
+- Proof IR requires an applicability witness;
+- target IR is downstream of Proof IR admission.
+
+### No silent semantic change
+
+- semantic ambiguity is not logical disjunction;
+- observed claims are not assumptions or theorems;
+- every introduced axiom is in the axiom delta;
+- every material discarded branch has assessment or loss evidence;
+- equality and universe distinctions remain explicit.
+
+### Demand conservation
+
+- every required unrepresented distinction produces an obligation or loss;
+- failed projection obligations return to PNF;
+- target failure does not erase valid source compilation;
+- bounded stop conditions are receipted.
+
+### Provenance and determinism
+
+- every Proof IR declaration and judgment traces to source factor revisions;
+- identical source, declarations, theory profiles, and versions produce identical
+  projection hashes;
+- external checker versions and morphism paths are recorded;
+- independent projections may disagree without one silently becoming canonical.
+
+### Validation independence
+
+- formalisation assessment and proof status are separate fields;
+- a kernel-checked proof of a violated formalisation fails correspondence;
+- an unproved but satisfied formalisation remains a valid theorem-engineering
+  artifact;
+- `inapplicable` is not treated as failure or success.
+
+## Explicit non-goals
+
+- no natural-language claim is promoted directly to a theorem;
+- no universal proof kernel is implemented inside SensibLaw;
+- no flattening of PNF ambiguity into one proof term;
+- no use of target libraries during source observation;
+- no generic `sorry` for all residual classes;
+- no claim that Dedukti/Logipedia transport is native target reconstruction;
+- no second PNF flow for proof languages;
+- no coupling between file extension and proof target;
+- no target result mutates source observations or PNF identity.
+
+## Decision
+
+Proceed with proof support as a promotion:
+
+\[
+\text{PNF}
+\rightarrow
+\text{formalisation candidates}
+\rightarrow
+\text{theory-indexed proof fibres}
+\rightarrow
+\text{admitted Proof IR} + \text{typed obligations}
+\]
+
+over the one existing ITIR semantic lifecycle.
+
+PNF is the canonical branch-preserving semantic IR. `ProofIRModule` is an
+applicability-backed projection stating what, under a named theory and explicit
+assumptions, may lawfully be presented to a proof checker. Lean, Rocq,
+Dedukti/Lambdapi, and other target IRs are subsequent fibre realisations.
+
+The concise contract is:
+
+```text
+PNF says what the source may mean.
+Proof IR says what we are prepared to ask a named proof theory to check.
+Target IR says how one selected system will realise that admitted request.
+```

--- a/docs/planning/unified_source_adapters_and_proof_fibres_20260729.md
+++ b/docs/planning/unified_source_adapters_and_proof_fibres_20260729.md
@@ -1,0 +1,506 @@
+# Unified source adapters and proof fibres
+
+Date: 2026-07-29
+Status: planning contract; no runtime authority change
+
+## Authority decision
+
+SensibLaw must retain one semantic compiler flow. Proof-language support must not
+create a second parser, PNF builder, compiler, lifecycle, graph authority, or CLI
+entry point.
+
+The governing shape is:
+
+```text
+source artifact
+-> source admission and source-kind resolution
+-> one source-adapter contract
+-> canonical anchored observation envelope
+-> one factor/proposal/constraint carrier
+-> one PNF reduction and fixed-point flow
+-> one assessment/admission/resolution lifecycle
+-> zero or more typed domain projections/fibres
+-> external execution/checking adapters
+-> one receipt family
+```
+
+Variation by file type, source language, external checker, persistence mode,
+concurrency, or target output belongs in declarations, strategies, profiles, and
+capability gates over that flow.
+
+## Why this fits the current PNF architecture
+
+The current operational and fibred compilers already establish the useful
+invariants:
+
+- immutable source observations and proposals;
+- branch-preserving typed alternatives;
+- explicit factors, constraints, residuals, and closure demands;
+- revision-bound fixed-point work;
+- fibre materialisation before downstream assessment;
+- assessment, admissibility, resolution, projection, and execution as separate
+  authority stages;
+- projection demands returning to the PNF carrier;
+- external execution results remaining evidence or proposals rather than
+  automatic truth or promotion.
+
+Proof-language integration should therefore extend the observation and domain-IR
+surfaces, not bypass them.
+
+## Required correction to the current media abstraction
+
+`MediaType` is useful for ingestion mechanics but is too coarse to select semantic
+compilation. `STRUCTURED` cannot safely mean RDF, Agda, Lean, Rocq, JSON evidence,
+or a precompiled ITIR object at once.
+
+Introduce a separate source-language identity:
+
+```text
+SourceKind
+  natural_language_text
+  legal_document
+  agda
+  lean4
+  rocq
+  dedukti
+  lambdapi
+  rdf
+  wikibase_slice
+  zelph_graph
+  itir_compiled
+```
+
+`MediaType` continues to describe physical adaptation. `SourceKind` selects the
+source observation declaration. Neither selects a different compiler.
+
+The source kind may be obtained from:
+
+1. explicit `--source-kind`;
+2. a revisioned extension/MIME resolver;
+3. bounded content inspection;
+4. otherwise a fail-closed ambiguity diagnostic.
+
+Explicit CLI choice wins, but the receipt records both declared and detected
+source kinds and any disagreement. No source adapter may silently reinterpret an
+ambiguous file.
+
+## One public CLI flow
+
+Extend only the canonical gateway:
+
+```bash
+python -m src.cli compile INPUT \
+  [--source-kind agda] \
+  [--target lean4] \
+  [--projection proof] \
+  [--checker lambdapi]
+```
+
+The durable command is `compile`. Do not add `compile-agda`, `compile-proof`, or a
+second package entry point.
+
+Suggested semantics:
+
+- `INPUT` selects one artifact or directory inventory;
+- `--source-kind` overrides deterministic source-kind detection;
+- `--target` requests a target fibre/projection, not a different compiler;
+- `--projection` requests an admitted output surface;
+- `--checker` selects an external validation strategy;
+- absence of `--target` still builds the canonical carrier and demands;
+- unsupported source/target capabilities emit typed residuals and receipts;
+- no target request may alter source observation or base PNF identity.
+
+Directory compilation resolves a source kind per artifact. Mixed directories are
+permitted only when every artifact is independently admitted and the corpus
+policy permits the resulting adapter set. Directory traversal remains inventory
+and scheduling, not semantic authority.
+
+## Source-adapter contract
+
+Add one revisioned interface, conceptually:
+
+```python
+class SourceObservationAdapter(Protocol):
+    declaration_ref: str
+    supported_source_kinds: frozenset[str]
+
+    def observe(
+        self,
+        artifact: SourceArtifact,
+        context: SourceObservationContext,
+    ) -> SourceObservationEnvelope: ...
+```
+
+The envelope must contain:
+
+```text
+artifact identity and content digest
+source kind and adapter declaration
+canonical source coordinates
+anchored observations
+relations between observations
+source capabilities and omissions
+source-local declarations or symbol identities
+provenance and toolchain versions
+warnings and explicit losses
+```
+
+Adapters observe; they do not resolve, promote, target-lower, or execute.
+
+### Natural-language adapter
+
+The existing canonical text, parsed envelope, annotation graph, mention licensing,
+and parser-relational projection remain the natural-language implementation of
+this contract.
+
+### Agda adapter
+
+The existing agda2lean backend should become the first proof-language adapter. It
+contributes elaborated observations such as:
+
+- module and declaration identities;
+- source spans;
+- binders, terms, universes, declarations, constructors, and dependencies;
+- active semantic builtin identities;
+- relevance and visibility;
+- feature/capability observations;
+- source elaboration and toolchain receipts.
+
+Its typed CBOR object may be admitted directly as `SourceKind.agda` evidence or
+through a dedicated sidecar invocation of the pinned Agda backend. SensibLaw must
+not parse Agda surface syntax itself.
+
+## Shared carrier versus domain algebra
+
+Do not flatten proof terms into natural-language predicates. Reuse the generic
+carrier lifecycle while allowing a domain signature on factor and relation kinds.
+
+```text
+Generic carrier
+  anchor
+  observation
+  factor
+  alternative
+  relation
+  constraint
+  residual
+  demand
+  evidence
+  authority state
+  receipt
+
+Natural-language signature
+  mention, predicate, argument, eventuality, modality, time, place, claim
+
+Proof signature
+  theory, module, declaration, binder, universe, term, inductive, constructor,
+  eliminator, clause, recursion, equality, rewrite, builtin, axiom
+```
+
+The proof domain should initially project agda2lean declarations and terms into
+proof-specific factors without changing the generic `Factor`, `TypedAlternative`,
+`FactorConstraint`, residual, and demand lifecycle.
+
+## Fibre placement
+
+A fibre is a typed projection or derivation over durable carrier factors. Proof
+fibres should include:
+
+```text
+Agda source fibre
+proof-theory capability fibre
+Dedukti/Lambdapi semantic projection fibre
+Lean native-reconstruction fibre
+Rocq native-reconstruction fibre
+computation-correspondence fibre
+axiom/universe-delta fibre
+```
+
+The current fibred operational ordering remains authoritative:
+
+```text
+base carrier
+-> fibre materialisation
+-> constraint worklist
+-> proposal assessment
+-> admissibility
+-> resolution
+-> domain-IR applicability
+-> optional execution
+-> projection and receipts
+```
+
+A proof target fibre may be materialised only from admitted source observations
+and applicable alignments. A checker result may satisfy an obligation, but cannot
+rewrite source observations or bypass admission.
+
+## External systems
+
+### Dedukti, Lambdapi, and Logipedia
+
+Treat these as proof-semantic projection, translation, and checking backends.
+They should not become a second SensibLaw compiler.
+
+```text
+proof factors
+-> applicable Dedukti projection
+-> external checker/translation
+-> validation evidence and target proposals
+-> ITIR reconciliation
+```
+
+Reuse existing theory encodings and translation paths where available. Persist the
+morphism path, computation relation, axiom delta, checker version, and unresolved
+boundaries in receipts.
+
+### Zelph
+
+Treat Zelph as an executable graph adapter:
+
+```text
+applicable domain-IR projection
+-> Zelph graph/rule/query request
+-> result proposal and execution receipt
+-> assessment and reconciliation
+```
+
+Zelph results remain external evidence. They do not become canonical factors
+without the normal lifecycle.
+
+## Where agda2lean lives
+
+The agda2lean repository remains a separate toolchain and specialised product,
+while exposing an ITIR-compatible proof adapter protocol.
+
+Current components map as follows:
+
+| agda2lean component | Unified-flow role |
+| --- | --- |
+| Agda backend | source observation adapter implementation |
+| elaboration snapshot | Agda source fibre payload |
+| typed DAG IR | proof-domain observation/carrier payload |
+| `BuiltinId` | protected proof concept identity |
+| registry layers | target alignment declarations |
+| support classifications | capability and residual declarations |
+| checked Lean emitter | Lean target execution/reconstruction adapter |
+| diagnostics | obligations and residual evidence |
+| conformance corpus | adapter/fibre promotion contract |
+| CBOR, hashes, receipts | deterministic interchange and provenance |
+
+Do not move the Agda compiler backend into SensibLaw Python. Define a versioned
+boundary and invoke or ingest it as an external source adapter.
+
+## Proposed data contracts
+
+### SourceArtifact
+
+```text
+artifact_ref
+content_sha256
+path or content handle
+media_type
+explicit_source_kind?
+detected_source_kind?
+source_kind_evidence
+```
+
+### SourceObservationEnvelope
+
+```text
+envelope_ref
+artifact_ref
+source_kind
+adapter_declaration_ref
+coordinate_system
+observations
+relations
+capabilities
+losses
+provenance_refs
+receipt_ref
+```
+
+### DomainSignature
+
+```text
+signature_ref
+domain_kind
+factor_type_declarations
+relation_type_declarations
+constraint_type_declarations
+residual_type_declarations
+projection_declarations
+```
+
+### ExternalExecutionDeclaration
+
+```text
+executor_ref
+accepted_projection_kinds
+required_capabilities
+result_schema
+trust/authority effect
+version and digest
+```
+
+These should be immutable, deterministic, and content addressed.
+
+## Capability gating
+
+Gating belongs at four explicit boundaries:
+
+1. **source admission** — can the selected adapter observe this artifact?
+2. **domain reduction** — are the observed constructs covered by declared proof
+   factor/relation reductions?
+3. **target projection** — can a target fibre realise the required constructs as
+   native, derived, encoded, conditional, or unavailable?
+4. **external execution** — does a checker/engine accept the projection and what
+   authority does its result carry?
+
+A target should never be selected merely from file extension. File type chooses
+or suggests the source adapter; target selection is an independent request.
+
+## Implementation tranches
+
+### P0: authority-preserving plan and inventory
+
+- adopt this document as the planning contract;
+- inventory all current compiler entry points and source/media adapters;
+- identify the callable canonical document compiler target after operational /
+  fibred parity work;
+- prohibit new proof-specific compiler entry points;
+- define expected receipts for adapter selection and source-kind disagreement.
+
+Acceptance:
+
+- no runtime behaviour change;
+- no second compiler or CLI path;
+- authority documentation points to this plan for proof-language integration.
+
+### P1: source-kind resolver and generic envelope
+
+- add `SourceKind`, `SourceArtifact`, and `SourceObservationEnvelope`;
+- wrap the current text/media path as the first adapter;
+- implement deterministic extension/MIME resolution with explicit override;
+- add `python -m src.cli compile ... --source-kind ...` only through the canonical
+  gateway;
+- ensure existing text compilation projects into byte-for-byte or semantically
+  equivalent downstream artifacts.
+
+Acceptance:
+
+- existing natural-language fixtures retain semantic parity;
+- ambiguous source kind fails closed;
+- detected/declared source-kind receipts are deterministic;
+- no PNF reducer depends directly on a filename extension.
+
+### P2: proof-domain declarations and agda2lean ingestion
+
+- define the proof `DomainSignature`;
+- add an adapter for agda2lean canonical CBOR;
+- project module, declaration, term, builtin, feature, and dependency observations
+  into proof-specific factors and constraints;
+- preserve original CBOR hash and agda2lean version context;
+- emit residuals for unsupported/unclassified constructs;
+- do not yet emit Lean or invoke Dedukti from SensibLaw.
+
+Acceptance:
+
+- the same generic compiler lifecycle processes text and Agda artifacts;
+- factor/constraint/demand/lifecycle receipts share schemas;
+- proof factors never use natural-language-only semantic assumptions;
+- the 19-case agda2lean conformance corpus can be imported deterministically.
+
+### P3: target-fibre applicability and Lean bridge
+
+- represent target capability/alignment declarations as domain-IR applicability
+  rules;
+- request the existing agda2lean checked Lean emitter through an external
+  execution declaration;
+- ingest Lean diagnostics and receipts as target-fibre evidence;
+- preserve reconstruction boundaries and fail-on-reconstruction policy;
+- ensure target output cannot mutate the source carrier.
+
+Acceptance:
+
+- target absence leaves a valid source compilation with residual demands;
+- supported Lean projections produce an execution receipt;
+- reconstruction and unsupported cases remain explicit;
+- native target output is linked to source factors and declarations.
+
+### P4: Dedukti/Lambdapi semantic projection
+
+- add a proof projection declaration for Lambdapi/Dedukti;
+- integrate external checking without embedding another kernel;
+- compare ITIR projection with Agda2Dedukti on shared fixtures;
+- record theory/morphism path, checker identity, axiom delta, and computation
+  relation;
+- treat Logipedia exports as target proposals/fallbacks rather than canonical
+  native reconstructions.
+
+Acceptance:
+
+- checker success and semantic correspondence remain distinct assessments;
+- disagreement produces a typed obligation rather than selecting one path;
+- external theory translations cannot bypass lifecycle admission.
+
+### P5: Zelph execution adapter and mixed-domain evidence
+
+- reuse the existing external graph bridge and domain-IR execution boundary;
+- declare Zelph query/rule capabilities and result schemas;
+- allow proof and text factors to request graph evidence through typed demands;
+- preserve source/domain scope and prohibit accidental cross-domain identity
+  collapse.
+
+Acceptance:
+
+- Zelph execution is optional and revision-pinned;
+- result rows remain evidence/proposals;
+- no graph result promotes proof validity, legal truth, or entity identity by
+  itself.
+
+### P6: consolidation
+
+- collapse operational/fibred/parallel variants into strategies after parity;
+- make the source-adapter registry and domain signatures declarative;
+- retire proof-of-concept adapters that bypass the generic envelope;
+- move durable maintenance scripts under the canonical CLI;
+- document one end-to-end flow for every supported source kind.
+
+## Tests and invariants
+
+Required invariants:
+
+- one compiler authority and one public CLI gateway;
+- one artifact identity independent of source adapter and target request;
+- source observation is immutable after admission;
+- file type affects adapter selection only;
+- target selection affects only target demands/fibres;
+- external execution cannot promote semantic truth;
+- all losses and unsupported constructs are explicit;
+- identical source, declarations, configuration, and tool versions yield
+  identical carrier hashes and receipts;
+- text and proof domains share lifecycle contracts without sharing an
+  impoverished term algebra;
+- mixed-source directories remain deterministic and document scoped;
+- failed target realisation does not invalidate a valid source compilation.
+
+## Explicit non-goals
+
+- no universal proof kernel inside SensibLaw;
+- no Agda surface parser in Python;
+- no second proof-specific PNF implementation;
+- no direct Logipedia or Zelph result promotion;
+- no filename-to-target coupling;
+- no flattening of proof terms into prose predicates;
+- no claim that semantic transport automatically yields idiomatic target code;
+- no new top-level compiler module before current compiler parity/consolidation.
+
+## Decision
+
+Proceed with proof-language support as a source adapter plus domain signature and
+fibres over the one existing semantic lifecycle. Gate source observation by
+`SourceKind` and explicit CLI override, and gate target projections by capability
+and applicability declarations. Keep agda2lean external but ITIR-compatible;
+reuse Dedukti/Logipedia for semantic transport and checking; use Zelph through the
+existing external execution boundary.


### PR DESCRIPTION
## Purpose

Adds an authority-preserving plan for integrating proof languages into the existing SensibLaw/ITIR PNF flow without creating a second compiler, parser authority, lifecycle, graph, or CLI entry point.

This PR now contains two complementary planning contracts:

1. `docs/planning/unified_source_adapters_and_proof_fibres_20260729.md`
2. `docs/planning/pnf_to_proof_ir_projection_20260729.md`

## Core flow

```text
source artifact
-> source-kind resolution
-> one source-adapter contract
-> canonical anchored observations
-> shared factor/proposal/constraint carrier
-> one PNF and fixed-point flow
-> formal-role and theory-indexed candidates
-> proof-fibre assessment and admission
-> Proof IR plus typed obligations
-> target-native or logical-framework projections
-> external checking/execution
-> evidence and demands returned to the same lifecycle
-> shared receipts
```

`MediaType` continues to describe physical ingestion. `SourceKind` selects a revisioned observation adapter. File type may suggest a source adapter, but target selection is independent and capability-gated.

## Representation boundary

The refined plan makes three levels explicit:

- `SourceObservationEnvelope`: what the frontend directly observed;
- `PNFGraph`: branch-preserving semantic possibilities, constraints, residuals, demands, evidence, and authority state;
- `ProofIRModule`: an applicability-backed, theory-indexed formal development containing declarations, judgments, definitions, typed holes, and obligations.

Lean, Rocq, Dedukti, Lambdapi, and other target IRs are downstream realisations of admitted Proof IR. They are not replacements for PNF.

The concise contract is:

```text
PNF says what the source may mean.
Proof IR says what we are prepared to ask a named proof theory to check.
Target IR says how one selected system will realise that admitted request.
```

## Planned placement

- existing natural-language parsing becomes the first `SourceObservationAdapter`;
- agda2lean remains a separate toolchain and becomes the first proof-language adapter plus Lean target realiser;
- proof terms use a proof `DomainSignature` over the generic factor/constraint/demand lifecycle rather than being flattened into prose predicates;
- PNF-to-Proof-IR projection adds formal-role recognition, theory selection, signature synthesis, judgment synthesis, typed obligation generation, and applicability witnesses;
- Dedukti/Lambdapi/Logipedia remain external proof-semantic projection, checking, and translation backends;
- Zelph remains an external executable graph backend whose results return as evidence/proposals.

## Required semantic separations

- semantic ambiguity is not logical disjunction;
- observed claim is not assumption, axiom, or theorem;
- well-typed statement is not proved theorem;
- kernel-checked proof is not automatically a semantically corresponding translation;
- projection success is not proof success;
- target failure does not invalidate source PNF or a target-neutral Proof IR;
- every introduced axiom, discarded branch, computation downgrade, and unresolved obligation is receipted.

## CLI policy

Extend only `python -m src.cli`, conceptually:

```bash
python -m src.cli compile INPUT \
  --source-kind agda \
  --target lean4 \
  --projection proof \
  --checker lambdapi
```

No `compile-agda`, `compile-proof`, second package entry point, or proof-specific PNF compiler.

## Revised tranches

- **P0:** authority and terminology;
- **P1:** `SourceKind` and generic observation envelope;
- **P2:** proof PNF domain signature and agda2lean CBOR ingestion;
- **P3:** PNF-to-Proof-IR candidate synthesis;
- **P4:** Proof IR admission and Lean target fibre;
- **P5:** Dedukti/Lambdapi differential projection;
- **P6:** Zelph and mixed-domain evidence;
- **P7:** final compiler consolidation and promotion.

## Runtime effect

None. This PR remains documentation/planning only and deliberately does not alter the active compiler authority while operational/fibred parity remains unresolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added planning guidance for projecting canonical representations into theory-indexed proof representations.
  * Defined lifecycle boundaries, typed obligations, applicability checks, authority states, and iterative refinement.
  * Documented a unified approach for integrating natural-language, legal, proof-language, and knowledge-source inputs.
  * Clarified source observation, domain signatures, capability checks, external proof execution, and evidence handling.
  * Added phased implementation plans, acceptance criteria, validation invariants, and explicit non-goals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->