### PR TITLE
Wire Zelph CLI snapshot backend

### DIFF
--- a/database/postgres_migrations/117_external_context_polarity_smallint_fix.sql
+++ b/database/postgres_migrations/117_external_context_polarity_smallint_fix.sql
@@ -1,0 +1,83 @@
+BEGIN;
+
+-- 117: keep the required-polarity coordinate typed as SMALLINT at the
+-- completion/cache-wakeup call sites.  The underlying function has always
+-- accepted SMALLINT; uncast integer literals fail only when a real provider
+-- result reaches completion.
+
+CREATE OR REPLACE FUNCTION execution.complete_numeric_pnf_external_request(
+    selected_request_id BIGINT,
+    leased_minimum_source_epoch BIGINT
+) RETURNS BOOLEAN LANGUAGE plpgsql AS $$
+DECLARE current_floor BIGINT;
+BEGIN
+    SELECT minimum_source_epoch INTO STRICT current_floor
+      FROM execution.semantic_pnf_external_request
+     WHERE request_id=selected_request_id
+     FOR UPDATE;
+
+    IF NOT EXISTS (
+        SELECT 1
+          FROM execution.semantic_pnf_external_request_active_member_v1 AS member
+         WHERE member.request_id=selected_request_id
+    ) THEN
+        UPDATE execution.semantic_pnf_external_request
+           SET request_state=8,lease_owner=NULL,lease_expires_at=NULL,
+               last_error_ref='no-active-semantic-observer',
+               updated_at=CURRENT_TIMESTAMP
+         WHERE request_id=selected_request_id;
+        RETURN FALSE;
+    END IF;
+
+    IF current_floor IS DISTINCT FROM leased_minimum_source_epoch THEN
+        UPDATE execution.semantic_pnf_external_request
+           SET request_state=1,lease_owner=NULL,lease_expires_at=NULL,
+               last_error_ref='freshness-contract-changed-during-lease',
+               updated_at=CURRENT_TIMESTAMP
+         WHERE request_id=selected_request_id;
+        RETURN FALSE;
+    END IF;
+
+    PERFORM execution.materialize_numeric_pnf_external_context_for_request(
+        selected_request_id,1::smallint
+    );
+
+    UPDATE execution.semantic_pnf_external_request
+       SET request_state=5,lease_owner=NULL,lease_expires_at=NULL,
+           last_error_ref=NULL,updated_at=CURRENT_TIMESTAMP
+     WHERE request_id=selected_request_id;
+    PERFORM execution.wake_numeric_pnf_external_request_members(selected_request_id);
+    RETURN TRUE;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION execution.wake_numeric_pnf_external_cache_hits()
+RETURNS BIGINT LANGUAGE plpgsql AS $$
+DECLARE request_row RECORD; affected BIGINT := 0; n BIGINT := 0;
+BEGIN
+    PERFORM execution.refresh_numeric_pnf_external_request_observer_state();
+    PERFORM execution.refresh_numeric_pnf_external_request_cache_state();
+
+    FOR request_row IN
+        SELECT request.request_id
+          FROM execution.semantic_pnf_external_request AS request
+         WHERE request.request_state=2
+           AND EXISTS (
+               SELECT 1
+                 FROM execution.semantic_pnf_external_request_active_member_v1 AS member
+                WHERE member.request_id=request.request_id
+           )
+         ORDER BY request.request_id
+    LOOP
+        PERFORM execution.materialize_numeric_pnf_external_context_for_request(
+            request_row.request_id,1::smallint
+        );
+        SELECT execution.wake_numeric_pnf_external_request_members(request_row.request_id)
+          INTO n;
+        affected:=affected+n;
+    END LOOP;
+    RETURN affected;
+END;
+$$;
+
+COMMIT;

