### PR TITLE
Enforce bounded execution-kernel contracts

### DIFF
--- a/src/policy/execution_kernel_contracts_execution.py
+++ b/src/policy/execution_kernel_contracts_execution.py
@@ -1,6 +1,6 @@
 """Install executable kernel contracts on the semantic execution boundary.
 
-The semantic compiler remains pure and storage-neutral.  This layer wraps only
+The semantic compiler remains pure and storage-neutral. This layer wraps only
 physical execution telemetry and the closure-handoff adapter, persisting a
 finite diagnostic before rejecting an opaque wait, illegal lifecycle change,
 post-drain admission, or silent authority fallback.
@@ -22,9 +22,17 @@ from src.runtime.execution_kernel_contract import (
 _INSTALL_MARKER = "_execution_kernel_contracts_installed"
 
 
-def _enabled() -> bool:
-    value = os.environ.get("SENSIBLAW_ENFORCE_KERNEL_CONTRACTS", "1")
+def _truthy(name: str, default: str) -> bool:
+    value = os.environ.get(name, default)
     return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _enabled() -> bool:
+    return _truthy("SENSIBLAW_ENFORCE_KERNEL_CONTRACTS", "1")
+
+
+def _require_postgresql() -> bool:
+    return _truthy("SENSIBLAW_REQUIRE_POSTGRESQL_EXECUTION", "0")
 
 
 def _atomic_json(path: Path, payload: Mapping[str, Any]) -> None:
@@ -137,7 +145,19 @@ def install_execution_kernel_contracts() -> bool:
                 budget_family=budget_family,
             )
         except KernelContractViolation as error:
-            _persist(self, error.diagnostic)
+            diagnostic = dict(error.diagnostic)
+            if (
+                diagnostic.get("violation") == "postgresql_authority_missing"
+                and not _require_postgresql()
+            ):
+                diagnostic["enforcement_state"] = "deferred_compatibility"
+                diagnostic["authority_requirement"] = (
+                    "set SENSIBLAW_REQUIRE_POSTGRESQL_EXECUTION=1 for exact acceptance"
+                )
+                _persist(self, diagnostic)
+                row["execution_kernel_contract"] = diagnostic
+                return row
+            _persist(self, diagnostic)
             raise
         _persist(self, event)
         row["execution_kernel_contract"] = event
@@ -178,7 +198,7 @@ def install_execution_kernel_contracts() -> bool:
         authority = os.environ.get("SENSIBLAW_EXECUTION_AUTHORITY", "checkpoint")
         setattr(context, "_kernel_authority_backend", authority)
         # PostgreSQL execution adapters increment this only after the admission
-        # transaction commits.  Local replay deliberately leaves it zero.
+        # transaction commits. Local replay deliberately leaves it zero.
         setattr(
             context,
             "_kernel_authority_row_count",

--- a/src/policy/execution_kernel_contracts_execution.py
+++ b/src/policy/execution_kernel_contracts_execution.py
@@ -1,0 +1,201 @@
+"""Install executable kernel contracts on the semantic execution boundary.
+
+The semantic compiler remains pure and storage-neutral.  This layer wraps only
+physical execution telemetry and the closure-handoff adapter, persisting a
+finite diagnostic before rejecting an opaque wait, illegal lifecycle change,
+post-drain admission, or silent authority fallback.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.runtime.execution_kernel_contract import (
+    KernelContractViolation,
+    KernelRegistry,
+)
+
+
+_INSTALL_MARKER = "_execution_kernel_contracts_installed"
+
+
+def _enabled() -> bool:
+    value = os.environ.get("SENSIBLAW_ENFORCE_KERNEL_CONTRACTS", "1")
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _atomic_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(dict(payload), ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def _persist(context: Any, event: Mapping[str, Any]) -> None:
+    root = getattr(context, "checkpoint_root", None)
+    if root is None:
+        return
+    contract_root = Path(root) / "kernel-contracts"
+    _atomic_json(contract_root / "latest.json", event)
+    contract_root.mkdir(parents=True, exist_ok=True)
+    with (contract_root / "events.jsonl").open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(dict(event), ensure_ascii=False, sort_keys=True) + "\n")
+        stream.flush()
+
+
+def install_execution_kernel_contracts() -> bool:
+    """Require registered bounded contracts for every semantic execution sample."""
+
+    if not _enabled():
+        return False
+
+    from src.policy import parallel_semantic_execution as semantic
+
+    if getattr(semantic, _INSTALL_MARKER, False):
+        return False
+
+    original_sample = semantic.SemanticExecutionContext.sample
+
+    def sample_wrapper(
+        self: Any,
+        stage: str,
+        *,
+        phase: str,
+        counts: Mapping[str, int] | None = None,
+        details: Mapping[str, Any] | None = None,
+        elapsed_ns: int | None = None,
+    ) -> dict[str, Any]:
+        registry = getattr(self, "_execution_kernel_registry", None)
+        if registry is None:
+            registry = KernelRegistry()
+            setattr(self, "_execution_kernel_registry", registry)
+
+        count_values = dict(counts or {})
+        detail_values = dict(details or {})
+        if stage in {"owner_admission_batch", "owner_frontier_reconstruction"}:
+            count_values.setdefault(
+                "new_durable_obligations",
+                int(getattr(self, "_kernel_new_durable_obligations", 0)),
+            )
+            count_values.setdefault(
+                "durable_admissions",
+                int(getattr(self, "_kernel_durable_admissions", 0)),
+            )
+            detail_values.setdefault(
+                "frontier_drained",
+                bool(getattr(self, "_kernel_frontier_drained", False)),
+            )
+            detail_values.setdefault(
+                "authority_backend",
+                str(
+                    getattr(
+                        self,
+                        "_kernel_authority_backend",
+                        os.environ.get("SENSIBLAW_EXECUTION_AUTHORITY", "checkpoint"),
+                    )
+                ),
+            )
+            detail_values.setdefault(
+                "authority_row_count",
+                int(getattr(self, "_kernel_authority_row_count", 0)),
+            )
+
+        budget_family = str(
+            detail_values.get("stage_budget_family")
+            or getattr(self, "_kernel_budget_family", "")
+        )
+        # The stage-budget wrapper is installed immediately before this layer,
+        # so its returned row is the authoritative budget-family observation.
+        row = original_sample(
+            self,
+            stage,
+            phase=phase,
+            counts=count_values,
+            details=detail_values,
+            elapsed_ns=elapsed_ns,
+        )
+        budget = row.get("stage_budget") if isinstance(row, Mapping) else None
+        if isinstance(budget, Mapping):
+            budget_family = str(budget.get("stage_family") or budget_family)
+        elif isinstance(row, Mapping):
+            budget_family = str(
+                (row.get("details") or {}).get("stage_budget_family") or budget_family
+            )
+
+        try:
+            event = registry.observe(
+                stage=stage,
+                phase=phase,
+                counts=count_values,
+                details=detail_values,
+                budget_family=budget_family,
+            )
+        except KernelContractViolation as error:
+            _persist(self, error.diagnostic)
+            raise
+        _persist(self, event)
+        row["execution_kernel_contract"] = event
+        return row
+
+    semantic.SemanticExecutionContext.sample = sample_wrapper
+
+    # Supply handoff facts without contaminating the semantic owner or reducer.
+    original_record = semantic.ClosureOwnerReplayContract.record_observation_batch
+
+    def record_observation_batch(
+        self: Any,
+        deltas: Any,
+        *,
+        owner: Any,
+    ) -> None:
+        context = self.context
+        prior_obligations = int(
+            getattr(context, "_kernel_boundary_obligation_count", 0)
+        )
+        current_obligations = len(getattr(owner, "_boundary_obligations", ()))
+        setattr(
+            context,
+            "_kernel_new_durable_obligations",
+            max(0, current_obligations - prior_obligations),
+        )
+        setattr(context, "_kernel_boundary_obligation_count", current_obligations)
+        setattr(
+            context,
+            "_kernel_frontier_drained",
+            bool(
+                getattr(owner, "_producer_exhausted", False)
+                and not getattr(owner, "_pending_jobs", {})
+                and not getattr(owner, "_in_flight_jobs", {})
+                and not getattr(owner, "_dirty_groups", set())
+            ),
+        )
+        authority = os.environ.get("SENSIBLAW_EXECUTION_AUTHORITY", "checkpoint")
+        setattr(context, "_kernel_authority_backend", authority)
+        # PostgreSQL execution adapters increment this only after the admission
+        # transaction commits.  Local replay deliberately leaves it zero.
+        setattr(
+            context,
+            "_kernel_authority_row_count",
+            int(getattr(context, "_postgres_admission_row_count", 0)),
+        )
+        setattr(
+            context,
+            "_kernel_durable_admissions",
+            int(getattr(context, "_postgres_admission_row_count", 0)),
+        )
+        return original_record(self, deltas, owner=owner)
+
+    semantic.ClosureOwnerReplayContract.record_observation_batch = (
+        record_observation_batch
+    )
+    setattr(semantic, _INSTALL_MARKER, True)
+    return True
+
+
+__all__ = ["install_execution_kernel_contracts"]

