### PR TITLE
Split demand trigger and target occurrence provenance

### DIFF
--- a/.github/workflows/durable-work-item-resume.yml
+++ b/.github/workflows/durable-work-item-resume.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 20
     env:
-      SENSIBLAW_LOCAL_POSTGRES_URL: postgresql://postgres@127.0.0.1:5433/postgres
+      SENSIBLAW_LOCAL_POSTGRES_URL: ${{ secrets.SENSIBLAW_CI_ADMIN_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/no-json-typed-execution-pr-v2.yml
+++ b/.github/workflows/no-json-typed-execution-pr-v2.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     env:
-      SENSIBLAW_LOCAL_POSTGRES_URL: postgresql://postgres@127.0.0.1:5433/postgres
+      SENSIBLAW_LOCAL_POSTGRES_URL: ${{ secrets.SENSIBLAW_CI_ADMIN_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -213,4 +213,4 @@ jobs:
       - name: Drop isolated database
         if: always() && steps.database.outputs.database_name != ''
         run: |
-          dropdb --if-exists --host=127.0.0.1 --port=5433 --username=postgres '${{ steps.database.outputs.database_name }}'
+          dropdb --if-exists --dbname="$SENSIBLAW_LOCAL_POSTGRES_URL" '${{ steps.database.outputs.database_name }}'

--- a/.github/workflows/no-json-typed-execution-pr-v3.yml
+++ b/.github/workflows/no-json-typed-execution-pr-v3.yml
@@ -161,7 +161,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 40
     env:
-      SENSIBLAW_LOCAL_POSTGRES_URL: postgresql://postgres@127.0.0.1:5433/postgres
+      SENSIBLAW_LOCAL_POSTGRES_URL: ${{ secrets.SENSIBLAW_CI_ADMIN_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -255,4 +255,4 @@ jobs:
       - name: Drop isolated database
         if: always() && steps.database.outputs.database_name != ''
         run: |
-          dropdb --if-exists --host=127.0.0.1 --port=5433 --username=postgres '${{ steps.database.outputs.database_name }}'
+          dropdb --if-exists --dbname="$SENSIBLAW_LOCAL_POSTGRES_URL" '${{ steps.database.outputs.database_name }}'

--- a/.github/workflows/no-json-typed-execution-pr.yml
+++ b/.github/workflows/no-json-typed-execution-pr.yml
@@ -162,7 +162,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     env:
-      SENSIBLAW_LOCAL_POSTGRES_URL: postgresql://postgres@127.0.0.1:5433/postgres
+      SENSIBLAW_LOCAL_POSTGRES_URL: ${{ secrets.SENSIBLAW_CI_ADMIN_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -239,4 +239,4 @@ jobs:
       - name: Drop isolated database
         if: always() && steps.database.outputs.database_name != ''
         run: |
-          dropdb --if-exists --host=127.0.0.1 --port=5433 --username=postgres '${{ steps.database.outputs.database_name }}'
+          dropdb --if-exists --dbname="$SENSIBLAW_LOCAL_POSTGRES_URL" '${{ steps.database.outputs.database_name }}'

--- a/.github/workflows/no-json-typed-execution-validation.yml
+++ b/.github/workflows/no-json-typed-execution-validation.yml
@@ -137,7 +137,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     env:
-      SENSIBLAW_LOCAL_POSTGRES_URL: postgresql://postgres@127.0.0.1:5433/postgres
+      SENSIBLAW_LOCAL_POSTGRES_URL: ${{ secrets.SENSIBLAW_CI_ADMIN_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/self-hosted-distributed-postgres-smoke.yml
+++ b/.github/workflows/self-hosted-distributed-postgres-smoke.yml
@@ -91,33 +91,21 @@ jobs:
               relation_name text;
           BEGIN
               FOREACH relation_name IN ARRAY ARRAY[
+                  'semantic_run',
                   'semantic_owner_stream',
-                  'semantic_job',
-                  'semantic_job_dependency',
+                  'semantic_closure_job',
                   'semantic_job_attempt',
-                  'semantic_delta',
+                  'semantic_immutable_delta',
                   'semantic_delta_admission',
-                  'semantic_graph_manifest',
-                  'semantic_graph_family_segment',
-                  'semantic_factor_revision',
-                  'semantic_residual_revision',
                   'semantic_finalization_checkpoint',
-                  'semantic_fixed_point_receipt',
                   'semantic_execution_receipt',
-                  'semantic_outbox',
-                  'publication_build'
+                  'semantic_publication',
+                  'semantic_outbox'
               ] LOOP
                   IF to_regclass('execution.' || relation_name) IS NULL THEN
                       RAISE EXCEPTION 'missing execution relation %', relation_name;
                   END IF;
               END LOOP;
-              IF NOT EXISTS (
-                  SELECT 1 FROM pg_trigger
-                  WHERE tgname = 'semantic_delta_admission_outbox'
-                    AND NOT tgisinternal
-              ) THEN
-                  RAISE EXCEPTION 'missing delta-admission outbox trigger';
-              END IF;
               IF NOT EXISTS (
                   SELECT 1 FROM pg_trigger
                   WHERE tgname = 'semantic_publication_outbox'

--- a/.github/workflows/self-hosted-distributed-postgres-smoke.yml
+++ b/.github/workflows/self-hosted-distributed-postgres-smoke.yml
@@ -21,14 +21,37 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     env:
-      PGHOST: 127.0.0.1
-      PGPORT: 5433
-      PGUSER: postgres
+      SENSIBLAW_CI_ADMIN_DATABASE_URL: ${{ secrets.SENSIBLAW_CI_ADMIN_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || 'agent/repair-corpus-progress-stage-lifecycle' }}
           persist-credentials: false
+
+      - name: Configure TrueNAS PostgreSQL client
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY' >> "$GITHUB_ENV"
+          import os
+          import shlex
+          from urllib.parse import unquote, urlsplit
+
+          parsed = urlsplit(os.environ["SENSIBLAW_CI_ADMIN_DATABASE_URL"])
+          if parsed.scheme not in {"postgresql", "postgres"}:
+              raise SystemExit("SENSIBLAW_CI_ADMIN_DATABASE_URL must be a PostgreSQL URL")
+          values = {
+              "PGHOST": parsed.hostname or "",
+              "PGPORT": str(parsed.port or 5432),
+              "PGUSER": unquote(parsed.username or ""),
+              "PGPASSWORD": unquote(parsed.password or ""),
+              "PGDATABASE": (parsed.path or "/postgres").lstrip("/") or "postgres",
+          }
+          if not values["PGHOST"] or not values["PGUSER"] or not values["PGPASSWORD"]:
+              raise SystemExit("TrueNAS PostgreSQL URL must include host, user, and password")
+          for key, value in values.items():
+              print(f"{key}={shlex.quote(value)}")
+          PY
 
       - name: Require local PostgreSQL
         run: |

--- a/.github/workflows/self-hosted-distributed-postgres-smoke.yml
+++ b/.github/workflows/self-hosted-distributed-postgres-smoke.yml
@@ -108,10 +108,10 @@ jobs:
               END LOOP;
               IF NOT EXISTS (
                   SELECT 1 FROM pg_trigger
-                  WHERE tgname = 'semantic_publication_outbox'
+                  WHERE tgname = 'semantic_typed_publication_outbox'
                     AND NOT tgisinternal
               ) THEN
-                  RAISE EXCEPTION 'missing publication outbox trigger';
+                  RAISE EXCEPTION 'missing typed publication outbox trigger';
               END IF;
           END
           $$;

--- a/.github/workflows/streaming-spacy-typed-parser-pr.yml
+++ b/.github/workflows/streaming-spacy-typed-parser-pr.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 50
     env:
-      SENSIBLAW_LOCAL_POSTGRES_URL: postgresql://postgres@127.0.0.1:5433/postgres
+      SENSIBLAW_LOCAL_POSTGRES_URL: ${{ secrets.SENSIBLAW_CI_ADMIN_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/streaming-spacy-typed-parser-validation.yml
+++ b/.github/workflows/streaming-spacy-typed-parser-validation.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 40
     env:
-      SENSIBLAW_LOCAL_POSTGRES_URL: postgresql://postgres@127.0.0.1:5433/postgres
+      SENSIBLAW_LOCAL_POSTGRES_URL: ${{ secrets.SENSIBLAW_CI_ADMIN_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/validate-pr468-durable-resume.yml
+++ b/.github/workflows/validate-pr468-durable-resume.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 20
     env:
-      SENSIBLAW_LOCAL_POSTGRES_URL: postgresql://postgres@127.0.0.1:5433/postgres
+      SENSIBLAW_LOCAL_POSTGRES_URL: ${{ secrets.SENSIBLAW_CI_ADMIN_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/validate-pr470-final-numeric-pnf.yml
+++ b/.github/workflows/validate-pr470-final-numeric-pnf.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 75
     env:
-      SENSIBLAW_LOCAL_POSTGRES_URL: postgresql://postgres@127.0.0.1:5433/postgres
+      SENSIBLAW_LOCAL_POSTGRES_URL: ${{ secrets.SENSIBLAW_CI_ADMIN_DATABASE_URL }}
       RECEIPT: .validation/pr470-final-numeric-pnf.txt
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate-pr470-numeric-pnf-report.yml
+++ b/.github/workflows/validate-pr470-numeric-pnf-report.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 60
     env:
-      SENSIBLAW_LOCAL_POSTGRES_URL: postgresql://postgres@127.0.0.1:5433/postgres
+      SENSIBLAW_LOCAL_POSTGRES_URL: ${{ secrets.SENSIBLAW_CI_ADMIN_DATABASE_URL }}
       VALIDATION_RECEIPT: .validation/pr470-numeric-pnf.txt
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate-pr470-numeric-pnf.yml
+++ b/.github/workflows/validate-pr470-numeric-pnf.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 50
     env:
-      SENSIBLAW_LOCAL_POSTGRES_URL: postgresql://postgres@127.0.0.1:5433/postgres
+      SENSIBLAW_LOCAL_POSTGRES_URL: ${{ secrets.SENSIBLAW_CI_ADMIN_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/database/postgres_migrations/135_demand_trigger_target_occurrence.sql
+++ b/database/postgres_migrations/135_demand_trigger_target_occurrence.sql
@@ -3,10 +3,15 @@ BEGIN;
 -- 135: demand occurrence provenance has distinct semantic roles.
 --
 -- Historical demand rows were created before trigger and target occurrences
--- were distinguished. They are intentionally NOT backfilled from lexical
--- symbols, object heads, dependency neighbours, or region proximity. Missing
--- target provenance is an unresolved state and cannot authorize H9 provider
--- work.
+-- were distinguished. They are intentionally NOT backfilled by this migration
+-- from lexical symbols, object heads, dependency neighbours, or region
+-- proximity. Missing target provenance is an unresolved state and cannot
+-- authorize H9 provider work.
+--
+-- New/recompiled demands are different: the demand producer has the exact
+-- factor, its typed slots and parser-token support available in the same
+-- transaction. An AFTER INSERT/UPDATE producer hook records provenance only
+-- when those existing coordinates uniquely license it.
 CREATE TABLE IF NOT EXISTS execution.semantic_pnf_demand_occurrence_provenance (
     demand_id BIGINT NOT NULL
         REFERENCES execution.semantic_pnf_demand(demand_id) ON DELETE CASCADE,
@@ -32,6 +37,179 @@ CREATE INDEX IF NOT EXISTS semantic_pnf_demand_target_object_idx
     ON execution.semantic_pnf_demand_occurrence_provenance
        (object_id,demand_id)
     WHERE occurrence_role=2 AND object_id IS NOT NULL;
+
+-- Explicit producer semantics: only residuals whose meaning identifies a typed
+-- factor slot receive an entity/object target. This is deliberately finite and
+-- numeric at runtime. Absence of a rule means factor-level/unlocated residual,
+-- not permission to select a nearby noun.
+CREATE TABLE IF NOT EXISTS execution.semantic_pnf_demand_target_role_rule (
+    residual_type_symbol_id BIGINT PRIMARY KEY
+        REFERENCES execution.semantic_symbol(symbol_id) ON DELETE CASCADE,
+    target_role_symbol_id BIGINT NOT NULL
+        REFERENCES execution.semantic_symbol(symbol_id) ON DELETE RESTRICT,
+    rule_ref TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO execution.semantic_pnf_demand_target_role_rule
+    (residual_type_symbol_id,target_role_symbol_id,rule_ref)
+SELECT residual.symbol_id,role.symbol_id,definition.rule_ref
+  FROM (VALUES
+      ('legal_object_identity_unresolved'::TEXT,'legal_object'::TEXT,
+       'producer-target:legal-object-identity:v1'::TEXT),
+      ('condition_attachment_unresolved'::TEXT,'host'::TEXT,
+       'producer-target:condition-host:v1'::TEXT),
+      ('exception_attachment_unresolved'::TEXT,'host'::TEXT,
+       'producer-target:exception-host:v1'::TEXT),
+      ('norm_bearer_unresolved'::TEXT,'bearer'::TEXT,
+       'producer-target:norm-bearer:v1'::TEXT)
+  ) AS definition(residual_name,role_name,rule_ref)
+  JOIN execution.semantic_symbol AS residual
+    ON residual.kind_id=13 AND residual.symbol_text=definition.residual_name
+  JOIN execution.semantic_symbol AS role
+    ON role.kind_id=19 AND role.symbol_text=definition.role_name
+ON CONFLICT(residual_type_symbol_id) DO UPDATE SET
+    target_role_symbol_id=EXCLUDED.target_role_symbol_id,
+    rule_ref=EXCLUDED.rule_ref;
+
+CREATE OR REPLACE FUNCTION execution.record_numeric_pnf_demand_occurrence_provenance()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    selected_factor_id BIGINT;
+    selected_trigger_token_id BIGINT;
+    selected_trigger_object_id BIGINT;
+    selected_target_role_id BIGINT;
+    selected_target_token_id BIGINT;
+    selected_target_object_id BIGINT;
+    producer_match_count BIGINT := 0;
+    target_match_count BIGINT := 0;
+BEGIN
+    -- A lexical key remains a candidate-planning coordinate. It may identify
+    -- the producer trigger, but never the semantic target by itself.
+    IF NEW.expected_factor_type_symbol_id IS NULL
+       OR NEW.lexical_symbol_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    -- Recover the exact current producer factor and trigger token from the
+    -- factor's own support carrier. Fail closed unless exactly one pair matches.
+    SELECT count(*),min(match.factor_id),min(match.token_id)
+      INTO producer_match_count,selected_factor_id,selected_trigger_token_id
+      FROM (
+          SELECT DISTINCT factor.factor_id,support.token_id
+            FROM execution.semantic_pnf_factor AS factor
+            JOIN execution.semantic_pnf_factor_token_support AS support
+              ON support.factor_id=factor.factor_id
+            JOIN execution.semantic_parser_token AS token
+              ON token.token_id=support.token_id
+             AND token.representation_version=2
+           WHERE factor.region_id=NEW.source_region_id
+             AND factor.factor_type_symbol_id=NEW.expected_factor_type_symbol_id
+             AND token.lemma_symbol_id=NEW.lexical_symbol_id
+      ) AS match;
+
+    IF producer_match_count<>1
+       OR selected_factor_id IS NULL
+       OR selected_trigger_token_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    -- Object attachment on the trigger is audit context only. Multiple object
+    -- representations do not prevent recording the trigger token itself.
+    SELECT min(support.object_id)
+      INTO selected_trigger_object_id
+      FROM execution.semantic_pnf_object_token_support AS support
+      JOIN execution.semantic_pnf_object AS object
+        ON object.object_id=support.object_id
+     WHERE support.token_id=selected_trigger_token_id
+       AND object.region_id=NEW.source_region_id
+    HAVING count(DISTINCT support.object_id)=1;
+
+    INSERT INTO execution.semantic_pnf_demand_occurrence_provenance
+        (demand_id,occurrence_role,token_id,object_id,ordinal,producer_ref)
+    VALUES (
+        NEW.demand_id,1,selected_trigger_token_id,selected_trigger_object_id,0,
+        'numeric-factor:'||selected_factor_id::TEXT
+    )
+    ON CONFLICT(demand_id,occurrence_role,token_id,ordinal) DO NOTHING;
+
+    -- Preserve the other exact factor-support tokens as evidence. They are not
+    -- target candidates and can never authorize provider lookup.
+    INSERT INTO execution.semantic_pnf_demand_occurrence_provenance
+        (demand_id,occurrence_role,token_id,object_id,ordinal,producer_ref)
+    SELECT NEW.demand_id,3,support.token_id,unique_object.object_id,
+           row_number() OVER (ORDER BY support.ordinal,support.token_id)::SMALLINT-1,
+           'numeric-factor:'||selected_factor_id::TEXT
+      FROM execution.semantic_pnf_factor_token_support AS support
+      LEFT JOIN LATERAL (
+          SELECT min(object_support.object_id) AS object_id
+            FROM execution.semantic_pnf_object_token_support AS object_support
+            JOIN execution.semantic_pnf_object AS object
+              ON object.object_id=object_support.object_id
+           WHERE object_support.token_id=support.token_id
+             AND object.region_id=NEW.source_region_id
+          HAVING count(DISTINCT object_support.object_id)=1
+      ) AS unique_object ON TRUE
+     WHERE support.factor_id=selected_factor_id
+       AND support.token_id<>selected_trigger_token_id
+    ON CONFLICT(demand_id,occurrence_role,token_id,ordinal) DO NOTHING;
+
+    SELECT rule.target_role_symbol_id
+      INTO selected_target_role_id
+      FROM execution.semantic_pnf_demand_target_role_rule AS rule
+     WHERE rule.residual_type_symbol_id=NEW.residual_type_symbol_id;
+
+    -- No target-role rule means the producer knows only a factor-level
+    -- residual. Do not manufacture an entity occurrence.
+    IF selected_target_role_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    -- A semantic target exists only when the typed factor role selects exactly
+    -- one object and that object carries exactly one parser token occurrence.
+    SELECT count(*),min(match.token_id),min(match.object_id)
+      INTO target_match_count,selected_target_token_id,selected_target_object_id
+      FROM (
+          SELECT DISTINCT support.token_id,edge.object_id
+            FROM execution.semantic_pnf_hyperedge AS edge
+            JOIN execution.semantic_pnf_object_token_support AS support
+              ON support.object_id=edge.object_id
+           WHERE edge.factor_id=selected_factor_id
+             AND edge.role_symbol_id=selected_target_role_id
+      ) AS match;
+
+    IF target_match_count<>1
+       OR selected_target_token_id IS NULL
+       OR selected_target_object_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    INSERT INTO execution.semantic_pnf_demand_occurrence_provenance
+        (demand_id,occurrence_role,token_id,object_id,ordinal,producer_ref)
+    VALUES (
+        NEW.demand_id,2,selected_target_token_id,selected_target_object_id,0,
+        'numeric-factor:'||selected_factor_id::TEXT
+    )
+    ON CONFLICT(demand_id,occurrence_role,token_id,ordinal) DO NOTHING;
+
+    RETURN NEW;
+END;
+$$;
+
+-- Existing rows are not touched by migration installation. A genuine compiler
+-- replay hits INSERT or ON CONFLICT UPDATE and can then derive provenance from
+-- the newly/currently materialized factor graph.
+DROP TRIGGER IF EXISTS semantic_pnf_demand_occurrence_producer
+    ON execution.semantic_pnf_demand;
+CREATE TRIGGER semantic_pnf_demand_occurrence_producer
+AFTER INSERT OR UPDATE OF
+    state,source_region_id,expected_factor_type_symbol_id,
+    lexical_symbol_id,residual_type_symbol_id
+ON execution.semantic_pnf_demand
+FOR EACH ROW
+EXECUTE FUNCTION execution.record_numeric_pnf_demand_occurrence_provenance();
 
 CREATE OR REPLACE VIEW execution.semantic_pnf_demand_trigger_occurrence_v1 AS
 SELECT provenance.demand_id,provenance.token_id,provenance.object_id,
@@ -59,30 +237,34 @@ SELECT demand.demand_id,
            AS target_occurrence_count,
        count(*) FILTER (WHERE provenance.occurrence_role=3)::BIGINT
            AS evidence_occurrence_count,
+       (rule.target_role_symbol_id IS NOT NULL) AS has_explicit_target_rule,
        CASE
          WHEN count(*) FILTER (WHERE provenance.occurrence_role=2)=1 THEN 1
          WHEN count(*) FILTER (WHERE provenance.occurrence_role=2)>1 THEN 2
-         WHEN count(*) FILTER (WHERE provenance.occurrence_role=1)>0 THEN 11
+         WHEN count(*) FILTER (WHERE provenance.occurrence_role=1)>0
+              AND rule.target_role_symbol_id IS NULL THEN 11
+         WHEN count(*) FILTER (WHERE provenance.occurrence_role=1)>0 THEN 12
          ELSE 10
        END::SMALLINT AS provenance_state
   FROM execution.semantic_pnf_demand AS demand
   LEFT JOIN execution.semantic_pnf_demand_occurrence_provenance AS provenance
     ON provenance.demand_id=demand.demand_id
- GROUP BY demand.demand_id;
+  LEFT JOIN execution.semantic_pnf_demand_target_role_rule AS rule
+    ON rule.residual_type_symbol_id=demand.residual_type_symbol_id
+ GROUP BY demand.demand_id,rule.target_role_symbol_id;
 
 -- H9-specific structural support. The older generic strong-occurrence view is
 -- retained for non-H9 audit/compatibility. World-entity work is licensed only
--- by producer-authored target occurrences that also carry the exact PNF object
--- created for that target token.
+-- by producer-authored target occurrences with the exact PNF object selected by
+-- the producer's typed factor slot.
 CREATE OR REPLACE VIEW execution.semantic_pnf_demand_h9_target_support_v1 AS
 SELECT target.demand_id,target.token_id,target.object_id,
        target.ordinal,target.producer_ref
   FROM execution.semantic_pnf_demand_target_occurrence_v1 AS target
  WHERE target.object_id IS NOT NULL;
 
--- Rewire the primary raw and quality-gated parser-entity occurrence bridges to
--- the semantic target token. Trigger/evidence occurrences are deliberately not
--- eligible for world-entity admission.
+-- Rewire raw and quality-gated parser-entity occurrence bridges to semantic
+-- target tokens. Trigger/evidence occurrences are deliberately invisible here.
 CREATE OR REPLACE VIEW execution.semantic_pnf_demand_parser_entity_occurrence_v1 AS
 SELECT DISTINCT target.demand_id,target.object_id,
        entity.entity_id,entity.entity_type_symbol_id,label.label_symbol_id

--- a/database/postgres_migrations/135_demand_trigger_target_occurrence.sql
+++ b/database/postgres_migrations/135_demand_trigger_target_occurrence.sql
@@ -1,0 +1,153 @@
+BEGIN;
+
+-- 135: demand occurrence provenance has distinct semantic roles.
+--
+-- Historical demand rows were created before trigger and target occurrences
+-- were distinguished. They are intentionally NOT backfilled from lexical
+-- symbols, object heads, dependency neighbours, or region proximity. Missing
+-- target provenance is an unresolved state and cannot authorize H9 provider
+-- work.
+CREATE TABLE IF NOT EXISTS execution.semantic_pnf_demand_occurrence_provenance (
+    demand_id BIGINT NOT NULL
+        REFERENCES execution.semantic_pnf_demand(demand_id) ON DELETE CASCADE,
+    occurrence_role SMALLINT NOT NULL CHECK (occurrence_role IN (1,2,3)),
+    token_id BIGINT NOT NULL
+        REFERENCES execution.semantic_parser_token(token_id) ON DELETE CASCADE,
+    object_id BIGINT
+        REFERENCES execution.semantic_pnf_object(object_id) ON DELETE SET NULL,
+    ordinal SMALLINT NOT NULL DEFAULT 0 CHECK (ordinal >= 0),
+    producer_ref TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY(demand_id,occurrence_role,token_id,ordinal)
+);
+
+-- occurrence_role:
+--   1 trigger  token whose parser/factor relation caused the demand to exist
+--   2 target   token/object the unresolved semantic question is actually about
+--   3 evidence other producer-licensed support token
+CREATE INDEX IF NOT EXISTS semantic_pnf_demand_occurrence_role_idx
+    ON execution.semantic_pnf_demand_occurrence_provenance
+       (occurrence_role,token_id,demand_id);
+CREATE INDEX IF NOT EXISTS semantic_pnf_demand_target_object_idx
+    ON execution.semantic_pnf_demand_occurrence_provenance
+       (object_id,demand_id)
+    WHERE occurrence_role=2 AND object_id IS NOT NULL;
+
+CREATE OR REPLACE VIEW execution.semantic_pnf_demand_trigger_occurrence_v1 AS
+SELECT provenance.demand_id,provenance.token_id,provenance.object_id,
+       provenance.ordinal,provenance.producer_ref
+  FROM execution.semantic_pnf_demand_occurrence_provenance AS provenance
+ WHERE provenance.occurrence_role=1;
+
+CREATE OR REPLACE VIEW execution.semantic_pnf_demand_target_occurrence_v1 AS
+SELECT provenance.demand_id,provenance.token_id,provenance.object_id,
+       provenance.ordinal,provenance.producer_ref
+  FROM execution.semantic_pnf_demand_occurrence_provenance AS provenance
+ WHERE provenance.occurrence_role=2;
+
+CREATE OR REPLACE VIEW execution.semantic_pnf_demand_evidence_occurrence_v1 AS
+SELECT provenance.demand_id,provenance.token_id,provenance.object_id,
+       provenance.ordinal,provenance.producer_ref
+  FROM execution.semantic_pnf_demand_occurrence_provenance AS provenance
+ WHERE provenance.occurrence_role=3;
+
+CREATE OR REPLACE VIEW execution.semantic_pnf_demand_occurrence_provenance_audit_v1 AS
+SELECT demand.demand_id,
+       count(*) FILTER (WHERE provenance.occurrence_role=1)::BIGINT
+           AS trigger_occurrence_count,
+       count(*) FILTER (WHERE provenance.occurrence_role=2)::BIGINT
+           AS target_occurrence_count,
+       count(*) FILTER (WHERE provenance.occurrence_role=3)::BIGINT
+           AS evidence_occurrence_count,
+       CASE
+         WHEN count(*) FILTER (WHERE provenance.occurrence_role=2)=1 THEN 1
+         WHEN count(*) FILTER (WHERE provenance.occurrence_role=2)>1 THEN 2
+         WHEN count(*) FILTER (WHERE provenance.occurrence_role=1)>0 THEN 11
+         ELSE 10
+       END::SMALLINT AS provenance_state
+  FROM execution.semantic_pnf_demand AS demand
+  LEFT JOIN execution.semantic_pnf_demand_occurrence_provenance AS provenance
+    ON provenance.demand_id=demand.demand_id
+ GROUP BY demand.demand_id;
+
+-- H9-specific structural support. The older generic strong-occurrence view is
+-- retained for non-H9 audit/compatibility. World-entity work is licensed only
+-- by producer-authored target occurrences that also carry the exact PNF object
+-- created for that target token.
+CREATE OR REPLACE VIEW execution.semantic_pnf_demand_h9_target_support_v1 AS
+SELECT target.demand_id,target.token_id,target.object_id,
+       target.ordinal,target.producer_ref
+  FROM execution.semantic_pnf_demand_target_occurrence_v1 AS target
+ WHERE target.object_id IS NOT NULL;
+
+-- Rewire the primary raw and quality-gated parser-entity occurrence bridges to
+-- the semantic target token. Trigger/evidence occurrences are deliberately not
+-- eligible for world-entity admission.
+CREATE OR REPLACE VIEW execution.semantic_pnf_demand_parser_entity_occurrence_v1 AS
+SELECT DISTINCT target.demand_id,target.object_id,
+       entity.entity_id,entity.entity_type_symbol_id,label.label_symbol_id
+  FROM execution.semantic_pnf_demand_h9_target_support_v1 AS target
+  JOIN execution.semantic_parser_token AS token
+    ON token.token_id=target.token_id
+   AND token.representation_version=2
+  JOIN execution.semantic_parser_provider_entity_span_v1 AS entity
+    ON entity.run_ref=token.run_ref
+   AND entity.document_ref=token.document_ref
+   AND entity.sentence_ref=token.sentence_ref
+   AND entity.start_char<=token.start_char
+   AND entity.end_char>=token.end_char
+  JOIN execution.semantic_pnf_parser_entity_surface_label AS label
+    ON label.entity_id=entity.entity_id;
+
+CREATE OR REPLACE VIEW execution.semantic_pnf_demand_raw_parser_entity_occurrence_v1 AS
+SELECT DISTINCT target.demand_id,target.object_id,entity.entity_id,
+       entity.entity_type_symbol_id,quality.quality_state
+  FROM execution.semantic_pnf_demand_h9_target_support_v1 AS target
+  JOIN execution.semantic_parser_token AS token
+    ON token.token_id=target.token_id
+   AND token.representation_version=2
+  JOIN execution.semantic_parser_entity_span AS entity
+    ON entity.representation_version=2
+   AND entity.run_ref=token.run_ref
+   AND entity.document_ref=token.document_ref
+   AND entity.sentence_ref=token.sentence_ref
+   AND entity.start_char<=token.start_char
+   AND entity.end_char>=token.end_char
+  JOIN execution.semantic_parser_entity_span_quality_v1 AS quality
+    ON quality.entity_id=entity.entity_id;
+
+-- Historical/current provider origins whose demand lacks exact producer target
+-- provenance are withdrawn, never deleted. This does not resolve or refute the
+-- demand; it only removes permission to cross the external boundary.
+UPDATE execution.semantic_pnf_consumer_external_need_origin AS origin
+   SET active=FALSE,updated_at=CURRENT_TIMESTAMP
+  FROM execution.semantic_pnf_consumer_external_need AS need
+ WHERE origin.need_id=need.need_id
+   AND origin.active
+   AND NOT EXISTS (
+       SELECT 1
+         FROM execution.semantic_pnf_demand_h9_target_support_v1 AS target
+        WHERE target.demand_id=need.demand_id
+          AND target.object_id=need.anchor_object_id
+   );
+
+WITH state AS MATERIALIZED (
+    SELECT need.need_id,COALESCE(bool_or(origin.active),FALSE) AS any_active,
+           min(origin.priority) FILTER (WHERE origin.active) AS min_priority,
+           max(origin.minimum_source_epoch) FILTER (WHERE origin.active) AS max_floor
+      FROM execution.semantic_pnf_consumer_external_need AS need
+      LEFT JOIN execution.semantic_pnf_consumer_external_need_origin AS origin
+        ON origin.need_id=need.need_id
+     GROUP BY need.need_id
+)
+UPDATE execution.semantic_pnf_consumer_external_need AS need
+   SET active=state.any_active,
+       priority=COALESCE(state.min_priority,need.priority),
+       minimum_source_epoch=state.max_floor
+  FROM state
+ WHERE state.need_id=need.need_id;
+
+SELECT execution.refresh_numeric_pnf_external_request_observer_state();
+SELECT execution.refresh_numeric_pnf_external_request_cache_state();
+
+COMMIT;

--- a/database/postgres_migrations/135_demand_trigger_target_occurrence.sql
+++ b/database/postgres_migrations/135_demand_trigger_target_occurrence.sql
@@ -9,9 +9,9 @@ BEGIN;
 -- authorize H9 provider work.
 --
 -- New/recompiled demands are different: the demand producer has the exact
--- factor, its typed slots and parser-token support available in the same
--- transaction. An AFTER INSERT/UPDATE producer hook records provenance only
--- when those existing coordinates uniquely license it.
+-- factor, typed slots and parser-token support available in the same
+-- transaction. Producer provenance is recorded only when those existing
+-- coordinates uniquely license it.
 CREATE TABLE IF NOT EXISTS execution.semantic_pnf_demand_occurrence_provenance (
     demand_id BIGINT NOT NULL
         REFERENCES execution.semantic_pnf_demand(demand_id) ON DELETE CASCADE,
@@ -38,10 +38,92 @@ CREATE INDEX IF NOT EXISTS semantic_pnf_demand_target_object_idx
        (object_id,demand_id)
     WHERE occurrence_role=2 AND object_id IS NOT NULL;
 
--- Explicit producer semantics: only residuals whose meaning identifies a typed
--- factor slot receive an entity/object target. This is deliberately finite and
--- numeric at runtime. Absence of a rule means factor-level/unlocated residual,
--- not permission to select a nearby noun.
+-- Generic producer API. Producers must state the occurrence role explicitly.
+-- The database validates that the token is actually inside the demand's source
+-- region and that any claimed object is an exact support object for that token
+-- in the same region. This API never searches for a nearby object.
+CREATE OR REPLACE FUNCTION execution.register_numeric_pnf_demand_occurrence(
+    selected_demand_id BIGINT,
+    selected_occurrence_role SMALLINT,
+    selected_token_id BIGINT,
+    selected_object_id BIGINT,
+    selected_ordinal SMALLINT,
+    selected_producer_ref TEXT
+)
+RETURNS BIGINT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    selected_source_region_id BIGINT;
+    selected_token_start BIGINT;
+    selected_token_end BIGINT;
+    selected_region_start BIGINT;
+    selected_region_end BIGINT;
+    existing_object_count BIGINT := 0;
+BEGIN
+    IF selected_occurrence_role NOT IN (1,2,3) THEN
+        RAISE EXCEPTION 'invalid demand occurrence role %',selected_occurrence_role;
+    END IF;
+    IF selected_ordinal<0 THEN
+        RAISE EXCEPTION 'negative demand occurrence ordinal %',selected_ordinal;
+    END IF;
+    IF selected_producer_ref IS NULL OR selected_producer_ref='' THEN
+        RAISE EXCEPTION 'demand occurrence producer_ref must be non-empty';
+    END IF;
+
+    SELECT demand.source_region_id,region.start_char,region.end_char,
+           token.start_char,token.end_char
+      INTO selected_source_region_id,selected_region_start,selected_region_end,
+           selected_token_start,selected_token_end
+      FROM execution.semantic_pnf_demand AS demand
+      JOIN execution.semantic_pnf_region AS region
+        ON region.region_id=demand.source_region_id
+      JOIN execution.semantic_parser_token AS token
+        ON token.token_id=selected_token_id
+       AND token.representation_version=2
+     WHERE demand.demand_id=selected_demand_id;
+
+    IF selected_source_region_id IS NULL THEN
+        RAISE EXCEPTION 'unknown demand/token pair %, %',
+            selected_demand_id,selected_token_id;
+    END IF;
+    IF selected_token_start<selected_region_start
+       OR selected_token_end>selected_region_end THEN
+        RAISE EXCEPTION 'demand occurrence token % is outside source region %',
+            selected_token_id,selected_source_region_id;
+    END IF;
+
+    IF selected_object_id IS NOT NULL THEN
+        SELECT count(*) INTO existing_object_count
+          FROM execution.semantic_pnf_object_token_support AS support
+          JOIN execution.semantic_pnf_object AS object
+            ON object.object_id=support.object_id
+         WHERE support.object_id=selected_object_id
+           AND support.token_id=selected_token_id
+           AND object.region_id=selected_source_region_id;
+        IF existing_object_count<>1 THEN
+            RAISE EXCEPTION
+                'object % does not exactly support demand occurrence token % in region %',
+                selected_object_id,selected_token_id,selected_source_region_id;
+        END IF;
+    END IF;
+
+    INSERT INTO execution.semantic_pnf_demand_occurrence_provenance
+        (demand_id,occurrence_role,token_id,object_id,ordinal,producer_ref)
+    VALUES (
+        selected_demand_id,selected_occurrence_role,selected_token_id,
+        selected_object_id,selected_ordinal,selected_producer_ref
+    )
+    ON CONFLICT(demand_id,occurrence_role,token_id,ordinal) DO UPDATE SET
+        object_id=EXCLUDED.object_id,
+        producer_ref=EXCLUDED.producer_ref;
+    RETURN 1;
+END;
+$$;
+
+-- Explicit factor-producer semantics: only residuals whose meaning identifies
+-- a typed factor slot receive an entity/object target. Absence of a rule means
+-- factor-level/unlocated residual, not permission to select a nearby noun.
 CREATE TABLE IF NOT EXISTS execution.semantic_pnf_demand_target_role_rule (
     residual_type_symbol_id BIGINT PRIMARY KEY
         REFERENCES execution.semantic_symbol(symbol_id) ON DELETE CASCADE,
@@ -53,21 +135,19 @@ CREATE TABLE IF NOT EXISTS execution.semantic_pnf_demand_target_role_rule (
 
 INSERT INTO execution.semantic_pnf_demand_target_role_rule
     (residual_type_symbol_id,target_role_symbol_id,rule_ref)
-SELECT residual.symbol_id,role.symbol_id,definition.rule_ref
-  FROM (VALUES
-      ('legal_object_identity_unresolved'::TEXT,'legal_object'::TEXT,
-       'producer-target:legal-object-identity:v1'::TEXT),
-      ('condition_attachment_unresolved'::TEXT,'host'::TEXT,
-       'producer-target:condition-host:v1'::TEXT),
-      ('exception_attachment_unresolved'::TEXT,'host'::TEXT,
-       'producer-target:exception-host:v1'::TEXT),
-      ('norm_bearer_unresolved'::TEXT,'bearer'::TEXT,
-       'producer-target:norm-bearer:v1'::TEXT)
-  ) AS definition(residual_name,role_name,rule_ref)
-  JOIN execution.semantic_symbol AS residual
-    ON residual.kind_id=13 AND residual.symbol_text=definition.residual_name
-  JOIN execution.semantic_symbol AS role
-    ON role.kind_id=19 AND role.symbol_text=definition.role_name
+VALUES
+    (execution.ensure_semantic_symbol(13::SMALLINT,'legal_object_identity_unresolved'),
+     execution.ensure_semantic_symbol(19::SMALLINT,'legal_object'),
+     'producer-target:legal-object-identity:v1'),
+    (execution.ensure_semantic_symbol(13::SMALLINT,'condition_attachment_unresolved'),
+     execution.ensure_semantic_symbol(19::SMALLINT,'host'),
+     'producer-target:condition-host:v1'),
+    (execution.ensure_semantic_symbol(13::SMALLINT,'exception_attachment_unresolved'),
+     execution.ensure_semantic_symbol(19::SMALLINT,'host'),
+     'producer-target:exception-host:v1'),
+    (execution.ensure_semantic_symbol(13::SMALLINT,'norm_bearer_unresolved'),
+     execution.ensure_semantic_symbol(19::SMALLINT,'bearer'),
+     'producer-target:norm-bearer:v1')
 ON CONFLICT(residual_type_symbol_id) DO UPDATE SET
     target_role_symbol_id=EXCLUDED.target_role_symbol_id,
     rule_ref=EXCLUDED.rule_ref;
@@ -85,8 +165,10 @@ DECLARE
     selected_target_object_id BIGINT;
     producer_match_count BIGINT := 0;
     target_match_count BIGINT := 0;
+    evidence_row RECORD;
+    evidence_ordinal SMALLINT := 0;
 BEGIN
-    -- A lexical key remains a candidate-planning coordinate. It may identify
+    -- lexical_symbol_id remains a candidate-planning coordinate. It may locate
     -- the producer trigger, but never the semantic target by itself.
     IF NEW.expected_factor_type_symbol_id IS NULL
        OR NEW.lexical_symbol_id IS NULL THEN
@@ -116,8 +198,9 @@ BEGIN
         RETURN NEW;
     END IF;
 
-    -- Object attachment on the trigger is audit context only. Multiple object
-    -- representations do not prevent recording the trigger token itself.
+    -- Object attachment on a trigger is audit context only. If representation
+    -- is ambiguous, record the exact trigger token with no object rather than
+    -- choosing one.
     SELECT min(support.object_id)
       INTO selected_trigger_object_id
       FROM execution.semantic_pnf_object_token_support AS support
@@ -127,34 +210,36 @@ BEGIN
        AND object.region_id=NEW.source_region_id
     HAVING count(DISTINCT support.object_id)=1;
 
-    INSERT INTO execution.semantic_pnf_demand_occurrence_provenance
-        (demand_id,occurrence_role,token_id,object_id,ordinal,producer_ref)
-    VALUES (
-        NEW.demand_id,1,selected_trigger_token_id,selected_trigger_object_id,0,
+    PERFORM execution.register_numeric_pnf_demand_occurrence(
+        NEW.demand_id,1::SMALLINT,selected_trigger_token_id,
+        selected_trigger_object_id,0::SMALLINT,
         'numeric-factor:'||selected_factor_id::TEXT
-    )
-    ON CONFLICT(demand_id,occurrence_role,token_id,ordinal) DO NOTHING;
+    );
 
-    -- Preserve the other exact factor-support tokens as evidence. They are not
-    -- target candidates and can never authorize provider lookup.
-    INSERT INTO execution.semantic_pnf_demand_occurrence_provenance
-        (demand_id,occurrence_role,token_id,object_id,ordinal,producer_ref)
-    SELECT NEW.demand_id,3,support.token_id,unique_object.object_id,
-           row_number() OVER (ORDER BY support.ordinal,support.token_id)::SMALLINT-1,
-           'numeric-factor:'||selected_factor_id::TEXT
-      FROM execution.semantic_pnf_factor_token_support AS support
-      LEFT JOIN LATERAL (
-          SELECT min(object_support.object_id) AS object_id
-            FROM execution.semantic_pnf_object_token_support AS object_support
-            JOIN execution.semantic_pnf_object AS object
-              ON object.object_id=object_support.object_id
-           WHERE object_support.token_id=support.token_id
-             AND object.region_id=NEW.source_region_id
-          HAVING count(DISTINCT object_support.object_id)=1
-      ) AS unique_object ON TRUE
-     WHERE support.factor_id=selected_factor_id
-       AND support.token_id<>selected_trigger_token_id
-    ON CONFLICT(demand_id,occurrence_role,token_id,ordinal) DO NOTHING;
+    -- Preserve all other exact factor-support tokens as evidence. They never
+    -- become target candidates merely because they support the factor.
+    FOR evidence_row IN
+        SELECT support.token_id,
+               (
+                   SELECT min(object_support.object_id)
+                     FROM execution.semantic_pnf_object_token_support AS object_support
+                     JOIN execution.semantic_pnf_object AS object
+                       ON object.object_id=object_support.object_id
+                    WHERE object_support.token_id=support.token_id
+                      AND object.region_id=NEW.source_region_id
+                   HAVING count(DISTINCT object_support.object_id)=1
+               ) AS object_id
+          FROM execution.semantic_pnf_factor_token_support AS support
+         WHERE support.factor_id=selected_factor_id
+           AND support.token_id<>selected_trigger_token_id
+         ORDER BY support.ordinal,support.token_id
+    LOOP
+        PERFORM execution.register_numeric_pnf_demand_occurrence(
+            NEW.demand_id,3::SMALLINT,evidence_row.token_id,evidence_row.object_id,
+            evidence_ordinal,'numeric-factor:'||selected_factor_id::TEXT
+        );
+        evidence_ordinal:=evidence_ordinal+1;
+    END LOOP;
 
     SELECT rule.target_role_symbol_id
       INTO selected_target_role_id
@@ -168,7 +253,7 @@ BEGIN
     END IF;
 
     -- A semantic target exists only when the typed factor role selects exactly
-    -- one object and that object carries exactly one parser token occurrence.
+    -- one object and that object carries exactly one parser-token occurrence.
     SELECT count(*),min(match.token_id),min(match.object_id)
       INTO target_match_count,selected_target_token_id,selected_target_object_id
       FROM (
@@ -186,21 +271,18 @@ BEGIN
         RETURN NEW;
     END IF;
 
-    INSERT INTO execution.semantic_pnf_demand_occurrence_provenance
-        (demand_id,occurrence_role,token_id,object_id,ordinal,producer_ref)
-    VALUES (
-        NEW.demand_id,2,selected_target_token_id,selected_target_object_id,0,
+    PERFORM execution.register_numeric_pnf_demand_occurrence(
+        NEW.demand_id,2::SMALLINT,selected_target_token_id,
+        selected_target_object_id,0::SMALLINT,
         'numeric-factor:'||selected_factor_id::TEXT
-    )
-    ON CONFLICT(demand_id,occurrence_role,token_id,ordinal) DO NOTHING;
-
+    );
     RETURN NEW;
 END;
 $$;
 
 -- Existing rows are not touched by migration installation. A genuine compiler
--- replay hits INSERT or ON CONFLICT UPDATE and can then derive provenance from
--- the newly/currently materialized factor graph.
+-- replay hits INSERT or ON CONFLICT UPDATE and derives provenance against the
+-- newly/currently materialized factor graph.
 DROP TRIGGER IF EXISTS semantic_pnf_demand_occurrence_producer
     ON execution.semantic_pnf_demand;
 CREATE TRIGGER semantic_pnf_demand_occurrence_producer

--- a/database/postgres_migrations/136_demand_occurrence_registration_hardening.sql
+++ b/database/postgres_migrations/136_demand_occurrence_registration_hardening.sql
@@ -1,0 +1,120 @@
+BEGIN;
+
+-- 136: exact occurrence registration is document-scoped, not merely offset-
+-- scoped. Two documents may share the same numeric character interval.
+CREATE OR REPLACE FUNCTION execution.register_numeric_pnf_demand_occurrence(
+    selected_demand_id BIGINT,
+    selected_occurrence_role SMALLINT,
+    selected_token_id BIGINT,
+    selected_object_id BIGINT,
+    selected_ordinal SMALLINT,
+    selected_producer_ref TEXT
+)
+RETURNS BIGINT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    selected_source_region_id BIGINT;
+    existing_object_count BIGINT := 0;
+BEGIN
+    IF selected_occurrence_role NOT IN (1,2,3) THEN
+        RAISE EXCEPTION 'invalid demand occurrence role %',selected_occurrence_role;
+    END IF;
+    IF selected_ordinal<0 THEN
+        RAISE EXCEPTION 'negative demand occurrence ordinal %',selected_ordinal;
+    END IF;
+    IF selected_producer_ref IS NULL OR selected_producer_ref='' THEN
+        RAISE EXCEPTION 'demand occurrence producer_ref must be non-empty';
+    END IF;
+
+    SELECT demand.source_region_id
+      INTO selected_source_region_id
+      FROM execution.semantic_pnf_demand AS demand
+      JOIN execution.semantic_pnf_region AS region
+        ON region.region_id=demand.source_region_id
+      JOIN execution.semantic_parser_token AS token
+        ON token.token_id=selected_token_id
+       AND token.representation_version=2
+       AND token.run_ref=region.run_ref
+       AND token.document_ref=region.document_ref
+       AND token.start_char>=region.start_char
+       AND token.end_char<=region.end_char
+     WHERE demand.demand_id=selected_demand_id;
+
+    IF selected_source_region_id IS NULL THEN
+        RAISE EXCEPTION
+            'token % is not an exact occurrence inside demand % source region',
+            selected_token_id,selected_demand_id;
+    END IF;
+
+    IF selected_object_id IS NOT NULL THEN
+        SELECT count(*) INTO existing_object_count
+          FROM execution.semantic_pnf_object_token_support AS support
+          JOIN execution.semantic_pnf_object AS object
+            ON object.object_id=support.object_id
+         WHERE support.object_id=selected_object_id
+           AND support.token_id=selected_token_id
+           AND object.region_id=selected_source_region_id;
+        IF existing_object_count<>1 THEN
+            RAISE EXCEPTION
+                'object % does not exactly support demand occurrence token % in region %',
+                selected_object_id,selected_token_id,selected_source_region_id;
+        END IF;
+    END IF;
+
+    INSERT INTO execution.semantic_pnf_demand_occurrence_provenance
+        (demand_id,occurrence_role,token_id,object_id,ordinal,producer_ref)
+    VALUES (
+        selected_demand_id,selected_occurrence_role,selected_token_id,
+        selected_object_id,selected_ordinal,selected_producer_ref
+    )
+    ON CONFLICT(demand_id,occurrence_role,token_id,ordinal) DO UPDATE SET
+        object_id=EXCLUDED.object_id,
+        producer_ref=EXCLUDED.producer_ref;
+    RETURN 1;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION execution.verify_numeric_pnf_demand_occurrence_provenance()
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+AS $$
+DECLARE invalid_count BIGINT := 0;
+BEGIN
+    SELECT count(*) INTO invalid_count
+      FROM execution.semantic_pnf_demand_occurrence_provenance AS provenance
+      JOIN execution.semantic_pnf_demand AS demand
+        ON demand.demand_id=provenance.demand_id
+      JOIN execution.semantic_pnf_region AS region
+        ON region.region_id=demand.source_region_id
+      LEFT JOIN execution.semantic_parser_token AS token
+        ON token.token_id=provenance.token_id
+       AND token.representation_version=2
+       AND token.run_ref=region.run_ref
+       AND token.document_ref=region.document_ref
+       AND token.start_char>=region.start_char
+       AND token.end_char<=region.end_char
+     WHERE token.token_id IS NULL
+        OR (
+            provenance.object_id IS NOT NULL
+            AND NOT EXISTS (
+                SELECT 1
+                  FROM execution.semantic_pnf_object_token_support AS support
+                  JOIN execution.semantic_pnf_object AS object
+                    ON object.object_id=support.object_id
+                 WHERE support.object_id=provenance.object_id
+                   AND support.token_id=provenance.token_id
+                   AND object.region_id=demand.source_region_id
+            )
+        );
+
+    IF invalid_count<>0 THEN
+        RAISE EXCEPTION 'invalid demand occurrence provenance rows: %',invalid_count;
+    END IF;
+    RETURN TRUE;
+END;
+$$;
+
+SELECT execution.verify_numeric_pnf_demand_occurrence_provenance();
+
+COMMIT;

--- a/database/postgres_migrations/137_operational_demand_occurrence_projection.sql
+++ b/database/postgres_migrations/137_operational_demand_occurrence_projection.sql
@@ -1,0 +1,190 @@
+BEGIN;
+
+-- 137: the ordinary compile_corpus.py path persists resolution.demand, while
+-- H3/H6/H9 execute over execution.semantic_pnf_demand.  Preserve the producer
+-- occurrence coordinates at the operational boundary and project them into the
+-- numeric carrier only when the exact parser token and numeric demand are
+-- uniquely identified.
+CREATE TABLE IF NOT EXISTS resolution.demand_occurrence_provenance (
+    demand_ref TEXT NOT NULL
+        REFERENCES resolution.demand(demand_ref) ON DELETE CASCADE,
+    residual_type_ref TEXT NOT NULL,
+    occurrence_role SMALLINT NOT NULL CHECK (occurrence_role IN (1,2,3)),
+    parser_token_ref TEXT NOT NULL,
+    numeric_token_id BIGINT
+        REFERENCES execution.semantic_parser_token(token_id) ON DELETE SET NULL,
+    semantic_role_ref TEXT,
+    ordinal SMALLINT NOT NULL DEFAULT 0 CHECK (ordinal >= 0),
+    producer_ref TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (
+        demand_ref,residual_type_ref,occurrence_role,parser_token_ref,ordinal
+    )
+);
+
+CREATE INDEX IF NOT EXISTS resolution_demand_occurrence_numeric_token_idx
+    ON resolution.demand_occurrence_provenance
+       (numeric_token_id,demand_ref,residual_type_ref)
+    WHERE numeric_token_id IS NOT NULL;
+
+CREATE OR REPLACE VIEW resolution.demand_occurrence_provenance_audit_v1 AS
+SELECT demand.demand_ref,
+       provenance.residual_type_ref,
+       count(*) FILTER (WHERE provenance.occurrence_role=1)::BIGINT
+           AS trigger_count,
+       count(*) FILTER (WHERE provenance.occurrence_role=2)::BIGINT
+           AS target_count,
+       count(*) FILTER (WHERE provenance.occurrence_role=3)::BIGINT
+           AS evidence_count,
+       count(*) FILTER (
+           WHERE provenance.numeric_token_id IS NOT NULL
+             AND provenance.occurrence_role=1
+       )::BIGINT AS numeric_trigger_count,
+       count(*) FILTER (
+           WHERE provenance.numeric_token_id IS NOT NULL
+             AND provenance.occurrence_role=2
+       )::BIGINT AS numeric_target_count
+  FROM resolution.demand AS demand
+  LEFT JOIN resolution.demand_occurrence_provenance AS provenance
+    ON provenance.demand_ref=demand.demand_ref
+ GROUP BY demand.demand_ref,provenance.residual_type_ref;
+
+CREATE OR REPLACE FUNCTION execution.project_resolution_demand_occurrence_to_numeric_pnf(
+    selected_demand_ref TEXT
+)
+RETURNS BIGINT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    residual_row RECORD;
+    provenance_row RECORD;
+    selected_numeric_demand_id BIGINT;
+    selected_source_region_id BIGINT;
+    candidate_count BIGINT;
+    selected_object_id BIGINT;
+    object_count BIGINT;
+    inserted_count BIGINT := 0;
+BEGIN
+    FOR residual_row IN
+        SELECT DISTINCT provenance.residual_type_ref,
+               demand.subject_kind_ref,
+               trigger.numeric_token_id AS trigger_token_id
+          FROM resolution.demand_occurrence_provenance AS provenance
+          JOIN resolution.demand AS demand
+            ON demand.demand_ref=provenance.demand_ref
+          JOIN resolution.demand_occurrence_provenance AS trigger
+            ON trigger.demand_ref=provenance.demand_ref
+           AND trigger.residual_type_ref=provenance.residual_type_ref
+           AND trigger.occurrence_role=1
+         WHERE provenance.demand_ref=selected_demand_ref
+           AND trigger.numeric_token_id IS NOT NULL
+    LOOP
+        -- The operational demand supplies the exact trigger occurrence.  Use it
+        -- only to identify the corresponding numeric demand in the same parser
+        -- sentence/PNF region with the same factor type, residual type and
+        -- lexical trigger.  Ambiguity is unresolved, never ranked away.
+        SELECT count(*),min(candidate.demand_id),min(candidate.source_region_id)
+          INTO candidate_count,selected_numeric_demand_id,selected_source_region_id
+          FROM (
+              SELECT DISTINCT demand.demand_id,demand.source_region_id
+                FROM execution.semantic_parser_token AS trigger_token
+                JOIN execution.semantic_pnf_sentence_region AS sentence_region
+                  ON sentence_region.sentence_id=trigger_token.sentence_id
+                JOIN execution.semantic_pnf_demand AS demand
+                  ON demand.source_region_id=sentence_region.region_id
+                JOIN execution.semantic_symbol AS residual_symbol
+                  ON residual_symbol.symbol_id=demand.residual_type_symbol_id
+                JOIN execution.semantic_symbol AS factor_type_symbol
+                  ON factor_type_symbol.symbol_id=demand.expected_factor_type_symbol_id
+               WHERE trigger_token.token_id=residual_row.trigger_token_id
+                 AND trigger_token.representation_version=2
+                 AND demand.lexical_symbol_id=trigger_token.lemma_symbol_id
+                 AND residual_symbol.kind_id=13
+                 AND residual_symbol.symbol_text=residual_row.residual_type_ref
+                 AND factor_type_symbol.symbol_text=residual_row.subject_kind_ref
+          ) AS candidate;
+
+        IF candidate_count<>1 OR selected_numeric_demand_id IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        FOR provenance_row IN
+            SELECT provenance.*
+              FROM resolution.demand_occurrence_provenance AS provenance
+             WHERE provenance.demand_ref=selected_demand_ref
+               AND provenance.residual_type_ref=residual_row.residual_type_ref
+               AND provenance.numeric_token_id IS NOT NULL
+             ORDER BY provenance.occurrence_role,provenance.ordinal,
+                      provenance.parser_token_ref
+        LOOP
+            selected_object_id := NULL;
+            object_count := 0;
+            SELECT count(DISTINCT support.object_id),min(support.object_id)
+              INTO object_count,selected_object_id
+              FROM execution.semantic_pnf_object_token_support AS support
+              JOIN execution.semantic_pnf_object AS object
+                ON object.object_id=support.object_id
+             WHERE support.token_id=provenance_row.numeric_token_id
+               AND object.region_id=selected_source_region_id
+               AND object.active;
+
+            IF object_count<>1 THEN
+                selected_object_id := NULL;
+            END IF;
+
+            -- A target without an exact object witness cannot authorize H9.
+            IF provenance_row.occurrence_role=2
+               AND selected_object_id IS NULL THEN
+                CONTINUE;
+            END IF;
+
+            PERFORM execution.register_numeric_pnf_demand_occurrence(
+                selected_numeric_demand_id,
+                provenance_row.occurrence_role,
+                provenance_row.numeric_token_id,
+                selected_object_id,
+                provenance_row.ordinal,
+                'operational-demand:'||selected_demand_ref
+            );
+            inserted_count := inserted_count + 1;
+        END LOOP;
+    END LOOP;
+
+    RETURN inserted_count;
+END;
+$$;
+
+-- This verifier proves only the transport invariant.  It does not claim that a
+-- target exists when the producer did not author one.
+CREATE OR REPLACE FUNCTION execution.verify_resolution_demand_occurrence_projection()
+RETURNS TABLE(check_name TEXT,violation_count BIGINT)
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT 'operational_numeric_token_document_mismatch'::TEXT,
+           count(*)::BIGINT
+      FROM resolution.demand_occurrence_provenance AS provenance
+      JOIN resolution.demand AS demand
+        ON demand.demand_ref=provenance.demand_ref
+      JOIN execution.semantic_parser_token AS token
+        ON token.token_id=provenance.numeric_token_id
+     WHERE provenance.numeric_token_id IS NOT NULL
+       AND token.document_ref<>demand.scope_ref
+    UNION ALL
+    SELECT 'projected_target_without_exact_object_support'::TEXT,
+           count(*)::BIGINT
+      FROM execution.semantic_pnf_demand_occurrence_provenance AS target
+     WHERE target.occurrence_role=2
+       AND target.producer_ref LIKE 'operational-demand:%'
+       AND (
+           target.object_id IS NULL
+           OR NOT EXISTS (
+               SELECT 1
+                 FROM execution.semantic_pnf_object_token_support AS support
+                WHERE support.object_id=target.object_id
+                  AND support.token_id=target.token_id
+           )
+       );
+$$;
+
+COMMIT;

--- a/database/postgres_migrations/137_operational_demand_occurrence_projection.sql
+++ b/database/postgres_migrations/137_operational_demand_occurrence_projection.sql
@@ -1,9 +1,9 @@
 BEGIN;
 
 -- 137: compile_corpus.py persists resolution.demand while H3/H6/H9 execute on
--- execution.semantic_pnf_demand.  Persist the producer's parser-token reference
--- plus its exact document character coordinates, then project only when those
--- coordinates identify exactly one numeric demand in a concrete parser run.
+-- execution.semantic_pnf_demand. Persist the producer's immutable parser-token
+-- reference immediately. Exact numeric document coordinates may be filled on a
+-- later replay if the numeric parser tape is not present yet.
 -- No text, nearest-noun, NER trimming or cross-region recovery is permitted.
 CREATE TABLE IF NOT EXISTS resolution.demand_occurrence_provenance (
     demand_ref TEXT NOT NULL
@@ -12,20 +12,30 @@ CREATE TABLE IF NOT EXISTS resolution.demand_occurrence_provenance (
     occurrence_role SMALLINT NOT NULL CHECK (occurrence_role IN (1,2,3)),
     parser_token_ref TEXT NOT NULL,
     document_ref TEXT NOT NULL,
-    start_char BIGINT NOT NULL CHECK (start_char >= 0),
-    end_char BIGINT NOT NULL CHECK (end_char > start_char),
+    start_char BIGINT,
+    end_char BIGINT,
     semantic_role_ref TEXT,
     ordinal SMALLINT NOT NULL DEFAULT 0 CHECK (ordinal >= 0),
     producer_ref TEXT NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (
         demand_ref,residual_type_ref,occurrence_role,parser_token_ref,ordinal
+    ),
+    CHECK (
+        (start_char IS NULL AND end_char IS NULL)
+        OR (
+            start_char IS NOT NULL
+            AND end_char IS NOT NULL
+            AND start_char >= 0
+            AND end_char > start_char
+        )
     )
 );
 
 CREATE INDEX IF NOT EXISTS resolution_demand_occurrence_coordinate_idx
     ON resolution.demand_occurrence_provenance
-       (document_ref,start_char,end_char,demand_ref,residual_type_ref);
+       (document_ref,start_char,end_char,demand_ref,residual_type_ref)
+    WHERE start_char IS NOT NULL AND end_char IS NOT NULL;
 
 CREATE OR REPLACE VIEW resolution.demand_occurrence_provenance_audit_v1 AS
 SELECT demand.demand_ref,
@@ -37,7 +47,13 @@ SELECT demand.demand_ref,
        count(*) FILTER (WHERE provenance.occurrence_role=3)::BIGINT
            AS evidence_count,
        count(*) FILTER (
+           WHERE provenance.start_char IS NULL
+              OR provenance.end_char IS NULL
+       )::BIGINT AS unresolved_coordinate_count,
+       count(*) FILTER (
            WHERE provenance.occurrence_role=1
+             AND provenance.start_char IS NOT NULL
+             AND provenance.end_char IS NOT NULL
              AND EXISTS (
                  SELECT 1
                    FROM execution.semantic_parser_token AS token
@@ -49,6 +65,8 @@ SELECT demand.demand_ref,
        )::BIGINT AS numeric_trigger_coordinate_count,
        count(*) FILTER (
            WHERE provenance.occurrence_role=2
+             AND provenance.start_char IS NOT NULL
+             AND provenance.end_char IS NOT NULL
              AND EXISTS (
                  SELECT 1
                    FROM execution.semantic_parser_token AS token
@@ -96,11 +114,13 @@ BEGIN
            AND trigger.residual_type_ref=provenance.residual_type_ref
            AND trigger.occurrence_role=1
          WHERE provenance.demand_ref=selected_demand_ref
+           AND trigger.start_char IS NOT NULL
+           AND trigger.end_char IS NOT NULL
     LOOP
         -- The exact trigger coordinate identifies the corresponding numeric
         -- demand only if one parser run + sentence region + factor/residual key
-        -- survives. Multiple historical runs therefore fail closed rather than
-        -- being silently ranked.
+        -- survives. Multiple historical runs fail closed rather than being
+        -- silently ranked.
         SELECT count(*),min(candidate.demand_id),min(candidate.source_region_id),
                min(candidate.run_ref)
           INTO candidate_count,selected_numeric_demand_id,
@@ -142,6 +162,11 @@ BEGIN
              ORDER BY provenance.occurrence_role,provenance.ordinal,
                       provenance.parser_token_ref
         LOOP
+            IF provenance_row.start_char IS NULL
+               OR provenance_row.end_char IS NULL THEN
+                CONTINUE;
+            END IF;
+
             selected_numeric_token_id := NULL;
             token_count := 0;
             SELECT count(*),min(token.token_id)
@@ -203,6 +228,11 @@ AS $$
       JOIN resolution.demand AS demand
         ON demand.demand_ref=provenance.demand_ref
      WHERE provenance.document_ref<>demand.scope_ref
+    UNION ALL
+    SELECT 'operational_half_coordinate'::TEXT,
+           count(*)::BIGINT
+      FROM resolution.demand_occurrence_provenance AS provenance
+     WHERE (provenance.start_char IS NULL)<>(provenance.end_char IS NULL)
     UNION ALL
     SELECT 'projected_target_without_exact_object_support'::TEXT,
            count(*)::BIGINT

--- a/database/postgres_migrations/137_operational_demand_occurrence_projection.sql
+++ b/database/postgres_migrations/137_operational_demand_occurrence_projection.sql
@@ -1,18 +1,19 @@
 BEGIN;
 
--- 137: the ordinary compile_corpus.py path persists resolution.demand, while
--- H3/H6/H9 execute over execution.semantic_pnf_demand.  Preserve the producer
--- occurrence coordinates at the operational boundary and project them into the
--- numeric carrier only when the exact parser token and numeric demand are
--- uniquely identified.
+-- 137: compile_corpus.py persists resolution.demand while H3/H6/H9 execute on
+-- execution.semantic_pnf_demand.  Persist the producer's parser-token reference
+-- plus its exact document character coordinates, then project only when those
+-- coordinates identify exactly one numeric demand in a concrete parser run.
+-- No text, nearest-noun, NER trimming or cross-region recovery is permitted.
 CREATE TABLE IF NOT EXISTS resolution.demand_occurrence_provenance (
     demand_ref TEXT NOT NULL
         REFERENCES resolution.demand(demand_ref) ON DELETE CASCADE,
     residual_type_ref TEXT NOT NULL,
     occurrence_role SMALLINT NOT NULL CHECK (occurrence_role IN (1,2,3)),
     parser_token_ref TEXT NOT NULL,
-    numeric_token_id BIGINT
-        REFERENCES execution.semantic_parser_token(token_id) ON DELETE SET NULL,
+    document_ref TEXT NOT NULL,
+    start_char BIGINT NOT NULL CHECK (start_char >= 0),
+    end_char BIGINT NOT NULL CHECK (end_char > start_char),
     semantic_role_ref TEXT,
     ordinal SMALLINT NOT NULL DEFAULT 0 CHECK (ordinal >= 0),
     producer_ref TEXT NOT NULL,
@@ -22,10 +23,9 @@ CREATE TABLE IF NOT EXISTS resolution.demand_occurrence_provenance (
     )
 );
 
-CREATE INDEX IF NOT EXISTS resolution_demand_occurrence_numeric_token_idx
+CREATE INDEX IF NOT EXISTS resolution_demand_occurrence_coordinate_idx
     ON resolution.demand_occurrence_provenance
-       (numeric_token_id,demand_ref,residual_type_ref)
-    WHERE numeric_token_id IS NOT NULL;
+       (document_ref,start_char,end_char,demand_ref,residual_type_ref);
 
 CREATE OR REPLACE VIEW resolution.demand_occurrence_provenance_audit_v1 AS
 SELECT demand.demand_ref,
@@ -37,13 +37,27 @@ SELECT demand.demand_ref,
        count(*) FILTER (WHERE provenance.occurrence_role=3)::BIGINT
            AS evidence_count,
        count(*) FILTER (
-           WHERE provenance.numeric_token_id IS NOT NULL
-             AND provenance.occurrence_role=1
-       )::BIGINT AS numeric_trigger_count,
+           WHERE provenance.occurrence_role=1
+             AND EXISTS (
+                 SELECT 1
+                   FROM execution.semantic_parser_token AS token
+                  WHERE token.document_ref=provenance.document_ref
+                    AND token.start_char=provenance.start_char
+                    AND token.end_char=provenance.end_char
+                    AND token.representation_version=2
+             )
+       )::BIGINT AS numeric_trigger_coordinate_count,
        count(*) FILTER (
-           WHERE provenance.numeric_token_id IS NOT NULL
-             AND provenance.occurrence_role=2
-       )::BIGINT AS numeric_target_count
+           WHERE provenance.occurrence_role=2
+             AND EXISTS (
+                 SELECT 1
+                   FROM execution.semantic_parser_token AS token
+                  WHERE token.document_ref=provenance.document_ref
+                    AND token.start_char=provenance.start_char
+                    AND token.end_char=provenance.end_char
+                    AND token.representation_version=2
+             )
+       )::BIGINT AS numeric_target_coordinate_count
   FROM resolution.demand AS demand
   LEFT JOIN resolution.demand_occurrence_provenance AS provenance
     ON provenance.demand_ref=demand.demand_ref
@@ -60,7 +74,10 @@ DECLARE
     provenance_row RECORD;
     selected_numeric_demand_id BIGINT;
     selected_source_region_id BIGINT;
+    selected_run_ref TEXT;
     candidate_count BIGINT;
+    selected_numeric_token_id BIGINT;
+    token_count BIGINT;
     selected_object_id BIGINT;
     object_count BIGINT;
     inserted_count BIGINT := 0;
@@ -68,7 +85,9 @@ BEGIN
     FOR residual_row IN
         SELECT DISTINCT provenance.residual_type_ref,
                demand.subject_kind_ref,
-               trigger.numeric_token_id AS trigger_token_id
+               trigger.document_ref,
+               trigger.start_char AS trigger_start_char,
+               trigger.end_char AS trigger_end_char
           FROM resolution.demand_occurrence_provenance AS provenance
           JOIN resolution.demand AS demand
             ON demand.demand_ref=provenance.demand_ref
@@ -77,26 +96,33 @@ BEGIN
            AND trigger.residual_type_ref=provenance.residual_type_ref
            AND trigger.occurrence_role=1
          WHERE provenance.demand_ref=selected_demand_ref
-           AND trigger.numeric_token_id IS NOT NULL
     LOOP
-        -- The operational demand supplies the exact trigger occurrence.  Use it
-        -- only to identify the corresponding numeric demand in the same parser
-        -- sentence/PNF region with the same factor type, residual type and
-        -- lexical trigger.  Ambiguity is unresolved, never ranked away.
-        SELECT count(*),min(candidate.demand_id),min(candidate.source_region_id)
-          INTO candidate_count,selected_numeric_demand_id,selected_source_region_id
+        -- The exact trigger coordinate identifies the corresponding numeric
+        -- demand only if one parser run + sentence region + factor/residual key
+        -- survives. Multiple historical runs therefore fail closed rather than
+        -- being silently ranked.
+        SELECT count(*),min(candidate.demand_id),min(candidate.source_region_id),
+               min(candidate.run_ref)
+          INTO candidate_count,selected_numeric_demand_id,
+               selected_source_region_id,selected_run_ref
           FROM (
-              SELECT DISTINCT demand.demand_id,demand.source_region_id
+              SELECT DISTINCT demand.demand_id,demand.source_region_id,region.run_ref
                 FROM execution.semantic_parser_token AS trigger_token
                 JOIN execution.semantic_pnf_sentence_region AS sentence_region
                   ON sentence_region.sentence_id=trigger_token.sentence_id
+                JOIN execution.semantic_pnf_region AS region
+                  ON region.region_id=sentence_region.region_id
+                 AND region.run_ref=trigger_token.run_ref
+                 AND region.document_ref=trigger_token.document_ref
                 JOIN execution.semantic_pnf_demand AS demand
                   ON demand.source_region_id=sentence_region.region_id
                 JOIN execution.semantic_symbol AS residual_symbol
                   ON residual_symbol.symbol_id=demand.residual_type_symbol_id
                 JOIN execution.semantic_symbol AS factor_type_symbol
                   ON factor_type_symbol.symbol_id=demand.expected_factor_type_symbol_id
-               WHERE trigger_token.token_id=residual_row.trigger_token_id
+               WHERE trigger_token.document_ref=residual_row.document_ref
+                 AND trigger_token.start_char=residual_row.trigger_start_char
+                 AND trigger_token.end_char=residual_row.trigger_end_char
                  AND trigger_token.representation_version=2
                  AND demand.lexical_symbol_id=trigger_token.lemma_symbol_id
                  AND residual_symbol.kind_id=13
@@ -113,10 +139,23 @@ BEGIN
               FROM resolution.demand_occurrence_provenance AS provenance
              WHERE provenance.demand_ref=selected_demand_ref
                AND provenance.residual_type_ref=residual_row.residual_type_ref
-               AND provenance.numeric_token_id IS NOT NULL
              ORDER BY provenance.occurrence_role,provenance.ordinal,
                       provenance.parser_token_ref
         LOOP
+            selected_numeric_token_id := NULL;
+            token_count := 0;
+            SELECT count(*),min(token.token_id)
+              INTO token_count,selected_numeric_token_id
+              FROM execution.semantic_parser_token AS token
+             WHERE token.run_ref=selected_run_ref
+               AND token.document_ref=provenance_row.document_ref
+               AND token.start_char=provenance_row.start_char
+               AND token.end_char=provenance_row.end_char
+               AND token.representation_version=2;
+            IF token_count<>1 OR selected_numeric_token_id IS NULL THEN
+                CONTINUE;
+            END IF;
+
             selected_object_id := NULL;
             object_count := 0;
             SELECT count(DISTINCT support.object_id),min(support.object_id)
@@ -124,15 +163,14 @@ BEGIN
               FROM execution.semantic_pnf_object_token_support AS support
               JOIN execution.semantic_pnf_object AS object
                 ON object.object_id=support.object_id
-             WHERE support.token_id=provenance_row.numeric_token_id
+             WHERE support.token_id=selected_numeric_token_id
                AND object.region_id=selected_source_region_id
                AND object.active;
-
             IF object_count<>1 THEN
                 selected_object_id := NULL;
             END IF;
 
-            -- A target without an exact object witness cannot authorize H9.
+            -- A target without an exact object witness is not H9 authority.
             IF provenance_row.occurrence_role=2
                AND selected_object_id IS NULL THEN
                 CONTINUE;
@@ -141,7 +179,7 @@ BEGIN
             PERFORM execution.register_numeric_pnf_demand_occurrence(
                 selected_numeric_demand_id,
                 provenance_row.occurrence_role,
-                provenance_row.numeric_token_id,
+                selected_numeric_token_id,
                 selected_object_id,
                 provenance_row.ordinal,
                 'operational-demand:'||selected_demand_ref
@@ -154,22 +192,17 @@ BEGIN
 END;
 $$;
 
--- This verifier proves only the transport invariant.  It does not claim that a
--- target exists when the producer did not author one.
 CREATE OR REPLACE FUNCTION execution.verify_resolution_demand_occurrence_projection()
 RETURNS TABLE(check_name TEXT,violation_count BIGINT)
 LANGUAGE sql
 STABLE
 AS $$
-    SELECT 'operational_numeric_token_document_mismatch'::TEXT,
+    SELECT 'operational_occurrence_document_mismatch'::TEXT,
            count(*)::BIGINT
       FROM resolution.demand_occurrence_provenance AS provenance
       JOIN resolution.demand AS demand
         ON demand.demand_ref=provenance.demand_ref
-      JOIN execution.semantic_parser_token AS token
-        ON token.token_id=provenance.numeric_token_id
-     WHERE provenance.numeric_token_id IS NOT NULL
-       AND token.document_ref<>demand.scope_ref
+     WHERE provenance.document_ref<>demand.scope_ref
     UNION ALL
     SELECT 'projected_target_without_exact_object_support'::TEXT,
            count(*)::BIGINT

--- a/database/postgres_migrations/README.md
+++ b/database/postgres_migrations/README.md
@@ -151,6 +151,13 @@
   registration run/document/span exact, validates claimed object-token support,
   and exposes a machine invariant over the new provenance carrier. H9 entity
   admission consumes only producer-authored target occurrences.
+- `137_operational_demand_occurrence_projection.sql` bridges the actual
+  `compile_corpus.py` demand carrier (`resolution.demand`) to numeric H3/H6/H9.
+  Producer-authored parser-token references survive even before a numeric parser
+  coordinate is available; exact document coordinates may be filled later.
+  Projection into `semantic_pnf_demand_occurrence_provenance` requires one exact
+  numeric trigger demand and, for targets, one exact object/token witness.
+  Ambiguous or unavailable crosswalks remain unresolved and cannot authorize H9.
 - See `docs/reopenable_runtime_architecture.md`,
   `docs/consumer_sufficient_numeric_runtime.md`,
   `docs/late_external_provider_runtime.md`, and

--- a/database/postgres_migrations/README.md
+++ b/database/postgres_migrations/README.md
@@ -138,6 +138,19 @@
   geometry, one owned sentence, no VERB/AUX clausal content, bounded size, a
   nominal anchor, and a provider-world-bearing NER class. Rejected spans remain
   unresolved parser evidence and cannot create HF/Wikidata work.
+- `134_provider_entity_terminal_boundary.sql` rejects otherwise well-formed raw
+  NER spans whose final token is structurally incomplete (for example an ADP,
+  conjunction, determiner or punctuation token) while retaining the raw parser
+  observation for audit.
+- `135_demand_trigger_target_occurrence.sql` separates producer trigger, semantic
+  target and supporting-evidence occurrences. Factor-derived targets exist only
+  through an explicit residual->typed-role rule and a unique slot/object/token
+  witness; historical lexical-only demands are not backfilled and remain
+  unresolved until genuine compiler replay.
+- `136_demand_occurrence_registration_hardening.sql` makes producer occurrence
+  registration run/document/span exact, validates claimed object-token support,
+  and exposes a machine invariant over the new provenance carrier. H9 entity
+  admission consumes only producer-authored target occurrences.
 - See `docs/reopenable_runtime_architecture.md`,
   `docs/consumer_sufficient_numeric_runtime.md`,
   `docs/late_external_provider_runtime.md`, and

--- a/docs/ci/self_hosted_postgres.md
+++ b/docs/ci/self_hosted_postgres.md
@@ -1,0 +1,19 @@
+# Self-hosted PostgreSQL authority
+
+Self-hosted PostgreSQL validation runs on the `cachy-lambo` runner and uses
+the TrueNAS PostgreSQL application rather than a PostgreSQL server bound to
+the runner's loopback interface.
+
+The repository secret `SENSIBLAW_CI_ADMIN_DATABASE_URL` contains an admin
+connection URL for the TrueNAS maintenance database. Workflows pass that URL
+to `provision_local_postgres`, which creates a uniquely named database for the
+run, applies the migration chain, and reports the disposable database URL to
+later steps. The shared benchmark database is not used by CI.
+
+The secret must not be committed to the repository. If the TrueNAS address,
+port, or password changes, rotate the repository secret rather than editing
+workflow files.
+
+The exact-0008 reference workflow is intentionally separate: it consumes a
+pre-seeded tranche database and is not a disposable migration smoke test. It
+must be migrated independently before being pointed at a new host.

--- a/docs/demand_target_occurrence_provenance.md
+++ b/docs/demand_target_occurrence_provenance.md
@@ -1,0 +1,119 @@
+# Demand trigger and target occurrence provenance
+
+A demand's lexical key is not its semantic world-entity target.
+
+The GWB H9 audit exposed demands whose old occurrence support landed on predicate tokens such as `Believed`, `Begins`, `Drop`, and `Seemed`, while a parser entity span happened to cover nearby name tokens. H9 must not repair that by trimming the entity span or selecting a nearby noun.
+
+The producer contract is now:
+
+```text
+producer
+  -> trigger occurrence: why the demand exists
+  -> target occurrence: what exact token/object the unresolved question is about
+  -> evidence occurrences: other exact tokens supporting the producer derivation
+```
+
+Only the **target occurrence** can authorize H9 world-entity admission.
+
+## Carrier
+
+`semantic_pnf_demand_occurrence_provenance` stores producer-authored occurrence rows:
+
+- role `1`: trigger;
+- role `2`: target;
+- role `3`: evidence.
+
+`register_numeric_pnf_demand_occurrence(...)` is the generic producer API. It rejects a token unless its parser run/document/span belongs to the demand's source region. If an object is supplied, that object must have exact `semantic_pnf_object_token_support` for the same token in the same region.
+
+No nearest-object, lexical similarity, title case, regex, or NER trimming is part of registration.
+
+## Existing numeric factor producer
+
+For current factor-derived demands, a demand replay can recover its producer trigger from already-authored factor structure only when there is exactly one pair satisfying:
+
+```text
+same source region
++ expected factor type
++ factor support token
++ token lemma == demand lexical key
+```
+
+The lexical key is therefore allowed to identify the **trigger** within the factor that generated the demand. It is never promoted to target provenance.
+
+Other factor support tokens become evidence occurrences only.
+
+A target is produced only when the residual type explicitly names a semantic target role. The initial finite rules are:
+
+```text
+legal_object_identity_unresolved -> legal_object
+condition_attachment_unresolved  -> host
+exception_attachment_unresolved  -> host
+norm_bearer_unresolved            -> bearer
+```
+
+The rule must select exactly one factor object carrying exactly one parser-token occurrence. Missing rule, missing slot, or ambiguity leaves the demand without a target.
+
+This means factor-level residuals such as jurisdiction, effective time, modal sense, and generic scope do not receive an entity target merely because a noun exists in the sentence.
+
+## Historical rows and recompilation
+
+Installing migrations 135-136 does **not** backfill historical demand provenance.
+
+Historical rows remain:
+
+```text
+trigger unknown
++ target unknown
+=> H9 external admission unavailable
+```
+
+A genuine compiler replay causes the normal demand `INSERT ... ON CONFLICT UPDATE` path to fire the producer hook against the newly/currently materialized factor graph. Only then can trigger/target/evidence provenance be added.
+
+This distinction is intentional. Re-running a migration over old lexical support would repeat the provenance error instead of correcting it.
+
+## H9 boundary
+
+The old generic occurrence support remains available for compatibility and audits, but H9 parser-entity admission now begins at:
+
+```text
+demand
+-> producer-authored target occurrence
+-> exact target PNF object
+-> exact parser token
+-> quality-valid parser entity span containing that token
+-> consumer world-axis contract
+-> external need
+```
+
+Trigger and evidence tokens are not visible to the provider-entity occurrence bridge.
+
+Rejected or target-less demands remain unresolved. They are not refuted and do not count as evidence that no world entity exists.
+
+## Live audit
+
+After recompiling the affected corpus, run `scripts/report_demand_target_provenance.py` before any HF/Zelph/Wikidata acquisition.
+
+The report shows:
+
+- contract-matched H9 demands;
+- demands with producer triggers;
+- demands with producer targets;
+- exact H9 target support;
+- quality-valid entity targets;
+- residual type;
+- trigger token;
+- target token/object;
+- resulting provider label when one exists;
+- `provider_io_performed: false`.
+
+A healthy result should demonstrate target provenance such as:
+
+```text
+demand -> Bush token/object -> George Bush entity span
+```
+
+rather than attempting to recover:
+
+```text
+demand -> Believed token -> George Bush Believed span -> trim
+```

--- a/scripts/report_demand_target_provenance.py
+++ b/scripts/report_demand_target_provenance.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Audit trigger/target demand provenance without performing provider I/O."""
+from __future__ import annotations
+
+import argparse
+import json
+
+from src.storage.postgres.spacy_parser_model import connect
+
+
+PROVENANCE_STATE = {
+    1: "one_exact_target",
+    2: "multiple_targets",
+    10: "no_producer_occurrence",
+    11: "trigger_only_factor_level",
+    12: "trigger_but_target_role_unresolved",
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--database-url", required=True)
+    parser.add_argument("--consumer-ref", required=True)
+    parser.add_argument("--query-ref", required=True)
+    parser.add_argument("--policy-ref", default="")
+    parser.add_argument("--limit", type=int, default=50)
+    args = parser.parse_args()
+
+    connection = connect(args.database_url)
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                WITH scoped AS (
+                    SELECT DISTINCT admission.demand_id
+                      FROM execution.semantic_pnf_h9_external_admission_v1 AS admission
+                     WHERE admission.consumer_ref=%s
+                       AND admission.query_ref=%s
+                       AND admission.policy_ref=%s
+                       AND admission.contract_id IS NOT NULL
+                )
+                SELECT audit.provenance_state,audit.has_explicit_target_rule,
+                       count(*)::BIGINT
+                  FROM scoped
+                  JOIN execution.semantic_pnf_demand_occurrence_provenance_audit_v1 audit
+                    USING(demand_id)
+                 GROUP BY audit.provenance_state,audit.has_explicit_target_rule
+                 ORDER BY audit.provenance_state,audit.has_explicit_target_rule DESC
+                """,
+                (args.consumer_ref, args.query_ref, args.policy_ref),
+            )
+            provenance_summary = [
+                {
+                    "state": int(state),
+                    "state_name": PROVENANCE_STATE.get(int(state), "unknown"),
+                    "has_explicit_target_rule": bool(has_rule),
+                    "demands": int(count),
+                }
+                for state, has_rule, count in cursor.fetchall()
+            ]
+
+            cursor.execute(
+                """
+                WITH scoped AS (
+                    SELECT DISTINCT admission.demand_id
+                      FROM execution.semantic_pnf_h9_external_admission_v1 AS admission
+                     WHERE admission.consumer_ref=%s
+                       AND admission.query_ref=%s
+                       AND admission.policy_ref=%s
+                       AND admission.contract_id IS NOT NULL
+                )
+                SELECT count(*)::BIGINT,
+                       count(*) FILTER (
+                           WHERE EXISTS (
+                               SELECT 1
+                                 FROM execution.semantic_pnf_demand_trigger_occurrence_v1 t
+                                WHERE t.demand_id=scoped.demand_id
+                           )
+                       )::BIGINT,
+                       count(*) FILTER (
+                           WHERE EXISTS (
+                               SELECT 1
+                                 FROM execution.semantic_pnf_demand_target_occurrence_v1 t
+                                WHERE t.demand_id=scoped.demand_id
+                           )
+                       )::BIGINT,
+                       count(*) FILTER (
+                           WHERE EXISTS (
+                               SELECT 1
+                                 FROM execution.semantic_pnf_demand_h9_target_support_v1 t
+                                WHERE t.demand_id=scoped.demand_id
+                           )
+                       )::BIGINT,
+                       count(*) FILTER (
+                           WHERE EXISTS (
+                               SELECT 1
+                                 FROM execution.semantic_pnf_demand_parser_entity_occurrence_v1 e
+                                WHERE e.demand_id=scoped.demand_id
+                           )
+                       )::BIGINT
+                  FROM scoped
+                """,
+                (args.consumer_ref, args.query_ref, args.policy_ref),
+            )
+            row = cursor.fetchone()
+            funnel = {
+                "contract_matched_demands": int(row[0]),
+                "producer_trigger_demands": int(row[1]),
+                "producer_target_demands": int(row[2]),
+                "h9_exact_target_support_demands": int(row[3]),
+                "quality_valid_entity_target_demands": int(row[4]),
+            }
+
+            cursor.execute(
+                """
+                WITH scoped AS (
+                    SELECT DISTINCT admission.demand_id
+                      FROM execution.semantic_pnf_h9_external_admission_v1 AS admission
+                     WHERE admission.consumer_ref=%s
+                       AND admission.query_ref=%s
+                       AND admission.policy_ref=%s
+                       AND admission.contract_id IS NOT NULL
+                )
+                SELECT demand.demand_id,
+                       residual.symbol_text AS residual_type,
+                       audit.provenance_state,
+                       audit.has_explicit_target_rule,
+                       trigger.producer_ref,
+                       trigger.token_id,
+                       trigger_orth.symbol_text AS trigger_text,
+                       trigger_lemma.symbol_text AS trigger_lemma,
+                       target.token_id,
+                       target_orth.symbol_text AS target_text,
+                       target_lemma.symbol_text AS target_lemma,
+                       target.object_id,
+                       entity_label.symbol_text AS provider_label,
+                       entity_type.symbol_text AS provider_entity_type
+                  FROM scoped
+                  JOIN execution.semantic_pnf_demand AS demand USING(demand_id)
+                  JOIN execution.semantic_symbol AS residual
+                    ON residual.symbol_id=demand.residual_type_symbol_id
+                  JOIN execution.semantic_pnf_demand_occurrence_provenance_audit_v1 AS audit
+                    USING(demand_id)
+                  LEFT JOIN execution.semantic_pnf_demand_trigger_occurrence_v1 AS trigger
+                    USING(demand_id)
+                  LEFT JOIN execution.semantic_parser_token AS trigger_token
+                    ON trigger_token.token_id=trigger.token_id
+                  LEFT JOIN execution.semantic_symbol AS trigger_orth
+                    ON trigger_orth.symbol_id=trigger_token.orth_symbol_id
+                  LEFT JOIN execution.semantic_symbol AS trigger_lemma
+                    ON trigger_lemma.symbol_id=trigger_token.lemma_symbol_id
+                  LEFT JOIN execution.semantic_pnf_demand_target_occurrence_v1 AS target
+                    USING(demand_id)
+                  LEFT JOIN execution.semantic_parser_token AS target_token
+                    ON target_token.token_id=target.token_id
+                  LEFT JOIN execution.semantic_symbol AS target_orth
+                    ON target_orth.symbol_id=target_token.orth_symbol_id
+                  LEFT JOIN execution.semantic_symbol AS target_lemma
+                    ON target_lemma.symbol_id=target_token.lemma_symbol_id
+                  LEFT JOIN execution.semantic_pnf_demand_parser_entity_occurrence_v1 AS entity
+                    ON entity.demand_id=demand.demand_id
+                   AND entity.object_id=target.object_id
+                  LEFT JOIN execution.semantic_symbol AS entity_label
+                    ON entity_label.symbol_id=entity.label_symbol_id
+                  LEFT JOIN execution.semantic_symbol AS entity_type
+                    ON entity_type.symbol_id=entity.entity_type_symbol_id
+                 ORDER BY
+                       (target.token_id IS NOT NULL) DESC,
+                       (entity.entity_id IS NOT NULL) DESC,
+                       demand.demand_id
+                 LIMIT %s
+                """,
+                (
+                    args.consumer_ref,
+                    args.query_ref,
+                    args.policy_ref,
+                    args.limit,
+                ),
+            )
+            sample = [
+                {
+                    "demand_id": int(demand_id),
+                    "residual_type": str(residual_type),
+                    "provenance_state": int(provenance_state),
+                    "provenance_state_name": PROVENANCE_STATE.get(
+                        int(provenance_state), "unknown"
+                    ),
+                    "has_explicit_target_rule": bool(has_rule),
+                    "producer_ref": str(producer_ref) if producer_ref else None,
+                    "trigger_token_id": int(trigger_token_id)
+                    if trigger_token_id is not None
+                    else None,
+                    "trigger_text": str(trigger_text) if trigger_text else None,
+                    "trigger_lemma": str(trigger_lemma) if trigger_lemma else None,
+                    "target_token_id": int(target_token_id)
+                    if target_token_id is not None
+                    else None,
+                    "target_text": str(target_text) if target_text else None,
+                    "target_lemma": str(target_lemma) if target_lemma else None,
+                    "target_object_id": int(target_object_id)
+                    if target_object_id is not None
+                    else None,
+                    "provider_label": str(provider_label) if provider_label else None,
+                    "provider_entity_type": str(provider_entity_type)
+                    if provider_entity_type
+                    else None,
+                }
+                for (
+                    demand_id,
+                    residual_type,
+                    provenance_state,
+                    has_rule,
+                    producer_ref,
+                    trigger_token_id,
+                    trigger_text,
+                    trigger_lemma,
+                    target_token_id,
+                    target_text,
+                    target_lemma,
+                    target_object_id,
+                    provider_label,
+                    provider_entity_type,
+                ) in cursor.fetchall()
+            ]
+    finally:
+        connection.close()
+
+    print(
+        json.dumps(
+            {
+                "funnel": funnel,
+                "provenance_summary": provenance_summary,
+                "sample": sample,
+                "provider_io_performed": False,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/report_operational_demand_occurrence_bridge.py
+++ b/scripts/report_operational_demand_occurrence_bridge.py
@@ -6,9 +6,15 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from pathlib import Path
+import sys
 from typing import Any
 
-from src.storage.postgres.spacy_parser_model import connect
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.storage.postgres.spacy_parser_model import connect  # noqa: E402
 
 
 def _parse_args() -> argparse.Namespace:
@@ -34,26 +40,15 @@ def main() -> int:
             summary = {
                 "operational_demands_with_occurrence_provenance": _scalar(
                     cursor,
-                    """
-                    SELECT count(DISTINCT demand_ref)
-                      FROM resolution.demand_occurrence_provenance
-                    """,
+                    "SELECT count(DISTINCT demand_ref) FROM resolution.demand_occurrence_provenance",
                 ),
                 "operational_trigger_demands": _scalar(
                     cursor,
-                    """
-                    SELECT count(DISTINCT demand_ref)
-                      FROM resolution.demand_occurrence_provenance
-                     WHERE occurrence_role=1
-                    """,
+                    "SELECT count(DISTINCT demand_ref) FROM resolution.demand_occurrence_provenance WHERE occurrence_role=1",
                 ),
                 "operational_target_demands": _scalar(
                     cursor,
-                    """
-                    SELECT count(DISTINCT demand_ref)
-                      FROM resolution.demand_occurrence_provenance
-                     WHERE occurrence_role=2
-                    """,
+                    "SELECT count(DISTINCT demand_ref) FROM resolution.demand_occurrence_provenance WHERE occurrence_role=2",
                 ),
                 "projected_numeric_trigger_demands": _scalar(
                     cursor,

--- a/scripts/report_operational_demand_occurrence_bridge.py
+++ b/scripts/report_operational_demand_occurrence_bridge.py
@@ -50,6 +50,22 @@ def main() -> int:
                     cursor,
                     "SELECT count(DISTINCT demand_ref) FROM resolution.demand_occurrence_provenance WHERE occurrence_role=2",
                 ),
+                "operational_occurrences_without_numeric_coordinates": _scalar(
+                    cursor,
+                    """
+                    SELECT count(*)
+                      FROM resolution.demand_occurrence_provenance
+                     WHERE start_char IS NULL OR end_char IS NULL
+                    """,
+                ),
+                "operational_demands_without_numeric_coordinates": _scalar(
+                    cursor,
+                    """
+                    SELECT count(DISTINCT demand_ref)
+                      FROM resolution.demand_occurrence_provenance
+                     WHERE start_char IS NULL OR end_char IS NULL
+                    """,
+                ),
                 "projected_numeric_trigger_demands": _scalar(
                     cursor,
                     """
@@ -125,7 +141,11 @@ def main() -> int:
                     "demand_ref": str(row[0]),
                     "residual_type": str(row[1]),
                     "trigger_ref": str(row[2]),
-                    "trigger_span": [int(row[3]), int(row[4])],
+                    "trigger_span": (
+                        [int(row[3]), int(row[4])]
+                        if row[3] is not None and row[4] is not None
+                        else None
+                    ),
                     "target_ref": str(row[5]) if row[5] is not None else None,
                     "target_span": (
                         [int(row[6]), int(row[7])]

--- a/scripts/report_operational_demand_occurrence_bridge.py
+++ b/scripts/report_operational_demand_occurrence_bridge.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Report operational->numeric demand occurrence transport without provider I/O."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+
+from src.storage.postgres.spacy_parser_model import connect
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
+    parser.add_argument("--limit", type=int, default=50)
+    args = parser.parse_args()
+    if not args.database_url:
+        parser.error("--database-url or DATABASE_URL is required")
+    return args
+
+
+def _scalar(cursor: Any, sql: str) -> int:
+    cursor.execute(sql)
+    return int(cursor.fetchone()[0])
+
+
+def main() -> int:
+    args = _parse_args()
+    connection = connect(args.database_url)
+    try:
+        with connection.cursor() as cursor:
+            summary = {
+                "operational_demands_with_occurrence_provenance": _scalar(
+                    cursor,
+                    """
+                    SELECT count(DISTINCT demand_ref)
+                      FROM resolution.demand_occurrence_provenance
+                    """,
+                ),
+                "operational_trigger_demands": _scalar(
+                    cursor,
+                    """
+                    SELECT count(DISTINCT demand_ref)
+                      FROM resolution.demand_occurrence_provenance
+                     WHERE occurrence_role=1
+                    """,
+                ),
+                "operational_target_demands": _scalar(
+                    cursor,
+                    """
+                    SELECT count(DISTINCT demand_ref)
+                      FROM resolution.demand_occurrence_provenance
+                     WHERE occurrence_role=2
+                    """,
+                ),
+                "projected_numeric_trigger_demands": _scalar(
+                    cursor,
+                    """
+                    SELECT count(DISTINCT demand_id)
+                      FROM execution.semantic_pnf_demand_occurrence_provenance
+                     WHERE occurrence_role=1
+                       AND producer_ref LIKE 'operational-demand:%'
+                    """,
+                ),
+                "projected_numeric_target_demands": _scalar(
+                    cursor,
+                    """
+                    SELECT count(DISTINCT demand_id)
+                      FROM execution.semantic_pnf_demand_occurrence_provenance
+                     WHERE occurrence_role=2
+                       AND producer_ref LIKE 'operational-demand:%'
+                    """,
+                ),
+                "exact_h9_target_support": _scalar(
+                    cursor,
+                    "SELECT count(DISTINCT demand_id) FROM execution.semantic_pnf_demand_h9_target_support_v1",
+                ),
+                "quality_valid_entity_targets": _scalar(
+                    cursor,
+                    "SELECT count(DISTINCT demand_id) FROM execution.semantic_pnf_demand_parser_entity_occurrence_v1",
+                ),
+                "provider_io_performed": False,
+            }
+            cursor.execute(
+                "SELECT * FROM execution.verify_resolution_demand_occurrence_projection()"
+            )
+            summary["verification"] = {
+                str(row[0]): int(row[1]) for row in cursor.fetchall()
+            }
+            cursor.execute(
+                """
+                SELECT operational.demand_ref,
+                       operational.residual_type_ref,
+                       trigger.parser_token_ref AS trigger_ref,
+                       trigger.start_char AS trigger_start,
+                       trigger.end_char AS trigger_end,
+                       target.parser_token_ref AS target_ref,
+                       target.start_char AS target_start,
+                       target.end_char AS target_end,
+                       target.semantic_role_ref AS target_role,
+                       numeric.demand_id AS numeric_demand_id,
+                       numeric_target.token_id AS numeric_target_token_id,
+                       numeric_target.object_id AS numeric_target_object_id
+                  FROM resolution.demand_occurrence_provenance AS operational
+                  JOIN resolution.demand_occurrence_provenance AS trigger
+                    ON trigger.demand_ref=operational.demand_ref
+                   AND trigger.residual_type_ref=operational.residual_type_ref
+                   AND trigger.occurrence_role=1
+                  LEFT JOIN resolution.demand_occurrence_provenance AS target
+                    ON target.demand_ref=operational.demand_ref
+                   AND target.residual_type_ref=operational.residual_type_ref
+                   AND target.occurrence_role=2
+                  LEFT JOIN execution.semantic_pnf_demand_occurrence_provenance AS numeric
+                    ON numeric.producer_ref='operational-demand:'||operational.demand_ref
+                   AND numeric.occurrence_role=1
+                  LEFT JOIN execution.semantic_pnf_demand_occurrence_provenance AS numeric_target
+                    ON numeric_target.demand_id=numeric.demand_id
+                   AND numeric_target.producer_ref=numeric.producer_ref
+                   AND numeric_target.occurrence_role=2
+                 WHERE operational.occurrence_role=1
+                 ORDER BY operational.demand_ref,operational.residual_type_ref
+                 LIMIT %s
+                """,
+                (max(0, args.limit),),
+            )
+            summary["sample"] = [
+                {
+                    "demand_ref": str(row[0]),
+                    "residual_type": str(row[1]),
+                    "trigger_ref": str(row[2]),
+                    "trigger_span": [int(row[3]), int(row[4])],
+                    "target_ref": str(row[5]) if row[5] is not None else None,
+                    "target_span": (
+                        [int(row[6]), int(row[7])]
+                        if row[6] is not None and row[7] is not None
+                        else None
+                    ),
+                    "target_role": str(row[8]) if row[8] is not None else None,
+                    "numeric_demand_id": int(row[9]) if row[9] is not None else None,
+                    "numeric_target_token_id": int(row[10]) if row[10] is not None else None,
+                    "numeric_target_object_id": int(row[11]) if row[11] is not None else None,
+                }
+                for row in cursor.fetchall()
+            ]
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return 0
+    finally:
+        connection.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pnf/demands.py
+++ b/src/pnf/demands.py
@@ -1,12 +1,111 @@
-"""Backend-free demand projection from open PNF factors."""
+"""Backend-free demand projection from open PNF factors.
+
+Demand provenance is authored here while the factor's typed role bindings are
+still available.  Trigger, target, and evidence occurrences are deliberately
+kept distinct; downstream persistence must not recover a target from lexical
+similarity, neighbourhood, or entity-span containment.
+"""
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Mapping
 
 from src.policy.carriers.canonical import canonical_sha256
 
 from .graph import PNFGraph
+
+
+# These are semantic role contracts of the current generic operator factors,
+# not lexical repair rules.  Producers with an explicit metadata declaration
+# override them below; absence of a target role remains unresolved.
+_TRIGGER_ROLE_BY_FACTOR_TYPE = {
+    "semantic.normative_relation": "conduct",
+    "semantic.legal_condition": "condition",
+    "semantic.legal_exception": "exception",
+    "semantic.legal_transition": "transition",
+}
+_TARGET_ROLE_BY_RESIDUAL = {
+    "legal_object_identity_unresolved": "legal_object",
+    "condition_attachment_unresolved": "host",
+    "exception_attachment_unresolved": "host",
+    "norm_bearer_unresolved": "bearer",
+}
+
+
+def _role_contract(metadata: Mapping[str, Any], factor_type: str) -> tuple[str | None, dict[str, str]]:
+    trigger_role = metadata.get("demand_trigger_role")
+    if trigger_role is None:
+        trigger_role = _TRIGGER_ROLE_BY_FACTOR_TYPE.get(factor_type)
+    declared_targets = metadata.get("demand_target_roles")
+    target_roles = (
+        {str(key): str(value) for key, value in declared_targets.items()}
+        if isinstance(declared_targets, Mapping)
+        else dict(_TARGET_ROLE_BY_RESIDUAL)
+    )
+    return (str(trigger_role) if trigger_role else None, target_roles)
+
+
+def _occurrence_provenance(
+    *,
+    factor_type: str,
+    metadata: Mapping[str, Any],
+    requested_facets: tuple[str, ...],
+) -> tuple[dict[str, Any], ...]:
+    role_bindings = {
+        str(role): str(token_ref)
+        for role, token_ref in (metadata.get("role_bindings") or {}).items()
+        if str(role) and str(token_ref)
+    }
+    provenance_refs = tuple(
+        sorted({str(value) for value in metadata.get("provenance_refs") or () if str(value)})
+    )
+    trigger_role, target_roles = _role_contract(metadata, factor_type)
+    trigger_ref = role_bindings.get(trigger_role or "")
+    producer_ref = str(
+        metadata.get("composition_contract_ref")
+        or metadata.get("producer_contract")
+        or "pnf-demand-role-contract:v1"
+    )
+
+    rows: list[dict[str, Any]] = []
+    for residual_type in requested_facets:
+        target_role = target_roles.get(residual_type)
+        target_ref = role_bindings.get(target_role or "")
+        if trigger_ref:
+            rows.append(
+                {
+                    "residual_type": residual_type,
+                    "occurrence_role": "trigger",
+                    "semantic_role": trigger_role,
+                    "parser_token_ref": trigger_ref,
+                    "producer_ref": producer_ref,
+                }
+            )
+        if target_ref:
+            rows.append(
+                {
+                    "residual_type": residual_type,
+                    "occurrence_role": "target",
+                    "semantic_role": target_role,
+                    "parser_token_ref": target_ref,
+                    "producer_ref": producer_ref,
+                }
+            )
+        excluded = {value for value in (trigger_ref, target_ref) if value}
+        for ordinal, token_ref in enumerate(
+            value for value in provenance_refs if value not in excluded
+        ):
+            rows.append(
+                {
+                    "residual_type": residual_type,
+                    "occurrence_role": "evidence",
+                    "semantic_role": None,
+                    "parser_token_ref": token_ref,
+                    "ordinal": ordinal,
+                    "producer_ref": producer_ref,
+                }
+            )
+    return tuple(rows)
 
 
 def derive_resolution_demands(graph: PNFGraph) -> tuple[dict[str, Any], ...]:
@@ -60,7 +159,7 @@ def derive_resolution_demands(graph: PNFGraph) -> tuple[dict[str, Any], ...]:
             }
             demands.append(
                 {
-                    "schema_version": "sl.factor_resolution_demand.v0_1",
+                    "schema_version": "sl.factor_resolution_demand.v0_2",
                     "demand_ref": f"demand:{canonical_sha256(semantic_key)}",
                     "graph_ref": graph.graph_ref,
                     "factor_ref": factor.factor_ref,
@@ -70,6 +169,13 @@ def derive_resolution_demands(graph: PNFGraph) -> tuple[dict[str, Any], ...]:
                     "formal_role": formal_role,
                     "expected_type_alternatives": list(alternatives),
                     "requested_facets": list(requested_facets),
+                    "occurrence_provenance": list(
+                        _occurrence_provenance(
+                            factor_type=factor.factor_type,
+                            metadata=metadata,
+                            requested_facets=requested_facets,
+                        )
+                    ),
                     "temporal_spatial_constraints": [
                         item
                         for item in constraints

--- a/src/storage/postgres/demand_occurrence_store.py
+++ b/src/storage/postgres/demand_occurrence_store.py
@@ -2,9 +2,9 @@
 
 The operational factor carrier uses immutable ``parser-token:...`` references.
 The numeric parser authority uses a different database-local token identity, so
-this boundary recovers only the token's canonical document coordinates.  The
-later SQL projection selects a concrete numeric parser run and demand, failing
-closed if more than one survives.
+this boundary optionally recovers the token's canonical document coordinates.
+The immutable operational occurrence is persisted even when that numeric tape
+is not available yet; later replay may fill the coordinates and project it.
 """
 
 from __future__ import annotations
@@ -22,10 +22,10 @@ def numeric_parser_token_coordinate_map(
 ) -> dict[str, tuple[int, int]]:
     """Reconstruct operational parser-token refs from exact numeric coordinates.
 
-    ``parser_index`` is the authored token order over the document.  Multiple
+    ``parser_index`` is the authored token order over the document. Multiple
     numeric parser runs may contain the same coordinates; they intentionally
     collapse here because run selection happens later against the exact numeric
-    demand.  No token text participates in the mapping.
+    demand. No token text participates in the mapping.
     """
 
     cursor.execute(
@@ -61,9 +61,10 @@ def persist_resolution_demand_occurrences(
 ) -> int:
     """Persist producer-authored occurrences and project them to numeric PNF.
 
-    Unknown/non-token provenance is ignored rather than guessed.  A demand can
-    therefore persist successfully with zero occurrence rows; that state remains
-    unresolved and cannot authorize H9.
+    A missing numeric coordinate does not erase the producer observation. It is
+    persisted with NULL coordinates and remains non-projectable until a later
+    replay can recover the exact parser coordinate. Unknown semantic roles are
+    ignored rather than guessed.
     """
 
     demand_ref = str(demand["demand_ref"])
@@ -81,10 +82,11 @@ def persist_resolution_demand_occurrences(
         role_id = _OCCURRENCE_ROLE_ID.get(role_name)
         token_ref = str(occurrence.get("parser_token_ref") or "")
         residual_type = str(occurrence.get("residual_type") or "")
-        coordinate = coordinate_map.get(token_ref)
-        if role_id is None or not residual_type or coordinate is None or not document_ref:
+        if role_id is None or not token_ref or not residual_type or not document_ref:
             continue
-        start_char, end_char = coordinate
+        coordinate = coordinate_map.get(token_ref)
+        start_char = coordinate[0] if coordinate is not None else None
+        end_char = coordinate[1] if coordinate is not None else None
         cursor.execute(
             """
             INSERT INTO resolution.demand_occurrence_provenance
@@ -95,7 +97,15 @@ def persist_resolution_demand_occurrences(
             ON CONFLICT (
                 demand_ref,residual_type_ref,occurrence_role,
                 parser_token_ref,ordinal
-            ) DO NOTHING
+            ) DO UPDATE SET
+                start_char=COALESCE(
+                    resolution.demand_occurrence_provenance.start_char,
+                    EXCLUDED.start_char
+                ),
+                end_char=COALESCE(
+                    resolution.demand_occurrence_provenance.end_char,
+                    EXCLUDED.end_char
+                )
             """,
             (
                 demand_ref,
@@ -112,7 +122,7 @@ def persist_resolution_demand_occurrences(
         )
         inserted += int(cursor.rowcount or 0)
 
-    # Projection is idempotent and fail-closed.  It may return zero when the
+    # Projection is idempotent and fail-closed. It may return zero when the
     # numeric demand carrier has not yet been built or when historical runs are
     # ambiguous; neither case is negative semantic evidence.
     cursor.execute(

--- a/src/storage/postgres/demand_occurrence_store.py
+++ b/src/storage/postgres/demand_occurrence_store.py
@@ -1,0 +1,129 @@
+"""Exact operational-demand occurrence persistence into PostgreSQL.
+
+The operational factor carrier uses immutable ``parser-token:...`` references.
+The numeric parser authority uses a different database-local token identity, so
+this boundary recovers only the token's canonical document coordinates.  The
+later SQL projection selects a concrete numeric parser run and demand, failing
+closed if more than one survives.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from src.policy.carriers.canonical import canonical_sha256
+
+
+_OCCURRENCE_ROLE_ID = {"trigger": 1, "target": 2, "evidence": 3}
+
+
+def numeric_parser_token_coordinate_map(
+    cursor: Any, *, document_ref: str
+) -> dict[str, tuple[int, int]]:
+    """Reconstruct operational parser-token refs from exact numeric coordinates.
+
+    ``parser_index`` is the authored token order over the document.  Multiple
+    numeric parser runs may contain the same coordinates; they intentionally
+    collapse here because run selection happens later against the exact numeric
+    demand.  No token text participates in the mapping.
+    """
+
+    cursor.execute(
+        """
+        SELECT DISTINCT token.start_char, token.end_char
+          FROM execution.semantic_parser_token AS token
+         WHERE token.document_ref = %s
+           AND token.representation_version = 2
+         ORDER BY token.start_char, token.end_char
+        """,
+        (document_ref,),
+    )
+    coordinates = tuple((int(row[0]), int(row[1])) for row in cursor.fetchall())
+    return {
+        "parser-token:"
+        + canonical_sha256(
+            {
+                "document_ref": document_ref,
+                "parser_index": parser_index,
+                "start": start_char,
+                "end": end_char,
+            }
+        ): (start_char, end_char)
+        for parser_index, (start_char, end_char) in enumerate(coordinates)
+    }
+
+
+def persist_resolution_demand_occurrences(
+    cursor: Any,
+    *,
+    demand: Mapping[str, Any],
+    coordinate_map: Mapping[str, tuple[int, int]],
+) -> int:
+    """Persist producer-authored occurrences and project them to numeric PNF.
+
+    Unknown/non-token provenance is ignored rather than guessed.  A demand can
+    therefore persist successfully with zero occurrence rows; that state remains
+    unresolved and cannot authorize H9.
+    """
+
+    demand_ref = str(demand["demand_ref"])
+    document_ref = str(
+        demand.get("document_scope")
+        or demand.get("scope_ref")
+        or demand.get("document_ref")
+        or ""
+    )
+    inserted = 0
+    for occurrence in demand.get("occurrence_provenance") or ():
+        if not isinstance(occurrence, Mapping):
+            continue
+        role_name = str(occurrence.get("occurrence_role") or "")
+        role_id = _OCCURRENCE_ROLE_ID.get(role_name)
+        token_ref = str(occurrence.get("parser_token_ref") or "")
+        residual_type = str(occurrence.get("residual_type") or "")
+        coordinate = coordinate_map.get(token_ref)
+        if role_id is None or not residual_type or coordinate is None or not document_ref:
+            continue
+        start_char, end_char = coordinate
+        cursor.execute(
+            """
+            INSERT INTO resolution.demand_occurrence_provenance
+                (demand_ref,residual_type_ref,occurrence_role,
+                 parser_token_ref,document_ref,start_char,end_char,
+                 semantic_role_ref,ordinal,producer_ref)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            ON CONFLICT (
+                demand_ref,residual_type_ref,occurrence_role,
+                parser_token_ref,ordinal
+            ) DO NOTHING
+            """,
+            (
+                demand_ref,
+                residual_type,
+                role_id,
+                token_ref,
+                document_ref,
+                start_char,
+                end_char,
+                occurrence.get("semantic_role"),
+                int(occurrence.get("ordinal") or 0),
+                str(occurrence.get("producer_ref") or "operational-demand:v1"),
+            ),
+        )
+        inserted += int(cursor.rowcount or 0)
+
+    # Projection is idempotent and fail-closed.  It may return zero when the
+    # numeric demand carrier has not yet been built or when historical runs are
+    # ambiguous; neither case is negative semantic evidence.
+    cursor.execute(
+        "SELECT execution.project_resolution_demand_occurrence_to_numeric_pnf(%s)",
+        (demand_ref,),
+    )
+    cursor.fetchone()
+    return inserted
+
+
+__all__ = [
+    "numeric_parser_token_coordinate_map",
+    "persist_resolution_demand_occurrences",
+]

--- a/src/storage/postgres/operational_build_store.py
+++ b/src/storage/postgres/operational_build_store.py
@@ -8,13 +8,32 @@ from src.policy.carriers.canonical import canonical_sha256
 
 
 _OPERATION_REF = "compiler.document.local-binding"
-# v0_9 adds producer-authored demand occurrence provenance.  Completed v0_8
-# builds must not be reused because their persisted demands predate that carrier.
+# v0_9 adds producer-authored demand occurrence provenance. Completed v0_8
+# receipts cannot satisfy this operation even when all earlier stage inputs are
+# byte-identical.
 _OPERATION_VERSION = "v0_9"
 
 
 def _digest(value: str) -> bytes:
     return bytes.fromhex(value)
+
+
+def _receipt_build_key(build_key_sha256: str) -> str:
+    """Namespace the execution receipt key by operation semantics.
+
+    ``execution.build.build_key_sha256`` is globally unique.  Reusing the raw
+    stage key under a new operation version would collide with the historical
+    v0_8 receipt, so the durable receipt gets an operation-versioned key while
+    the caller's semantic stage key remains unchanged.
+    """
+
+    return canonical_sha256(
+        {
+            "operation_ref": _OPERATION_REF,
+            "operation_version": _OPERATION_VERSION,
+            "stage_build_key_sha256": build_key_sha256,
+        }
+    )
 
 
 def operational_build_ref(
@@ -29,7 +48,7 @@ def operational_build_ref(
             "operation_version": _OPERATION_VERSION,
             "document_ref": document_ref,
             "compiler_contract_ref": compiler_contract_ref,
-            "build_key_sha256": build_key_sha256,
+            "build_key_sha256": _receipt_build_key(build_key_sha256),
         }
     )
 
@@ -41,6 +60,7 @@ def load_completed_operational_build(
     compiler_contract_ref: str,
     build_key_sha256: str,
 ) -> tuple[str, ...] | None:
+    receipt_key = _receipt_build_key(build_key_sha256)
     cursor.execute(
         """
         SELECT document_build.build_ref
@@ -59,7 +79,7 @@ def load_completed_operational_build(
         (
             document_ref,
             compiler_contract_ref,
-            _digest(build_key_sha256),
+            _digest(receipt_key),
             _OPERATION_REF,
             _OPERATION_VERSION,
         ),
@@ -89,6 +109,7 @@ def persist_completed_operational_build(
     graph_ref: str,
     demand_refs: Sequence[str],
 ) -> str:
+    receipt_key = _receipt_build_key(build_key_sha256)
     build_ref = operational_build_ref(
         document_ref=document_ref,
         compiler_contract_ref=compiler_contract_ref,
@@ -114,7 +135,7 @@ def persist_completed_operational_build(
             build_ref,
             _OPERATION_REF,
             _OPERATION_VERSION,
-            _digest(build_key_sha256),
+            _digest(receipt_key),
             graph_ref,
         ),
     )
@@ -140,7 +161,7 @@ def persist_completed_operational_build(
             build_ref,
             document_ref,
             compiler_contract_ref,
-            _digest(build_key_sha256),
+            _digest(receipt_key),
             graph_ref,
         ),
     )

--- a/src/storage/postgres/operational_build_store.py
+++ b/src/storage/postgres/operational_build_store.py
@@ -8,7 +8,9 @@ from src.policy.carriers.canonical import canonical_sha256
 
 
 _OPERATION_REF = "compiler.document.local-binding"
-_OPERATION_VERSION = "v0_8"
+# v0_9 adds producer-authored demand occurrence provenance.  Completed v0_8
+# builds must not be reused because their persisted demands predate that carrier.
+_OPERATION_VERSION = "v0_9"
 
 
 def _digest(value: str) -> bytes:
@@ -50,9 +52,17 @@ def load_completed_operational_build(
         WHERE document_build.document_ref = %s
           AND document_build.compiler_contract_ref = %s
           AND document_build.build_key_sha256 = %s
+          AND build.operation_ref = %s
+          AND build.operation_version = %s
           AND build.build_state_ref = 'completed'
         """,
-        (document_ref, compiler_contract_ref, _digest(build_key_sha256)),
+        (
+            document_ref,
+            compiler_contract_ref,
+            _digest(build_key_sha256),
+            _OPERATION_REF,
+            _OPERATION_VERSION,
+        ),
     )
     row = cursor.fetchone()
     if row is None:

--- a/src/storage/postgres/semantic_store.py
+++ b/src/storage/postgres/semantic_store.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from typing import Any, Mapping, Sequence
 
 from src.policy.carriers.canonical import canonical_sha256
+from src.storage.postgres.demand_occurrence_store import (
+    numeric_parser_token_coordinate_map,
+    persist_resolution_demand_occurrences,
+)
 from src.storage.postgres.factor_revision_store import (
     factor_revision_payload,
     factor_revision_ref,
@@ -141,6 +145,7 @@ def persist_resolution_artifacts(
     refinements: Sequence[Mapping[str, Any]],
 ) -> tuple[str, ...]:
     demand_refs: list[str] = []
+    token_coordinates_by_document: dict[str, dict[str, tuple[int, int]]] = {}
     for row in evidence:
         cursor.execute(
             """
@@ -208,6 +213,22 @@ def persist_resolution_artifacts(
                 VALUES (%s, %s) ON CONFLICT DO NOTHING
                 """,
                 (demand_ref, str(facet)),
+            )
+
+        # The operational compiler is the producer that still has the typed
+        # role bindings. Preserve those exact occurrences here, before the
+        # demand is flattened into downstream runtime indexes.
+        if row.get("occurrence_provenance"):
+            coordinate_map = token_coordinates_by_document.get(scope_ref)
+            if coordinate_map is None:
+                coordinate_map = numeric_parser_token_coordinate_map(
+                    cursor, document_ref=scope_ref
+                )
+                token_coordinates_by_document[scope_ref] = coordinate_map
+            persist_resolution_demand_occurrences(
+                cursor,
+                demand=row,
+                coordinate_map=coordinate_map,
             )
     for row in meets:
         cursor.execute(

--- a/tests/test_demand_trigger_target_provenance_contract.py
+++ b/tests/test_demand_trigger_target_provenance_contract.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+M135 = (ROOT / "database/postgres_migrations/135_demand_trigger_target_occurrence.sql").read_text()
+M136 = (ROOT / "database/postgres_migrations/136_demand_occurrence_registration_hardening.sql").read_text()
+REPORT = (ROOT / "scripts/report_demand_target_provenance.py").read_text()
+
+
+def test_carrier_splits_trigger_target_and_evidence_occurrences() -> None:
+    assert "semantic_pnf_demand_occurrence_provenance" in M135
+    assert "occurrence_role SMALLINT" in M135
+    assert "occurrence_role=1" in M135
+    assert "occurrence_role=2" in M135
+    assert "occurrence_role=3" in M135
+    assert "semantic_pnf_demand_trigger_occurrence_v1" in M135
+    assert "semantic_pnf_demand_target_occurrence_v1" in M135
+    assert "semantic_pnf_demand_evidence_occurrence_v1" in M135
+
+
+def test_generic_registration_requires_explicit_role_and_exact_object_support() -> None:
+    assert "register_numeric_pnf_demand_occurrence" in M135
+    assert "selected_occurrence_role NOT IN (1,2,3)" in M135
+    assert "semantic_pnf_object_token_support" in M135
+    assert "support.token_id=selected_token_id" in M135
+    assert "object.region_id=selected_source_region_id" in M135
+
+
+def test_registration_is_document_scoped_not_offset_only() -> None:
+    assert "token.run_ref=region.run_ref" in M136
+    assert "token.document_ref=region.document_ref" in M136
+    assert "token.start_char>=region.start_char" in M136
+    assert "token.end_char<=region.end_char" in M136
+    assert "verify_numeric_pnf_demand_occurrence_provenance" in M136
+
+
+def test_factor_producer_uses_exact_support_token_for_trigger() -> None:
+    assert "semantic_pnf_factor_token_support" in M135
+    assert "factor.factor_type_symbol_id=NEW.expected_factor_type_symbol_id" in M135
+    assert "token.lemma_symbol_id=NEW.lexical_symbol_id" in M135
+    assert "producer_match_count<>1" in M135
+    assert "NEW.demand_id,1::SMALLINT,selected_trigger_token_id" in M135
+
+
+def test_factor_support_is_evidence_not_automatic_target() -> None:
+    evidence = M135.split("Preserve all other exact factor-support tokens as evidence", 1)[1]
+    evidence = evidence.split("SELECT rule.target_role_symbol_id", 1)[0]
+    assert "3::SMALLINT" in evidence
+    assert "2::SMALLINT" not in evidence
+
+
+def test_target_requires_explicit_residual_to_role_rule() -> None:
+    assert "semantic_pnf_demand_target_role_rule" in M135
+    assert "legal_object_identity_unresolved" in M135
+    assert "'legal_object'" in M135
+    assert "condition_attachment_unresolved" in M135
+    assert "exception_attachment_unresolved" in M135
+    assert "norm_bearer_unresolved" in M135
+    assert "No target-role rule means" in M135
+    assert "selected_target_role_id IS NULL" in M135
+
+
+def test_target_requires_unique_typed_factor_slot_and_exact_token_object() -> None:
+    assert "edge.factor_id=selected_factor_id" in M135
+    assert "edge.role_symbol_id=selected_target_role_id" in M135
+    assert "support.object_id=edge.object_id" in M135
+    assert "target_match_count<>1" in M135
+    assert "NEW.demand_id,2::SMALLINT,selected_target_token_id" in M135
+
+
+def test_migration_install_does_not_backfill_historical_demands() -> None:
+    lowered = M135.lower()
+    assert "historical demand rows" in lowered
+    assert "not backfilled" in lowered
+    assert "update execution.semantic_pnf_demand\n   set" not in lowered
+    assert "insert into execution.semantic_pnf_demand_occurrence_provenance\n    select demand.demand_id" not in lowered
+
+
+def test_recompile_path_fires_on_insert_and_existing_demand_update() -> None:
+    assert "AFTER INSERT OR UPDATE OF" in M135
+    assert "state,source_region_id,expected_factor_type_symbol_id" in M135
+    assert "record_numeric_pnf_demand_occurrence_provenance" in M135
+
+
+def test_h9_consumes_only_producer_target_occurrence() -> None:
+    assert "semantic_pnf_demand_h9_target_support_v1" in M135
+    safe = M135.split(
+        "CREATE OR REPLACE VIEW execution.semantic_pnf_demand_parser_entity_occurrence_v1",
+        1,
+    )[1]
+    safe = safe.split(
+        "CREATE OR REPLACE VIEW execution.semantic_pnf_demand_raw_parser_entity_occurrence_v1",
+        1,
+    )[0]
+    assert "semantic_pnf_demand_h9_target_support_v1" in safe
+    assert "semantic_pnf_demand_strong_occurrence_support_v1" not in safe
+    assert "semantic_pnf_demand_trigger_occurrence_v1" not in safe
+
+
+def test_historical_provider_origins_are_withdrawn_not_deleted() -> None:
+    assert "UPDATE execution.semantic_pnf_consumer_external_need_origin" in M135
+    assert "SET active=FALSE" in M135
+    assert "DELETE FROM execution.semantic_pnf_consumer_external_need_origin" not in M135
+
+
+def test_no_textual_nearest_noun_recovery_is_added() -> None:
+    lowered = M135.lower()
+    for forbidden in ("regexp", " regex", " like ", "ilike", "similar to"):
+        assert forbidden not in lowered
+    assert "nearby noun" in lowered
+
+
+def test_live_report_is_no_provider_io_and_surfaces_trigger_target_split() -> None:
+    assert "semantic_pnf_demand_trigger_occurrence_v1" in REPORT
+    assert "semantic_pnf_demand_target_occurrence_v1" in REPORT
+    assert "semantic_pnf_demand_h9_target_support_v1" in REPORT
+    assert "semantic_pnf_demand_parser_entity_occurrence_v1" in REPORT
+    assert '"provider_io_performed": False' in REPORT

--- a/tests/test_operational_demand_occurrence_projection_contract.py
+++ b/tests/test_operational_demand_occurrence_projection_contract.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.pnf.demands import derive_resolution_demands
+from src.pnf.graph import PNFGraph
+from src.policy.algebra import Factor
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _factor(
+    *,
+    factor_type: str,
+    role_bindings: dict[str, str],
+    provenance_refs: tuple[str, ...],
+    residuals: tuple[str, ...],
+) -> Factor[object]:
+    return Factor(
+        factor_ref=f"factor:{factor_type}",
+        factor_type=factor_type,
+        residuals=residuals,
+        closure_state="requires_external_resolution",
+        metadata={
+            "role_bindings": role_bindings,
+            "provenance_refs": provenance_refs,
+            "composition_contract_ref": "grammar:semantic:operator-composition:v0_1",
+        },
+    )
+
+
+def test_transition_demand_carries_distinct_trigger_and_target() -> None:
+    graph = PNFGraph(
+        graph_ref="graph:test",
+        document_ref="document:test",
+        factors=(
+            _factor(
+                factor_type="semantic.legal_transition",
+                role_bindings={
+                    "transition": "parser-token:repeal",
+                    "legal_object": "parser-token:act",
+                },
+                provenance_refs=("parser-token:repeal",),
+                residuals=(
+                    "legal_object_identity_unresolved",
+                    "effective_time_unresolved",
+                ),
+            ),
+        ),
+    )
+
+    (demand,) = derive_resolution_demands(graph)
+    provenance = demand["occurrence_provenance"]
+    legal_object_rows = [
+        row
+        for row in provenance
+        if row["residual_type"] == "legal_object_identity_unresolved"
+    ]
+    assert any(
+        row["occurrence_role"] == "trigger"
+        and row["parser_token_ref"] == "parser-token:repeal"
+        for row in legal_object_rows
+    )
+    assert any(
+        row["occurrence_role"] == "target"
+        and row["parser_token_ref"] == "parser-token:act"
+        for row in legal_object_rows
+    )
+    effective_time_rows = [
+        row
+        for row in provenance
+        if row["residual_type"] == "effective_time_unresolved"
+    ]
+    assert any(row["occurrence_role"] == "trigger" for row in effective_time_rows)
+    assert not any(row["occurrence_role"] == "target" for row in effective_time_rows)
+
+
+def test_missing_typed_target_role_stays_targetless() -> None:
+    graph = PNFGraph(
+        graph_ref="graph:test",
+        document_ref="document:test",
+        factors=(
+            _factor(
+                factor_type="semantic.normative_relation",
+                role_bindings={"conduct": "parser-token:believed"},
+                provenance_refs=("parser-token:may", "parser-token:believed"),
+                residuals=("norm_bearer_unresolved", "jurisdiction_unresolved"),
+            ),
+        ),
+    )
+
+    (demand,) = derive_resolution_demands(graph)
+    provenance = demand["occurrence_provenance"]
+    assert any(
+        row["occurrence_role"] == "trigger"
+        and row["parser_token_ref"] == "parser-token:believed"
+        for row in provenance
+    )
+    assert not any(row["occurrence_role"] == "target" for row in provenance)
+
+
+def test_condition_attachment_uses_typed_host_not_nearby_evidence() -> None:
+    graph = PNFGraph(
+        graph_ref="graph:test",
+        document_ref="document:test",
+        factors=(
+            _factor(
+                factor_type="semantic.legal_condition",
+                role_bindings={
+                    "condition": "parser-token:applies",
+                    "host": "parser-token:provision",
+                },
+                provenance_refs=("parser-token:if", "parser-token:applies"),
+                residuals=("condition_attachment_unresolved",),
+            ),
+        ),
+    )
+
+    (demand,) = derive_resolution_demands(graph)
+    provenance = demand["occurrence_provenance"]
+    assert any(
+        row["occurrence_role"] == "target"
+        and row["semantic_role"] == "host"
+        and row["parser_token_ref"] == "parser-token:provision"
+        for row in provenance
+    )
+    assert not any(
+        row["occurrence_role"] == "target"
+        and row["parser_token_ref"] == "parser-token:if"
+        for row in provenance
+    )
+
+
+def test_persistence_projects_only_exact_coordinate_provenance() -> None:
+    store_source = (
+        ROOT / "src/storage/postgres/demand_occurrence_store.py"
+    ).read_text(encoding="utf-8")
+    semantic_source = (
+        ROOT / "src/storage/postgres/semantic_store.py"
+    ).read_text(encoding="utf-8")
+    migration = (
+        ROOT
+        / "database/postgres_migrations/137_operational_demand_occurrence_projection.sql"
+    ).read_text(encoding="utf-8")
+
+    assert "numeric_parser_token_coordinate_map" in semantic_source
+    assert "persist_resolution_demand_occurrences" in semantic_source
+    assert "token text" not in store_source.lower()
+    assert "start_char" in migration and "end_char" in migration
+    assert "candidate_count<>1" in migration
+    assert "object_count<>1" in migration
+    assert "register_numeric_pnf_demand_occurrence" in migration
+    assert "nearest-noun" in migration
+    assert "LIKE 'operational-demand:%'" in migration
+
+
+def test_pre_provenance_completed_builds_are_not_reused() -> None:
+    source = (
+        ROOT / "src/storage/postgres/operational_build_store.py"
+    ).read_text(encoding="utf-8")
+    assert '_OPERATION_VERSION = "v0_9"' in source
+    assert "build.operation_version = %s" in source

--- a/tests/test_operational_demand_occurrence_projection_contract.py
+++ b/tests/test_operational_demand_occurrence_projection_contract.py
@@ -146,7 +146,8 @@ def test_persistence_projects_only_exact_coordinate_provenance() -> None:
 
     assert "numeric_parser_token_coordinate_map" in semantic_source
     assert "persist_resolution_demand_occurrences" in semantic_source
-    assert "token text" not in store_source.lower()
+    assert ".casefold(" not in store_source
+    assert "symbol_text" not in store_source
     assert "start_char" in migration and "end_char" in migration
     assert "candidate_count<>1" in migration
     assert "object_count<>1" in migration


### PR DESCRIPTION
## Summary

Move H9 occurrence authority to the actual demand-producing compiler path. A demand now has producer-authored **trigger**, **target**, and **evidence** occurrences, and H9 consumes only an exact target occurrence that survives the existing provider-entity quality gate.

This remains stacked on `agent/provider-entity-quality-boundary`, where malformed spaCy NER spans were already rejected and provider I/O was held at zero.

## Live evidence

The first post-136 GWB replay made the remaining seam explicit:

- 6 documents compiled successfully;
- 4 failed only because the local temporary filesystem returned `Errno 122` quota errors;
- initial H9-stage demand population: 53,935;
- H3 evidence rows: 735,057;
- H3-supported demands: 52,340;
- H6 evidence rows: 53,247;
- H6-supported demands: 4,170;
- H6 preferred candidates: 512;
- H6 residual demands: 52,340;
- active external needs: 0;
- active provider requests: 0;
- producer trigger demands: 0;
- producer target demands: 0;
- exact H9 target support: 0;
- quality-valid entity targets: 0.

The observer's 1,130 provider-request rows are historical/inactive receipts, not live work.

Those zero producer counts were not evidence that the role rules found no targets. The replay command itself was using a different carrier.

## Root cause: two demand carriers

`compile_corpus.py` calls `compile_directory_postgres(...)`, whose default executor is `persist_document_compilation`. That path derives operational `resolution_demands` and persists them through `persist_resolution_artifacts()` into `resolution.demand`.

Migrations 135-136 were attached to `execution.semantic_pnf_demand`, the numeric H3/H6/H9 carrier. Therefore a normal `compile_corpus.py` replay could complete successfully while never reaching the new producer hook.

The fix is now explicit rather than attempting more reverse inference in H9.

## Operational producer contract

`src/pnf/demands.py` now emits `sl.factor_resolution_demand.v0_2` with facet-specific `occurrence_provenance` while typed factor role bindings still exist.

Roles are:

1. **trigger** — exact parser token whose factor relation caused this residual demand;
2. **target** — exact parser token named by the residual's semantic factor role;
3. **evidence** — other producer-observed parser tokens.

Current generic operator contracts are structural:

- normative relation trigger -> `conduct`;
- legal condition trigger -> `condition`;
- legal exception trigger -> `exception`;
- legal transition trigger -> `transition`;
- `legal_object_identity_unresolved` target -> `legal_object`;
- `condition_attachment_unresolved` target -> `host`;
- `exception_attachment_unresolved` target -> `host`;
- `norm_bearer_unresolved` target -> `bearer`.

A producer may explicitly declare replacement role mappings in factor metadata. If the target role is not present, the residual remains target-less. There is no nearest noun, capitalization, lexical similarity, NER trimming, or surrounding-span repair.

Thus a transition can produce:

```text
repeal the Act
trigger: repeal
legal_object_identity target: Act
effective_time target: absent
```

while a factor-level jurisdiction residual remains trigger-only.

## Operational -> numeric bridge

Migration 137 adds `resolution.demand_occurrence_provenance` and the exact projection
`execution.project_resolution_demand_occurrence_to_numeric_pnf(...)`.

The operational compiler's immutable `parser-token:` reference is persisted even when the numeric parser tape is not yet available. Exact `(document_ref, start_char, end_char)` coordinates are filled when recoverable; unresolved coordinates remain explicit rather than causing the producer observation to disappear.

Projection into the numeric carrier requires:

- exact trigger document/span;
- one concrete numeric parser run/sentence region;
- matching numeric factor type;
- matching residual type;
- numeric demand lexical key equal to the exact trigger token lemma;
- exactly one numeric demand candidate.

Target projection additionally requires exactly one active PNF object in that source region supporting the exact target token. Ambiguity or missing coordinates simply leaves the occurrence unprojected.

The resulting path is:

```text
operational factor role binding
-> resolution demand occurrence provenance
-> exact parser coordinate crosswalk
-> unique numeric demand
-> producer-authored numeric target occurrence
-> provider entity quality gate
-> consumer world-axis contract
-> H9 external need
```

## Existing numeric safety

Migrations 135-136 remain the numeric-side contract:

- trigger, target and evidence occupy distinct rows;
- generic producer registration validates exact run/document/source-region membership;
- a claimed object must support the exact parser token;
- historical lexical-only demands are never guessed into targets;
- H9 entity admission sees target occurrences only;
- stale external origins are deactivated, not deleted.

## Completed-build replay safety

The successful six documents would otherwise be eligible for completed-build reuse, which would replay pre-provenance `resolution.demand` rows and reproduce zero occurrence rows.

`operational_build_store.py` therefore advances the local-binding operation receipt to `v0_9`. Its durable build key is namespaced by operation version, avoiding the global `execution.build.build_key_sha256` uniqueness collision with historical v0_8 receipts while leaving the semantic stage build key unchanged.

This forces the required producer replay without rewriting historical build receipts.

## Audit surfaces

`scripts/report_operational_demand_occurrence_bridge.py` performs zero provider I/O and reports:

- operational demands with occurrence provenance;
- operational trigger demands;
- operational target demands;
- occurrences/demands whose numeric coordinates are still unavailable;
- projected numeric trigger demands;
- projected numeric target demands;
- exact H9 target support;
- quality-valid entity targets;
- projection invariant violations;
- bounded trigger/target samples;
- `provider_io_performed: false`.

`scripts/report_demand_target_provenance.py` remains the downstream H9-facing audit.

## Next live gate

1. Apply migration 137.
2. Replay under the v0.9 operational-build identity.
3. Redirect `TMPDIR`/`TMP`/`TEMP` to the spacious local `/home` filesystem for the four documents previously blocked by the temp quota.
4. Run the operational occurrence bridge report.
5. Inspect in order:
   - operational triggers > 0;
   - operational targets > 0 only for explicitly target-bearing residuals;
   - unresolved numeric-coordinate count;
   - numeric trigger/target projection counts;
   - exact target object samples;
   - quality-valid entity targets.
6. Do not perform HF/Zelph/Wikidata I/O until those samples are semantically clean.

If operational occurrence rows exist but numeric projection remains zero, the report now localises the failure to the crosswalk/numeric-demand matching layer rather than conflating it with demand production.

## Validation boundary

Added source-contract coverage for typed trigger/target derivation, target-less residuals, exact coordinate projection, ambiguity fail-closed behavior, object-token target requirements, durable unresolved operational occurrences, and v0.9 completed-build invalidation.

No GitHub Actions or CodeRabbit were invoked. No HF/Zelph/Wikidata call was made. The new tranche is not claimed live until migration 137 and the v0.9 replay are run against the GWB database.