--- a/database/postgres_migrations/118_external_context_request_alias_fix.sql
+++ b/database/postgres_migrations/118_external_context_request_alias_fix.sql
@@ -1,0 +1,109 @@
+BEGIN;
+
+-- 118: avoid the PL/pgSQL variable/table-alias collision in the external
+-- context projection. Discovery completions call this function before the
+-- request-kind fast return, so the ambiguity is observable on every provider
+-- result even when no property projection is needed.
+
+CREATE OR REPLACE FUNCTION execution.materialize_numeric_pnf_external_context_for_request(
+    selected_request_id BIGINT,
+    selected_required_polarity SMALLINT DEFAULT 1
+) RETURNS BIGINT LANGUAGE plpgsql AS $$
+DECLARE
+    selected_request RECORD;
+    selected_epoch BIGINT;
+    affected BIGINT := 0;
+    n BIGINT := 0;
+BEGIN
+    IF selected_required_polarity NOT IN (-1,1) THEN
+        RAISE EXCEPTION 'required polarity must be -1 or +1';
+    END IF;
+
+    SELECT request_row.* INTO STRICT selected_request
+      FROM execution.semantic_pnf_external_request AS request_row
+     WHERE request_row.request_id=selected_request_id;
+    IF selected_request.request_kind<>2 OR selected_request.axis_kind IS NULL THEN
+        RETURN 0;
+    END IF;
+
+    SELECT max(evidence.source_epoch)
+      INTO selected_epoch
+      FROM execution.semantic_pnf_external_evidence AS evidence
+     WHERE evidence.provider_id=selected_request.provider_id
+       AND evidence.subject_world_entity_id=selected_request.world_entity_id
+       AND evidence.provider_property_numeric_id=selected_request.provider_property_numeric_id
+       AND evidence.value_kind=2
+       AND evidence.value_symbol_id IS NOT NULL
+       AND (
+           selected_request.minimum_source_epoch IS NULL
+           OR evidence.source_epoch>=selected_request.minimum_source_epoch
+       );
+
+    DELETE FROM execution.semantic_pnf_world_candidate_requirement AS requirement
+     WHERE requirement.world_entity_id=selected_request.world_entity_id
+       AND requirement.axis_kind=selected_request.axis_kind
+       AND requirement.provider_property_numeric_id=selected_request.provider_property_numeric_id
+       AND requirement.external_evidence_id IS NOT NULL
+       AND NOT EXISTS (
+           SELECT 1
+             FROM execution.semantic_pnf_external_evidence AS evidence
+            WHERE evidence.external_evidence_id=requirement.external_evidence_id
+              AND evidence.provider_id=selected_request.provider_id
+              AND evidence.subject_world_entity_id=selected_request.world_entity_id
+              AND evidence.provider_property_numeric_id=selected_request.provider_property_numeric_id
+              AND evidence.value_kind=2
+              AND evidence.value_symbol_id IS NOT NULL
+              AND (
+                  (selected_epoch IS NOT NULL AND evidence.source_epoch=selected_epoch)
+                  OR
+                  (selected_epoch IS NULL
+                   AND selected_request.minimum_source_epoch IS NULL
+                   AND evidence.source_epoch IS NULL)
+              )
+       );
+    GET DIAGNOSTICS n=ROW_COUNT; affected:=affected+n;
+
+    INSERT INTO execution.semantic_pnf_world_candidate_requirement
+        (world_entity_id,axis_kind,required_symbol_id,required_polarity,
+         requirement_revision,evidence_ref,external_evidence_id,
+         provider_property_numeric_id,source_epoch)
+    SELECT selected_request.world_entity_id,
+           selected_request.axis_kind,
+           evidence.value_symbol_id,
+           selected_required_polarity,
+           COALESCE(evidence.provider_revision,1),
+           'external-evidence:' || evidence.external_evidence_id::TEXT
+               || ':request:' || selected_request_id::TEXT,
+           evidence.external_evidence_id,
+           evidence.provider_property_numeric_id,
+           evidence.source_epoch
+      FROM execution.semantic_pnf_external_evidence AS evidence
+     WHERE evidence.provider_id=selected_request.provider_id
+       AND evidence.subject_world_entity_id=selected_request.world_entity_id
+       AND evidence.provider_property_numeric_id=selected_request.provider_property_numeric_id
+       AND evidence.value_kind=2
+       AND evidence.value_symbol_id IS NOT NULL
+       AND (
+           (selected_epoch IS NOT NULL AND evidence.source_epoch=selected_epoch)
+           OR
+           (selected_epoch IS NULL
+            AND selected_request.minimum_source_epoch IS NULL
+            AND evidence.source_epoch IS NULL)
+       )
+    ON CONFLICT(world_entity_id,axis_kind,required_symbol_id,required_polarity)
+    DO UPDATE SET
+        requirement_revision=GREATEST(
+            execution.semantic_pnf_world_candidate_requirement.requirement_revision,
+            EXCLUDED.requirement_revision
+        ),
+        evidence_ref=EXCLUDED.evidence_ref,
+        external_evidence_id=EXCLUDED.external_evidence_id,
+        provider_property_numeric_id=EXCLUDED.provider_property_numeric_id,
+        source_epoch=EXCLUDED.source_epoch;
+    GET DIAGNOSTICS n=ROW_COUNT; affected:=affected+n;
+
+    RETURN affected;
+END;
+$$;
+
+COMMIT;