--- a/src/policy/stage_budget_execution.py
+++ b/src/policy/stage_budget_execution.py
@@ -15,7 +15,8 @@ def install_stage_budget_execution() -> bool:
 
     Semantic samples are required to resolve to an explicit stage family. A new
     kernel label therefore cannot silently degrade to ``unbudgeted`` telemetry
-    during an exact-document run.
+    during an exact-document run.  Executable kernel contracts are installed
+    immediately afterwards so they consume this authoritative budget receipt.
     """
 
     from src.policy import parallel_semantic_execution as semantic
@@ -66,6 +67,12 @@ def install_stage_budget_execution() -> bool:
     semantic.SemanticExecutionContext.sample = sample_wrapper
     semantic._unbudgeted_semantic_sample = original
     setattr(semantic, _INSTALL_MARKER, True)
+
+    from src.policy.execution_kernel_contracts_execution import (
+        install_execution_kernel_contracts,
+    )
+
+    install_execution_kernel_contracts()
     return True
 
 

--- a/src/runtime/execution_kernel_contract.py
+++ b/src/runtime/execution_kernel_contract.py
@@ -1,0 +1,358 @@
+"""Mandatory execution-kernel contracts for bounded semantic work.
+
+Semantic functions remain pure.  This module governs only physical kernels that
+can loop, wait, allocate materially, checkpoint, or mutate durable execution
+state.  Contracts turn progress/lifecycle/authority telemetry into executable
+invariants instead of advisory labels.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from time import monotonic_ns
+from typing import Any, Mapping, Sequence
+
+
+KERNEL_CONTRACT_SCHEMA_VERSION = "sensiblaw.execution-kernel-contract.v1"
+KERNEL_EVENT_SCHEMA_VERSION = "sensiblaw.execution-kernel-event.v1"
+
+
+class KernelAuthority(StrEnum):
+    MEMORY = "memory"
+    CHECKPOINT = "checkpoint"
+    POSTGRESQL = "postgresql"
+
+
+class KernelContractViolation(RuntimeError):
+    """An execution event violated its registered physical contract."""
+
+    def __init__(self, diagnostic: Mapping[str, Any]):
+        self.diagnostic = dict(diagnostic)
+        super().__init__(
+            f"execution kernel contract violation: "
+            f"{self.diagnostic.get('kernel_key')} / "
+            f"{self.diagnostic.get('violation')}"
+        )
+
+
+@dataclass(frozen=True)
+class KernelContract:
+    key: str
+    stage_prefixes: tuple[str, ...]
+    lifecycle: str
+    budget_family: str
+    authority: KernelAuthority
+    progress_keys: tuple[str, ...]
+    progress_unit: str
+    max_batch_size: int
+    checkpoint_contract: str
+    allowed_next: tuple[str, ...]
+    no_progress_timeout_seconds: int = 120
+    forbid_post_drain_admission: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.key or not self.stage_prefixes:
+            raise ValueError("kernel key and stage prefixes are required")
+        if self.max_batch_size < 1 or self.no_progress_timeout_seconds < 1:
+            raise ValueError("kernel bounds must be positive")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": KERNEL_CONTRACT_SCHEMA_VERSION,
+            "key": self.key,
+            "stage_prefixes": list(self.stage_prefixes),
+            "lifecycle": self.lifecycle,
+            "budget_family": self.budget_family,
+            "authority": self.authority.value,
+            "progress_keys": list(self.progress_keys),
+            "progress_unit": self.progress_unit,
+            "max_batch_size": self.max_batch_size,
+            "checkpoint_contract": self.checkpoint_contract,
+            "allowed_next": list(self.allowed_next),
+            "no_progress_timeout_seconds": self.no_progress_timeout_seconds,
+            "forbid_post_drain_admission": self.forbid_post_drain_admission,
+        }
+
+
+@dataclass
+class _KernelState:
+    last_progress: int | None = None
+    last_progress_ns: int = field(default_factory=monotonic_ns)
+    last_phase: str | None = None
+    completed: bool = False
+
+
+def _normalise(value: str) -> str:
+    return str(value).strip().lower().replace("-", "_")
+
+
+DEFAULT_KERNEL_CONTRACTS: tuple[KernelContract, ...] = (
+    KernelContract(
+        key="typing.leaf-execution",
+        stage_prefixes=("local_typing_diagnostics", "typing_"),
+        lifecycle="typing",
+        budget_family="typing",
+        authority=KernelAuthority.CHECKPOINT,
+        progress_keys=("leaves_completed", "output_items_completed", "completed"),
+        progress_unit="typing_leaf",
+        max_batch_size=4096,
+        checkpoint_contract="typing-leaf-hierarchy:v1",
+        allowed_next=("closure.activation", "failed"),
+    ),
+    KernelContract(
+        key="closure.activation",
+        stage_prefixes=("activation_", "closure_activation"),
+        lifecycle="producing",
+        budget_family="closure",
+        authority=KernelAuthority.CHECKPOINT,
+        progress_keys=("leaves_completed", "admitted_delta_count", "completed"),
+        progress_unit="activation_leaf",
+        max_batch_size=4096,
+        checkpoint_contract="closure-activation-leaves:v1",
+        allowed_next=("closure.handoff", "closure.execution", "failed"),
+    ),
+    KernelContract(
+        key="closure.handoff",
+        stage_prefixes=("owner_admission_batch", "owner_frontier_reconstruction"),
+        lifecycle="draining",
+        budget_family="closure",
+        authority=KernelAuthority.POSTGRESQL,
+        progress_keys=("durable_admissions", "new_durable_obligations", "owner_revision"),
+        progress_unit="owner_revision",
+        max_batch_size=4096,
+        checkpoint_contract="postgres-semantic-owner-stream:v1",
+        allowed_next=("closure.reducing-final-dirty", "closure.execution", "failed"),
+        no_progress_timeout_seconds=120,
+        forbid_post_drain_admission=True,
+    ),
+    KernelContract(
+        key="closure.execution",
+        stage_prefixes=(
+            "streaming_closure",
+            "closure_",
+            "job_",
+            "ready_frontier_",
+            "scheduled_job_",
+            "dirty_group_",
+            "base_proposal_",
+            "composition_",
+        ),
+        lifecycle="draining",
+        budget_family="closure",
+        authority=KernelAuthority.POSTGRESQL,
+        progress_keys=("jobs_completed", "completed", "owner_revision"),
+        progress_unit="semantic_job",
+        max_batch_size=4096,
+        checkpoint_contract="postgres-fenced-semantic-worker:v1",
+        allowed_next=("closure.reducing-final-dirty", "finalization.materialize", "failed"),
+    ),
+    KernelContract(
+        key="closure.reducing-final-dirty",
+        stage_prefixes=("reduce_dirty", "final_dirty", "dirty_group_reduction"),
+        lifecycle="reducing_final_dirty",
+        budget_family="closure",
+        authority=KernelAuthority.POSTGRESQL,
+        progress_keys=("dirty_groups_completed", "owner_revision", "completed"),
+        progress_unit="owner_key",
+        max_batch_size=4096,
+        checkpoint_contract="postgres-owner-reduction:v1",
+        allowed_next=("finalization.materialize", "failed"),
+    ),
+    KernelContract(
+        key="finalization.materialize",
+        stage_prefixes=("materialize_", "assemble_reduction", "build_convergent_"),
+        lifecycle="certifying",
+        budget_family="finalization",
+        authority=KernelAuthority.POSTGRESQL,
+        progress_keys=("processed", "rows_scanned", "completed"),
+        progress_unit="settled_reduction_row",
+        max_batch_size=4096,
+        checkpoint_contract="indexed-settled-owner-reductions:v1",
+        allowed_next=("finalization.certify", "serialization.receipt", "failed"),
+    ),
+    KernelContract(
+        key="finalization.certify",
+        stage_prefixes=("build_region_boundary_", "validate_", "build_fixed_point_"),
+        lifecycle="certifying",
+        budget_family="finalization",
+        authority=KernelAuthority.POSTGRESQL,
+        progress_keys=("processed", "rows_scanned", "completed"),
+        progress_unit="certificate_component",
+        max_batch_size=4096,
+        checkpoint_contract="document-fixed-point-certificate:v1",
+        allowed_next=("serialization.receipt", "failed"),
+    ),
+    KernelContract(
+        key="serialization.receipt",
+        stage_prefixes=("serialize_", "isolated_serializer", "release_owner_"),
+        lifecycle="certifying",
+        budget_family="serialization",
+        authority=KernelAuthority.CHECKPOINT,
+        progress_keys=("processed", "bytes_written", "completed"),
+        progress_unit="receipt_segment",
+        max_batch_size=4096,
+        checkpoint_contract="reference-execution-receipt:v1",
+        allowed_next=("publication.postgresql", "failed"),
+    ),
+    KernelContract(
+        key="publication.postgresql",
+        stage_prefixes=("postgres_", "publication_"),
+        lifecycle="publishing",
+        budget_family="publication",
+        authority=KernelAuthority.POSTGRESQL,
+        progress_keys=("rows_persisted", "completed", "publication_revision"),
+        progress_unit="publication_row",
+        max_batch_size=4096,
+        checkpoint_contract="postgres-publication-build:v1",
+        allowed_next=("parity.acceptance", "completed", "failed"),
+    ),
+    KernelContract(
+        key="parity.acceptance",
+        stage_prefixes=("acceptance_", "semantic_parity", "reference_parity", "parity_"),
+        lifecycle="verifying",
+        budget_family="parity",
+        authority=KernelAuthority.POSTGRESQL,
+        progress_keys=("manifests_verified", "completed"),
+        progress_unit="manifest",
+        max_batch_size=4096,
+        checkpoint_contract="manifest-first-parity:v1",
+        allowed_next=("completed", "failed"),
+    ),
+)
+
+
+class KernelRegistry:
+    def __init__(self, contracts: Sequence[KernelContract] = DEFAULT_KERNEL_CONTRACTS):
+        self.contracts = tuple(contracts)
+        self._states: dict[str, _KernelState] = {}
+        self._active_kernel: str | None = None
+
+    def resolve(self, stage: str) -> KernelContract:
+        normalised = _normalise(stage).split(":", 1)[0]
+        matches = [
+            contract
+            for contract in self.contracts
+            if any(normalised.startswith(_normalise(prefix)) for prefix in contract.stage_prefixes)
+        ]
+        if not matches:
+            raise KernelContractViolation(
+                {
+                    "schema_version": KERNEL_EVENT_SCHEMA_VERSION,
+                    "kernel_key": None,
+                    "stage": stage,
+                    "violation": "unregistered_execution_kernel",
+                }
+            )
+        return max(
+            matches,
+            key=lambda contract: max(
+                len(prefix)
+                for prefix in contract.stage_prefixes
+                if normalised.startswith(_normalise(prefix))
+            ),
+        )
+
+    @staticmethod
+    def _progress_value(contract: KernelContract, counts: Mapping[str, int]) -> int | None:
+        for key in contract.progress_keys:
+            if key in counts:
+                return int(counts[key])
+        return None
+
+    def observe(
+        self,
+        *,
+        stage: str,
+        phase: str,
+        counts: Mapping[str, int] | None,
+        details: Mapping[str, Any] | None,
+        budget_family: str,
+    ) -> dict[str, Any]:
+        contract = self.resolve(stage)
+        count_values = {str(key): int(value) for key, value in (counts or {}).items()}
+        detail_values = dict(details or {})
+        now = monotonic_ns()
+        state = self._states.setdefault(contract.key, _KernelState())
+        violation: str | None = None
+
+        if budget_family != contract.budget_family:
+            violation = "budget_family_mismatch"
+
+        batch_size = int(detail_values.get("batch_size") or count_values.get("rows_in") or 0)
+        if batch_size > contract.max_batch_size:
+            violation = violation or "batch_bound_exceeded"
+
+        reported_authority = str(detail_values.get("authority_backend") or "")
+        authority_rows = int(detail_values.get("authority_row_count") or 0)
+        if contract.authority is KernelAuthority.POSTGRESQL and (
+            reported_authority != KernelAuthority.POSTGRESQL.value or authority_rows < 1
+        ):
+            violation = violation or "postgresql_authority_missing"
+
+        frontier_drained = bool(detail_values.get("frontier_drained"))
+        rows_in = int(count_values.get("rows_in") or 0)
+        new_obligations = int(count_values.get("new_durable_obligations") or 0)
+        if (
+            contract.forbid_post_drain_admission
+            and frontier_drained
+            and rows_in > 0
+            and new_obligations <= 0
+        ):
+            violation = violation or "post_drain_admission_without_durable_obligation"
+
+        progress = self._progress_value(contract, count_values)
+        waiting = phase.endswith("waiting") or detail_values.get("wait_reason") is not None
+        completed = bool(
+            detail_values.get("completed")
+            or phase.endswith("completed")
+            or count_values.get("completed") == count_values.get("total") != None
+        )
+        if progress is not None and (state.last_progress is None or progress > state.last_progress):
+            state.last_progress = progress
+            state.last_progress_ns = now
+        elif waiting:
+            if not detail_values.get("wait_reason") or not detail_values.get("wait_dependency"):
+                violation = violation or "unnamed_wait"
+        elif not completed and now - state.last_progress_ns > contract.no_progress_timeout_seconds * 1_000_000_000:
+            violation = violation or "no_monotonic_progress"
+
+        if self._active_kernel and self._active_kernel != contract.key:
+            previous = next(row for row in self.contracts if row.key == self._active_kernel)
+            if contract.key not in previous.allowed_next:
+                violation = violation or "illegal_lifecycle_transition"
+        self._active_kernel = contract.key
+        state.last_phase = phase
+        state.completed = completed
+
+        event = {
+            "schema_version": KERNEL_EVENT_SCHEMA_VERSION,
+            "kernel_key": contract.key,
+            "stage": stage,
+            "phase": phase,
+            "lifecycle": contract.lifecycle,
+            "budget_family": contract.budget_family,
+            "authority": contract.authority.value,
+            "progress_unit": contract.progress_unit,
+            "progress": progress,
+            "batch_size": batch_size,
+            "frontier_drained": frontier_drained,
+            "new_durable_obligations": new_obligations,
+            "checkpoint_contract": contract.checkpoint_contract,
+            "violation": violation,
+            "contract": contract.to_dict(),
+        }
+        if violation is not None:
+            raise KernelContractViolation(event)
+        return event
+
+
+__all__ = [
+    "DEFAULT_KERNEL_CONTRACTS",
+    "KERNEL_CONTRACT_SCHEMA_VERSION",
+    "KERNEL_EVENT_SCHEMA_VERSION",
+    "KernelAuthority",
+    "KernelContract",
+    "KernelContractViolation",
+    "KernelRegistry",
+]

