### PR TITLE
Fix reference parity import cycle

### DIFF
--- a/src/policy/semantic_receipt_enrichment.py
+++ b/src/policy/semantic_receipt_enrichment.py
@@ -7,9 +7,6 @@ import os
 from pathlib import Path
 from typing import Any, Mapping
 
-from src.runtime.reference_parity import reference_semantic_surface
-
-
 _INSTALL_MARKER = "_semantic_receipt_enrichment_installed"
 
 
@@ -60,9 +57,15 @@ def enrich_semantic_receipt(
         if isinstance(row, Mapping)
     )
     streaming_build = artifacts.get("streaming_semantic_build") or {}
-    if isinstance(streaming_build, Mapping) and streaming_build.get(
-        "reference_backed"
-    ):
+    if isinstance(streaming_build, Mapping) and streaming_build.get("reference_backed"):
+        # ``reference_parity`` imports the canonical policy carrier.  This
+        # module is itself imported by the eager execution-strategy installer
+        # during policy package initialization, so importing it at module load
+        # time forms a cycle when a caller starts at ``reference_parity``.
+        # The function is only needed for a completed receipt, well after the
+        # strategy installer has finished; defer it to retain that boundary.
+        from src.runtime.reference_parity import reference_semantic_surface
+
         # Typing hierarchy receipts live in the execution receipt rather than in
         # the streaming-build compatibility view. Bind them into the compact
         # parity surface before hashing so partition-independent typing identity

--- a/tests/runtime/test_reference_parity.py
+++ b/tests/runtime/test_reference_parity.py
@@ -1,9 +1,31 @@
 from __future__ import annotations
 
+from pathlib import Path
+import subprocess
+import sys
+
 from src.runtime.reference_parity import (
     compare_reference_surfaces,
     reference_semantic_surface,
 )
+
+
+def test_reference_parity_import_is_safe_from_a_fresh_interpreter() -> None:
+    """Reference-parity must not re-enter policy installation during import."""
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from src.runtime.reference_parity import reference_semantic_surface",
+        ],
+        cwd=Path(__file__).parents[2],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def _build(*, factor_digest: str = "factor-digest") -> dict[str, object]:


### PR DESCRIPTION
Fixes the current-head exact-0008 CLI startup failure.

The eager policy strategy installer imports receipt enrichment while `reference_parity` is partially initialized. Deferring the parity helper import to completed-receipt enrichment breaks that cycle. Includes a fresh-interpreter regression.

Validation:
- `python scripts/run_exact_0008_parallel_acceptance.py --help`
- focused parity and receipt-enrichment tests
- Ruff check and format check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when loading reference-backed receipt enrichment by preventing import-time dependency conflicts.
  - Preserved existing reference surface generation behavior.

- **Tests**
  - Added regression coverage to verify reference surface imports succeed cleanly in a fresh runtime without unintended policy installation or errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->