--- a/database/postgres_migrations/README.md
+++ b/database/postgres_migrations/README.md
@@ -112,6 +112,11 @@
   revision semantically immutable: changing selectors, provider coordinates,
   priority or freshness requires a new revision; same-revision re-registration
   may only toggle whether that revision is currently active.
+- `117_external_context_polarity_smallint_fix.sql` preserves the SMALLINT type
+  at external completion/cache-wakeup call sites so real provider results can
+  complete without an integer-literal function-resolution failure.
+- `118_external_context_request_alias_fix.sql` removes the PL/pgSQL request
+  variable/table-alias collision reached during external request completion.
 - See `docs/reopenable_runtime_architecture.md`,
   `docs/consumer_sufficient_numeric_runtime.md`,
   `docs/late_external_provider_runtime.md`, and

--- a/docs/late_external_provider_runtime.md
+++ b/docs/late_external_provider_runtime.md
@@ -232,6 +232,23 @@ The preferred first target is the pruned Zelph snapshot, but that is an empirica
 optimization, not a semantic preference. Compare it against the full snapshot and
 live transport on actual H9 residuals rather than raw graph-wide queries.
 
+### Zelph shard planning boundary
+
+The primary deployment target is a revision-pinned HF Zelph manifest, with a
+local `.bin` artifact retained as an offline/reproducibility source. The current
+public March 2026 pruned v2 manifest has no `nodeRouteIndex`; its legacy chunks
+are therefore too coarse for one-process-per-label discovery. The CLI backend
+loads only the name index for v2 discovery and batches all labels through one
+Zelph process. It does not silently load adjacency sections for label lookup.
+
+The ITIR shard studies measured approximately 21.70 MiB median and 41.57 MiB
+p95 for v2 route-name loads, and approximately 51.95 MiB median and 60.63 MiB
+p95 for two-sided route-node loads. Those values are a transport-cost
+observation, not a semantic result. The planned v3 query-shaped bucket layout
+and route sidecar remain the optimization path for a newer full HF rip. Until a
+route-aware manifest is selected, the runtime records the coarse-v2 fallback
+explicitly rather than presenting it as an optimal shard plan.
+
 ## External evidence
 
 Provider facts are immutable cache rows. An evidence digest is idempotent and a

--- a/src/policy/wikidata_tiered_transport.py
+++ b/src/policy/wikidata_tiered_transport.py
@@ -16,8 +16,11 @@ queried and then rejected downstream.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
+import subprocess
 from typing import Mapping, Protocol, Sequence
 