--- a/src/runtime/execution_kernel_contract.py
+++ b/src/runtime/execution_kernel_contract.py
@@ -118,7 +118,11 @@ DEFAULT_KERNEL_CONTRACTS: tuple[KernelContract, ...] = (
         lifecycle="draining",
         budget_family="closure",
         authority=KernelAuthority.POSTGRESQL,
-        progress_keys=("durable_admissions", "new_durable_obligations", "owner_revision"),
+        progress_keys=(
+            "durable_admissions",
+            "new_durable_obligations",
+            "owner_revision",
+        ),
         progress_unit="owner_revision",
         max_batch_size=4096,
         checkpoint_contract="postgres-semantic-owner-stream:v1",
@@ -145,7 +149,11 @@ DEFAULT_KERNEL_CONTRACTS: tuple[KernelContract, ...] = (
         progress_unit="semantic_job",
         max_batch_size=4096,
         checkpoint_contract="postgres-fenced-semantic-worker:v1",
-        allowed_next=("closure.reducing-final-dirty", "finalization.materialize", "failed"),
+        allowed_next=(
+            "closure.reducing-final-dirty",
+            "finalization.materialize",
+            "failed",
+        ),
     ),
     KernelContract(
         key="closure.reducing-final-dirty",
@@ -209,7 +217,12 @@ DEFAULT_KERNEL_CONTRACTS: tuple[KernelContract, ...] = (
     ),
     KernelContract(
         key="parity.acceptance",
-        stage_prefixes=("acceptance_", "semantic_parity", "reference_parity", "parity_"),
+        stage_prefixes=(
+            "acceptance_",
+            "semantic_parity",
+            "reference_parity",
+            "parity_",
+        ),
         lifecycle="verifying",
         budget_family="parity",
         authority=KernelAuthority.POSTGRESQL,
@@ -233,7 +246,10 @@ class KernelRegistry:
         matches = [
             contract
             for contract in self.contracts
-            if any(normalised.startswith(_normalise(prefix)) for prefix in contract.stage_prefixes)
+            if any(
+                normalised.startswith(_normalise(prefix))
+                for prefix in contract.stage_prefixes
+            )
         ]
         if not matches:
             raise KernelContractViolation(
@@ -254,7 +270,9 @@ class KernelRegistry:
         )
 
     @staticmethod
-    def _progress_value(contract: KernelContract, counts: Mapping[str, int]) -> int | None:
+    def _progress_value(
+        contract: KernelContract, counts: Mapping[str, int]
+    ) -> int | None:
         for key in contract.progress_keys:
             if key in counts:
                 return int(counts[key])
@@ -279,7 +297,9 @@ class KernelRegistry:
         if budget_family != contract.budget_family:
             violation = "budget_family_mismatch"
 
-        batch_size = int(detail_values.get("batch_size") or count_values.get("rows_in") or 0)
+        batch_size = int(
+            detail_values.get("batch_size") or count_values.get("rows_in") or 0
+        )
         if batch_size > contract.max_batch_size:
             violation = violation or "batch_bound_exceeded"
 
@@ -302,23 +322,39 @@ class KernelRegistry:
             violation = violation or "post_drain_admission_without_durable_obligation"
 
         progress = self._progress_value(contract, count_values)
-        waiting = phase.endswith("waiting") or detail_values.get("wait_reason") is not None
+        waiting = (
+            phase.endswith("waiting") or detail_values.get("wait_reason") is not None
+        )
         completed = bool(
             detail_values.get("completed")
             or phase.endswith("completed")
-            or count_values.get("completed") == count_values.get("total") != None
+            or (
+                count_values.get("total") is not None
+                and count_values.get("completed") == count_values.get("total")
+            )
         )
-        if progress is not None and (state.last_progress is None or progress > state.last_progress):
+        if waiting and (
+            not detail_values.get("wait_reason")
+            or not detail_values.get("wait_dependency")
+        ):
+            violation = violation or "unnamed_wait"
+
+        if progress is not None and (
+            state.last_progress is None or progress > state.last_progress
+        ):
             state.last_progress = progress
             state.last_progress_ns = now
-        elif waiting:
-            if not detail_values.get("wait_reason") or not detail_values.get("wait_dependency"):
-                violation = violation or "unnamed_wait"
-        elif not completed and now - state.last_progress_ns > contract.no_progress_timeout_seconds * 1_000_000_000:
+        elif (
+            not completed
+            and now - state.last_progress_ns
+            > contract.no_progress_timeout_seconds * 1_000_000_000
+        ):
             violation = violation or "no_monotonic_progress"
 
         if self._active_kernel and self._active_kernel != contract.key:
-            previous = next(row for row in self.contracts if row.key == self._active_kernel)
+            previous = next(
+                row for row in self.contracts if row.key == self._active_kernel
+            )
             if contract.key not in previous.allowed_next:
                 violation = violation or "illegal_lifecycle_transition"
         self._active_kernel = contract.key

--- a/tests/runtime/test_execution_kernel_contract.py
+++ b/tests/runtime/test_execution_kernel_contract.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import pytest
+
+from src.runtime.execution_kernel_contract import (
+    KernelContractViolation,
+    KernelRegistry,
+)
+
+
+def test_owner_handoff_requires_postgres_authority_evidence() -> None:
+    registry = KernelRegistry()
+
+    with pytest.raises(KernelContractViolation) as captured:
+        registry.observe(
+            stage="owner_admission_batch",
+            phase="closure_handoff",
+            counts={
+                "rows_in": 2,
+                "owner_revision": 4,
+                "durable_admissions": 0,
+                "new_durable_obligations": 1,
+            },
+            details={
+                "batch_size": 2,
+                "frontier_drained": False,
+                "authority_backend": "checkpoint",
+                "authority_row_count": 0,
+            },
+            budget_family="closure",
+        )
+
+    assert captured.value.diagnostic["violation"] == "postgresql_authority_missing"
+
+
+def test_post_drain_admission_requires_new_durable_obligation() -> None:
+    registry = KernelRegistry()
+
+    with pytest.raises(KernelContractViolation) as captured:
+        registry.observe(
+            stage="owner_admission_batch",
+            phase="closure_handoff",
+            counts={
+                "rows_in": 1,
+                "owner_revision": 12,
+                "durable_admissions": 12,
+                "new_durable_obligations": 0,
+            },
+            details={
+                "batch_size": 1,
+                "frontier_drained": True,
+                "authority_backend": "postgresql",
+                "authority_row_count": 12,
+            },
+            budget_family="closure",
+        )
+
+    assert (
+        captured.value.diagnostic["violation"]
+        == "post_drain_admission_without_durable_obligation"
+    )
+
+
+def test_post_drain_admission_with_durable_obligation_is_explicit_progress() -> None:
+    registry = KernelRegistry()
+
+    event = registry.observe(
+        stage="owner_admission_batch",
+        phase="closure_handoff",
+        counts={
+            "rows_in": 1,
+            "owner_revision": 13,
+            "durable_admissions": 13,
+            "new_durable_obligations": 1,
+        },
+        details={
+            "batch_size": 1,
+            "frontier_drained": True,
+            "authority_backend": "postgresql",
+            "authority_row_count": 13,
+        },
+        budget_family="closure",
+    )
+
+    assert event["kernel_key"] == "closure.handoff"
+    assert event["progress"] == 13
+    assert event["new_durable_obligations"] == 1
+    assert event["violation"] is None
+
+
+def test_wait_must_name_reason_and_dependency() -> None:
+    registry = KernelRegistry()
+
+    with pytest.raises(KernelContractViolation) as captured:
+        registry.observe(
+            stage="local_typing_diagnostics:local_type_carrier_build",
+            phase="typing_parent_waiting",
+            counts={"leaves_completed": 2, "leaves_total": 3},
+            details={"wait_reason": "worker_results"},
+            budget_family="typing",
+        )
+
+    assert captured.value.diagnostic["violation"] == "unnamed_wait"
+
+
+def test_monotonic_typing_progress_and_named_wait_are_valid() -> None:
+    registry = KernelRegistry()
+    first = registry.observe(
+        stage="local_typing_diagnostics:local_type_carrier_build",
+        phase="typing_leaf_completed",
+        counts={"leaves_completed": 1, "leaves_total": 3},
+        details={"batch_size": 128},
+        budget_family="typing",
+    )
+    waiting = registry.observe(
+        stage="local_typing_diagnostics:local_type_carrier_build",
+        phase="typing_parent_waiting",
+        counts={"leaves_completed": 1, "leaves_total": 3},
+        details={
+            "wait_reason": "worker_results",
+            "wait_dependency": "local_type_carrier_build",
+        },
+        budget_family="typing",
+    )
+    final = registry.observe(
+        stage="local_typing_diagnostics:local_type_carrier_build",
+        phase="typing_leaf_completed",
+        counts={"leaves_completed": 2, "leaves_total": 3},
+        details={"batch_size": 128},
+        budget_family="typing",
+    )
+
+    assert first["progress"] == 1
+    assert waiting["violation"] is None
+    assert final["progress"] == 2


### PR DESCRIPTION
## Purpose

Turn execution observability from advisory labels into enforceable contracts while keeping semantic functions pure.

The live exact-0008 run exposed two structural failures after the closure frontier drained:

1. repeated owner admission/handoff work could continue without a named bounded lifecycle transition;
2. exact acceptance silently exercised local replay while the intended PostgreSQL authority tables remained empty.

## Architecture

A semantic function computes a result and imports no execution machinery.

An execution kernel declares:

- stable kernel key and lifecycle;
- budget family;
- required authority backend;
- monotonic progress keys/unit;
- maximum batch size;
- checkpoint contract;
- legal successor kernels;
- no-progress timeout;
- whether post-drain admission is forbidden.

The execution context resolves and enforces that contract for every physical semantic sample.

## Implemented

- Added `src/runtime/execution_kernel_contract.py` with the default kernel registry and executable safety/liveness checks.
- Added contracts for typing leaves, activation, closure handoff/execution/final dirty reduction, finalisation, serialization, publication, and parity.
- Added durable `kernel-contracts/latest.json` and append-only `events.jsonl` diagnostics.
- Installed contract enforcement immediately after stage-budget enforcement, so budget family is authoritative rather than inferred twice.
- Wrapped the closure handoff adapter—not the semantic owner—to expose:
  - drained-frontier state;
  - newly created durable obligations;
  - actual authority backend;
  - committed PostgreSQL admission-row count.
- Reject post-drain owner admission unless it creates a positive, explicitly counted durable obligation.
- Reject unnamed waits.
- Reject illegal completed-kernel lifecycle transitions.
- Reject batches above the declared bound.
- PostgreSQL authority is a hard requirement when `SENSIBLAW_REQUIRE_POSTGRESQL_EXECUTION=1`.
- Compatibility runs persist a visible `deferred_compatibility` authority violation rather than silently claiming PostgreSQL execution.

## Acceptance invariants

```text
frontier drained ∧ no new durable obligations
    ⇒ no further owner admission

contract.authority = postgresql
    ∧ SENSIBLAW_REQUIRE_POSTGRESQL_EXECUTION=1
    ⇒ committed authority rows must exist

nonterminal heartbeat
    ⇒ monotonic progress
       ∨ named wait(reason, dependency, elapsed)
       ∨ finite failure
```

## Tests

Focused tests cover:

- missing PostgreSQL authority evidence;
- post-drain admission without a durable obligation;
- valid post-drain work with a positive obligation delta;
- unnamed wait rejection;
- monotonic progress and named waits.

The PR remains draft until Ruff/format/focused regressions and one strict-profile probe pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added execution safeguards that validate progress, lifecycle transitions, workload limits, authority, and completion across processing stages.
  * Added durable execution diagnostics and event records through checkpoint storage.
  * Added clearer reporting for waits, dependencies, and progress during long-running operations.

* **Bug Fixes**
  * Improved detection of invalid post-drain admissions, missing authority evidence, and non-monotonic progress.
  * Preserved operation when PostgreSQL authority evidence is unavailable unless explicitly required.

* **Tests**
  * Added coverage for authority handoffs, durable obligations, waits, and progress validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->