+from src.policy.external_demand import ExternalValueKind
 from src.policy.wikidata_late_provider import (
     WikidataPropertyBatch,
     WikidataPropertyFact,
@@ -61,6 +64,193 @@ class ZelphSnapshotQueryBackend(Protocol):
     def fetch_wikidata_properties(
         self, keys: Sequence[tuple[int, int]]
     ) -> ZelphSnapshotPropertyResult: ...
+
+
+class ZelphCliSnapshotQueryBackend:
+    """Query a local or HF-routed Zelph artifact through its CLI.
+
+    A manifest source uses Zelph's routed ``.load-partial`` path and therefore
+    fetches only the route-selected HF shards.  A local ``.bin`` source uses a
+    normal full load; callers should reserve that mode for a machine with
+    enough memory.  This adapter deliberately exposes acquisition subprocess
+    count as its literal I/O metric; the Zelph process also emits transfer
+    diagnostics when ``ZELPH_HF_TRANSFER_LOG`` is configured.
+    """
+
+    _QID_RE = re.compile(r"https://www\.wikidata\.org/wiki/(Q([1-9][0-9]*))")
+    _QID_VALUE_RE = re.compile(r"^Q([1-9][0-9]*)(?:\s+\(.*\))?$")
+
+    def __init__(
+        self,
+        executable: str,
+        source: str,
+        *,
+        source_ref: str | None = None,
+        language: str = "en",
+        timeout_seconds: float = 300.0,
+    ) -> None:
+        if not executable.strip():
+            raise ValueError("Zelph executable must be non-empty")
+        if not source.strip():
+            raise ValueError("Zelph source must be non-empty")
+        if not language.strip():
+            raise ValueError("Zelph language must be non-empty")
+        if timeout_seconds <= 0:
+            raise ValueError("Zelph timeout must be positive")
+        self.executable = executable
+        self.source = source
+        self.source_ref = source_ref or f"zelph:{source}"
+        self.language = language
+        self.timeout_seconds = timeout_seconds
+
+    @property
+    def _is_manifest(self) -> bool:
+        return self.source.endswith(".json") or self.source.startswith("hf://")
+
+    @staticmethod
+    def _quote_command_text(value: str) -> str:
+        return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+    def _load_command(self, *, route_name: str | None = None) -> str:
+        source = self._quote_command_text(self.source)
+        if self._is_manifest and route_name is not None:
+            return (
+                f".load-partial {source} "
+                f"route-name={self._quote_command_text(route_name)} "
+                f"route-lang={self.language}"
+            )
+        if self._is_manifest:
+            return f".load-partial {source}"
+        return f".load {source}"
+
+    def _run(self, commands: Sequence[str], *, allow_missing_node: bool = False) -> str:
+        script = "\n".join((*commands, ".quit", ""))
+        try:
+            completed = subprocess.run(
+                [self.executable],
+                input=script,
+                text=True,
+                capture_output=True,
+                timeout=self.timeout_seconds,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"Zelph executable unavailable: {self.executable}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise TimeoutError(f"Zelph query timed out after {self.timeout_seconds}s") from exc
+        output = "\n".join(part for part in (completed.stdout, completed.stderr) if part)
+        missing_node_only = allow_missing_node and "No node found with name" in output
+        if completed.returncode != 0 or ("Error in line" in output and not missing_node_only):
+            raise RuntimeError(f"Zelph query failed ({completed.returncode}): {output[-4000:]}")
+        return output
+
+    @classmethod
+    def _candidate_from_node_output(
+        cls, output: str, *, source_ref: str
+    ) -> WikidataSearchCandidate | None:
+        match = cls._QID_RE.search(output)
+        if match is None:
+            return None
+        return WikidataSearchCandidate(
+            qid=int(match.group(2)), rank=0, source_ref=source_ref
+        )
+
+    def search_wikidata_entities(
+        self, labels: Sequence[str], *, limit_per_label: int
+    ) -> ZelphSnapshotSearchResult:
+        if limit_per_label < 1:
+            raise ValueError("limit_per_label must be positive")
+        candidates: dict[str, tuple[int, ...]] = {}
+        acquisitions = 0
+        for label in dict.fromkeys(label for label in labels if label.strip()):
+            output = self._run(
+                (
+                    f".lang {self.language}",
+                    self._load_command(route_name=label if self._is_manifest else None),
+                    f".node {self._quote_command_text(label)}",
+                ),
+                allow_missing_node=True,
+            )
+            acquisitions += 1
+            candidate = self._candidate_from_node_output(output, source_ref=self.source_ref)
+            candidates[label] = (candidate.qid,) if candidate is not None else ()
+        return ZelphSnapshotSearchResult(candidates, acquisitions)
+
+    @staticmethod
+    def _property_query(subject_qid: int, property_pid: int) -> str:
+        return (
+            "sparql\n"
+            "SELECT ?value WHERE { "
+            f"wd:Q{subject_qid} wdt:P{property_pid} ?value . "
+            "}"
+        )
+
+    @staticmethod
+    def _result_values(output: str) -> tuple[str, ...]:
+        values: list[str] = []
+        in_results = False
+        for raw_line in output.splitlines():
+            line = raw_line.strip()
+            if line == "?value":
+                in_results = True
+                continue
+            if not in_results or line.startswith("--") or not line:
+                continue
+            values.append(line.split("\t", 1)[0].strip())
+        return tuple(dict.fromkeys(values))
+
+    @classmethod
+    def _fact_for_value(
+        cls,
+        subject_qid: int,
+        property_pid: int,
+        value: str,
+        *,
+        source_ref: str,
+    ) -> WikidataPropertyFact | None:
+        qid_match = cls._QID_VALUE_RE.fullmatch(value)
+        if qid_match is not None:
+            return WikidataPropertyFact(
+                subject_qid=subject_qid,
+                property_pid=property_pid,
+                value_kind=ExternalValueKind.WORLD_ENTITY,
+                value_qid=int(qid_match.group(1)),
+                source_ref=source_ref,
+            )
+        if value.isdigit():
+            return WikidataPropertyFact(
+                subject_qid=subject_qid,
+                property_pid=property_pid,
+                value_kind=ExternalValueKind.NUMERIC,
+                value_numeric=int(value),
+                source_ref=source_ref,
+            )
+        return None
+
+    def fetch_wikidata_properties(
+        self, keys: Sequence[tuple[int, int]]
+    ) -> ZelphSnapshotPropertyResult:
+        unique_keys = tuple(sorted(set((int(q), int(p)) for q, p in keys)))
+        if not unique_keys:
+            return ZelphSnapshotPropertyResult({}, 0)
+        commands = [self._load_command(), ".import sparql"]
+        facts: dict[tuple[int, int], tuple[WikidataPropertyFact, ...]] = {}
+        for subject_qid, property_pid in unique_keys:
+            commands.extend((self._property_query(subject_qid, property_pid), ""))
+        output = self._run(commands)
+        # Each repeated query has its own ?value header; preserve query order
+        # while parsing the corresponding result section.
+        sections = output.split("?value\n")[1:]
+        for key, section in zip(unique_keys, sections, strict=False):
+            section = section.split("--", 1)[0]
+            rows = tuple(
+                fact
+                for value in self._result_values("?value\n" + section)
+                if (fact := self._fact_for_value(*key, value, source_ref=self.source_ref))
+                is not None
+            )
+            facts[key] = rows
+        return ZelphSnapshotPropertyResult(facts, 1)
 
 
 @dataclass(frozen=True, slots=True)
@@ -295,6 +485,7 @@ __all__ = [
     "TieredWikidataTransport",
     "WikidataTierPolicy",
     "ZelphHFWikidataTransport",
+    "ZelphCliSnapshotQueryBackend",
     "ZelphSnapshotPropertyResult",
     "ZelphSnapshotQueryBackend",
     "ZelphSnapshotSearchResult",

--- a/src/policy/wikidata_tiered_transport.py
+++ b/src/policy/wikidata_tiered_transport.py
@@ -111,7 +111,9 @@ class ZelphCliSnapshotQueryBackend:
     def _quote_command_text(value: str) -> str:
         return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
 
-    def _load_command(self, *, route_name: str | None = None) -> str:
+    def _load_command(
+        self, *, route_name: str | None = None, name_only: bool = False
+    ) -> str:
         source = self._quote_command_text(self.source)
         if self._is_manifest and route_name is not None:
             return (
@@ -120,7 +122,12 @@ class ZelphCliSnapshotQueryBackend:
                 f"route-lang={self.language}"
             )
         if self._is_manifest:
-            return f".load-partial {source}"
+            if name_only:
+                return (
+                    f".load-partial {source} left=none right=none "
+                    "nameOfNode=none"
+                )
+            return f".load-partial {source} nameOfNode=none nodeOfName=none"
         return f".load {source}"
 
     def _run(self, commands: Sequence[str], *, allow_missing_node: bool = False) -> str:
@@ -161,19 +168,29 @@ class ZelphCliSnapshotQueryBackend:
         if limit_per_label < 1:
             raise ValueError("limit_per_label must be positive")
         candidates: dict[str, tuple[int, ...]] = {}
-        acquisitions = 0
-        for label in dict.fromkeys(label for label in labels if label.strip()):
-            output = self._run(
+        unique_labels = tuple(dict.fromkeys(label for label in labels if label.strip()))
+        if not unique_labels:
+            return ZelphSnapshotSearchResult({}, 0)
+        commands = [
+            f".lang {self.language}",
+            self._load_command(name_only=self._is_manifest),
+        ]
+        for index, label in enumerate(unique_labels):
+            commands.extend(
                 (
-                    f".lang {self.language}",
-                    self._load_command(route_name=label if self._is_manifest else None),
+                    f'%(print "__SL_LOOKUP_{index}__")',
                     f".node {self._quote_command_text(label)}",
-                ),
-                allow_missing_node=True,
+                )
             )
-            acquisitions += 1
-            candidate = self._candidate_from_node_output(output, source_ref=self.source_ref)
+        output = self._run(commands, allow_missing_node=True)
+        sections = output.split("__SL_LOOKUP_")[1:]
+        for index, label in enumerate(unique_labels):
+            section = next(
+                (part for part in sections if part.startswith(f"{index}__")), ""
+            )
+            candidate = self._candidate_from_node_output(section, source_ref=self.source_ref)
             candidates[label] = (candidate.qid,) if candidate is not None else ()
+        acquisitions = 1
         return ZelphSnapshotSearchResult(candidates, acquisitions)
 
     @staticmethod

--- a/tests/test_wikidata_tiered_transport.py
+++ b/tests/test_wikidata_tiered_transport.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import subprocess
 
 from src.policy.external_demand import ExternalValueKind
 from src.policy.wikidata_late_provider import (
@@ -13,6 +14,7 @@ from src.policy.wikidata_tiered_transport import (
     TieredWikidataTransport,
     WikidataTierPolicy,
     ZelphHFWikidataTransport,
+    ZelphCliSnapshotQueryBackend,
     ZelphSnapshotPropertyResult,
     ZelphSnapshotSearchResult,
 )
@@ -262,3 +264,31 @@ def test_negative_acquisition_count_is_rejected() -> None:
         assert "non-negative" in str(exc)
     else:
         raise AssertionError("negative acquisition count must be rejected")
+
+
+def test_zelph_cli_backend_parses_discovery_and_property_rows(monkeypatch) -> None:
+    outputs = iter(
+        (
+            "Node ID: 11\n"
+            "Wikidata URL: https://www.wikidata.org/wiki/Q408\n",
+            "?value\nQ408 (Australia)\n-- 1 result(s) --\n",
+        )
+    )
+    calls: list[str] = []
+
+    def fake_run(command, *, input, **kwargs):
+        calls.append(input)
+        return subprocess.CompletedProcess(command, 0, next(outputs), "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    backend = ZelphCliSnapshotQueryBackend("zelph", "hf://example/manifest.json")
+
+    candidates = backend.search_wikidata_entities(("Australia",), limit_per_label=8)
+    facts = backend.fetch_wikidata_properties(((1, 17),))
+
+    assert candidates.candidates_by_label == {"Australia": (408,)}
+    assert candidates.acquisition_call_count == 1
+    assert facts.facts_by_key[(1, 17)][0].value_qid == 408
+    assert facts.acquisition_call_count == 1
+    assert 'route-name="Australia"' in calls[0]
+    assert "SELECT ?value" in calls[1]

--- a/tests/test_wikidata_tiered_transport.py
+++ b/tests/test_wikidata_tiered_transport.py
@@ -269,7 +269,7 @@ def test_negative_acquisition_count_is_rejected() -> None:
 def test_zelph_cli_backend_parses_discovery_and_property_rows(monkeypatch) -> None:
     outputs = iter(
         (
-            "Node ID: 11\n"
+            "__SL_LOOKUP_0__\nNode ID: 11\n"
             "Wikidata URL: https://www.wikidata.org/wiki/Q408\n",
             "?value\nQ408 (Australia)\n-- 1 result(s) --\n",
         )
@@ -290,5 +290,5 @@ def test_zelph_cli_backend_parses_discovery_and_property_rows(monkeypatch) -> No
     assert candidates.acquisition_call_count == 1
     assert facts.facts_by_key[(1, 17)][0].value_qid == 408
     assert facts.acquisition_call_count == 1
-    assert 'route-name="Australia"' in calls[0]
+    assert "left=none right=none nameOfNode=none" in calls[0]
     assert "SELECT ?value" in calls[1]


### PR DESCRIPTION
## Summary
- add a reusable Zelph CLI snapshot backend for HF routed manifests and local .bin artifacts
- parse exact Wikidata discovery URLs and typed property results through the existing provider-neutral transport boundary
- retain explicit acquisition counts and no live fallback by default

## Validation
- `pytest -q tests/test_wikidata_tiered_transport.py` (10 passed)
- `ruff check src/policy/wikidata_tiered_transport.py tests/test_wikidata_tiered_transport.py`
- local Zelph 0.9.9-dev build validated against a generated .bin fixture

The ITIR superproject gitlink update is in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for querying local or hosted Wikidata snapshot artifacts through the Zelph command-line interface.
  * Added entity search and property lookup capabilities with deduplicated results and configurable limits.
  * Added support for route-specific artifact loading and reporting acquisition counts.
  * Added handling for unavailable tools, timeouts, invalid configuration, and failed queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->