### PR TITLE
Make closure-owner handoff incremental

### DIFF
--- a/.github/workflows/bounded-pnf-retention.yml
+++ b/.github/workflows/bounded-pnf-retention.yml
@@ -18,11 +18,13 @@ on:
       - "scripts/run_exact_0008_calibration.py"
       - "scripts/run_exact_0008_parallel_acceptance.py"
       - "scripts/run_post_closure_probe.py"
+      - "scripts/benchmark_owner_handoff_bookkeeping.py"
       - "scripts/normalize_exact_0008_baseline.py"
       - "tests/pnf/**"
       - "tests/policy/**"
       - "tests/runtime/**"
       - "tests/storage/**"
+      - "tests/test_owner_handoff_performance_contract.py"
       - "docs/bounded_document_execution.md"
       - "docs/distributed_semantic_execution.md"
       - "docs/hierarchical_graph_execution.md"
@@ -50,18 +52,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install environment
+      - name: Use provisioned self-hosted environment
+        shell: bash
         run: |
-          python -m pip install --upgrade pip uv
-          uv sync --frozen --extra test --extra dev
+          set -euo pipefail
+          ci_venv="${SENSIBLAW_CI_VENV:-/home/c/Documents/code/ITIR-suite/.venv}"
+          test -x "${ci_venv}/bin/python"
+          "${ci_venv}/bin/python" -VV
+          "${ci_venv}/bin/python" -m ruff --version
+          "${ci_venv}/bin/python" -m pytest --version
+          printf 'SENSIBLAW_CI_PYTHON=%s\n' "${ci_venv}/bin/python" >> "${GITHUB_ENV}"
 
       - name: Lint bounded and distributed execution surfaces
         run: |
-          uv run ruff check \
+          "${SENSIBLAW_CI_PYTHON}" -m ruff check \
             src/pnf/__init__.py \
             src/pnf/bounded_streaming_owner.py \
             src/pnf/fibred_build_projection.py \
@@ -80,6 +84,8 @@ jobs:
             src/policy/stage_budget_execution.py \
             src/policy/semantic_receipt_enrichment.py \
             src/policy/manifest_stream_validation.py \
+            src/policy/owner_handoff_batch_performance.py \
+            src/policy/owner_handoff_performance.py \
             src/runtime/checkpoint_retention.py \
             src/runtime/distributed_semantic_worker.py \
             src/runtime/reference_parity.py \
@@ -94,6 +100,7 @@ jobs:
             scripts/run_exact_0008_parallel_acceptance.py \
             scripts/run_post_closure_probe.py \
             scripts/normalize_exact_0008_baseline.py \
+            scripts/benchmark_owner_handoff_bookkeeping.py \
             tests/pnf/test_streaming_build_reader.py \
             tests/policy/test_closure_liveness_execution.py \
             tests/policy/test_progress_observability_execution.py \
@@ -104,11 +111,12 @@ jobs:
             tests/runtime/test_reference_receipt.py \
             tests/runtime/test_stage_memory_budget.py \
             tests/storage/test_distributed_semantic_execution_store.py \
-            tests/storage/test_reference_publication_authority.py
+            tests/storage/test_reference_publication_authority.py \
+            tests/test_owner_handoff_performance_contract.py
 
       - name: Check formatting
         run: |
-          uv run ruff format --check \
+          "${SENSIBLAW_CI_PYTHON}" -m ruff format --check \
             src/pnf/fibred_build_projection.py \
             src/pnf/streaming_build_reader.py \
             src/pnf/streaming_reduction_projection.py \
@@ -117,6 +125,8 @@ jobs:
             src/policy/closure_finalization_hardening.py \
             src/policy/reference_backed_finalization.py \
             src/policy/fibred_operational_corpus_compilation.py \
+            src/policy/owner_handoff_batch_performance.py \
+            src/policy/owner_handoff_performance.py \
             src/policy/progress_observability_execution.py \
             src/policy/stage_budget_execution.py \
             src/policy/semantic_receipt_enrichment.py \
@@ -131,6 +141,7 @@ jobs:
             src/storage/postgres/reference_streaming_semantic_store.py \
             scripts/run_exact_0008_parallel_acceptance.py \
             scripts/run_post_closure_probe.py \
+            scripts/benchmark_owner_handoff_bookkeeping.py \
             tests/pnf/test_streaming_build_reader.py \
             tests/policy/test_closure_liveness_execution.py \
             tests/policy/test_progress_observability_execution.py \
@@ -141,11 +152,12 @@ jobs:
             tests/runtime/test_reference_receipt.py \
             tests/runtime/test_stage_memory_budget.py \
             tests/storage/test_distributed_semantic_execution_store.py \
-            tests/storage/test_reference_publication_authority.py
+            tests/storage/test_reference_publication_authority.py \
+            tests/test_owner_handoff_performance_contract.py
 
       - name: Run bounded and distributed execution regressions
         run: |
-          uv run pytest --maxfail=1 -q \
+          "${SENSIBLAW_CI_PYTHON}" -m pytest --maxfail=1 -q \
             tests/runtime/test_document_execution_policy.py \
             tests/runtime/test_bounded_document_scheduler.py \
             tests/runtime/test_hierarchical_graph_execution.py \
@@ -176,25 +188,30 @@ jobs:
             tests/policy/test_operational_corpus_compilation.py \
             tests/policy/test_fibred_operational_corpus_compilation.py \
             tests/storage/test_distributed_semantic_execution_store.py \
-            tests/storage/test_reference_publication_authority.py
+            tests/storage/test_reference_publication_authority.py \
+            tests/test_owner_handoff_performance_contract.py
 
       - name: Validate migration and formal protocol surfaces
         run: |
-          python - <<'PY'
+          "${SENSIBLAW_CI_PYTHON}" - <<'PY'
           from pathlib import Path
 
           migration = Path("database/postgres_migrations/026_distributed_semantic_execution.sql").read_text()
           for table in (
+              "semantic_run",
               "semantic_owner_stream",
-              "semantic_job",
+              "semantic_closure_job",
+              "semantic_job_attempt",
+              "semantic_immutable_delta",
               "semantic_delta_admission",
-              "semantic_graph_manifest",
               "semantic_finalization_checkpoint",
-              "semantic_fixed_point_receipt",
               "semantic_execution_receipt",
-              "publication_build",
+              "semantic_publication",
+              "semantic_kernel_registration",
+              "semantic_owner_revision_history",
+              "semantic_lifecycle_event",
           ):
-              assert table in migration
+              assert f"CREATE TABLE IF NOT EXISTS execution.{table}" in migration
 
           worker = Path("src/storage/postgres/distributed_semantic_execution_store.py").read_text()
           assert "FOR UPDATE SKIP LOCKED" in worker

--- a/.github/workflows/json-sin-bin-delta.yml
+++ b/.github/workflows/json-sin-bin-delta.yml
@@ -29,14 +29,22 @@ jobs:
         run: |
           git rev-parse HEAD
           git rev-parse 'origin/${{ github.base_ref }}'
+      - name: Use provisioned self-hosted environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          ci_venv="${SENSIBLAW_CI_VENV:-/home/c/Documents/code/ITIR-suite/.venv}"
+          test -x "${ci_venv}/bin/python"
+          "${ci_venv}/bin/python" -VV
+          printf 'SENSIBLAW_CI_PYTHON=%s\n' "${ci_venv}/bin/python" >> "${GITHUB_ENV}"
       - name: Reject new JSON findings
         run: |
-          uv run python scripts/check_new_json_findings.py \
+          "${SENSIBLAW_CI_PYTHON}" scripts/check_new_json_findings.py \
             --base-ref 'origin/${{ github.base_ref }}'
       - name: Enforce zero authority findings
         run: |
           mkdir -p .tmp/json-sin-bin
-          uv run python scripts/audit_json_sin_bin.py \
+          "${SENSIBLAW_CI_PYTHON}" scripts/audit_json_sin_bin.py \
             --write .tmp/json-sin-bin/JSON_SIN_BIN.md \
             --check-authority
       - uses: actions/upload-artifact@v4

--- a/docs/owner_handoff_performance.md
+++ b/docs/owner_handoff_performance.md
@@ -1,0 +1,96 @@
+# Incremental closure-owner handoff
+
+## Scope
+
+This change is execution-only. It does not alter proposal identity, semantic
+owner identity, admission order, reduction semantics, residual semantics, or the
+fixed-point criterion.
+
+The runtime previously stored replay history twice on every new event:
+
+1. `_append_replay_event` copied the complete artifact-ref tuple and complete
+   event tuple before appending one member;
+2. `_write_closure_handoff_checkpoint` embedded every accumulated event/artifact
+   ref in the next atomic JSON checkpoint.
+
+For `E` replay events, that makes bookkeeping copy/serialization work grow like
+`sum(1..E)`, i.e. O(E^2), even when semantic work per event is bounded.
+
+## v3 physical carrier
+
+`closure-owner-replay:v3` separates cold append-only replay history from the hot
+current frontier:
+
+```text
+immutable replay artifact
+        |
+        v
+one compact journal event  ---- append O(1)
+        |
+        v
+small atomic frontier checkpoint
+```
+
+The journal stores only:
+
+- sequence number;
+- artifact kind;
+- artifact ref;
+- previous event digest;
+- event digest.
+
+The atomic frontier checkpoint stores the current owner revision/frontier,
+activation progress, recorded delta refs, and the journal count/digest. It does
+not embed the cumulative proposal/receipt/reduction event history.
+
+On resume, the journal digest chain is verified and its events are materialized
+once for deterministic owner reconstruction. Those temporary replay lists are
+removed from hot state after reconstruction.
+
+If a process dies after a journal append but before the corresponding frontier
+checkpoint is atomically replaced, that uncheckpointed journal tail is truncated
+on resume and deterministically recomputed. No partial owner state is guessed.
+
+## Identity caching
+
+The owner hot path repeatedly probes/sorts immutable content-addressed objects.
+`FactorProposal`, `OwnerKey`, `ObservationDelta`, `SolverJob`, and
+`SolverReceipt` now cache their canonical ref after its first computation. Their
+semantic payload remains unchanged.
+
+## Formal boundary
+
+No new Agda theorem is required for this tranche because the transformation is
+observationally the identity on semantic execution:
+
+```text
+same immutable inputs
+same canonical event order
+same replay artifacts
+same owner reconstruction
+same reduced factors/residuals
+```
+
+The next planned performance step is different: evaluating independent
+`OwnerKey` reductions concurrently and committing their results canonically.
+Before implementing that step, the required commutation/independence condition
+should be checked against the Agda execution/dynamic-safety contracts (and added
+there if it is not already explicit). Parallel physical execution must be
+justified by semantic independence, not merely by available cores.
+
+## Telemetry
+
+The existing closure amplification receipt automatically exposes the new
+counters:
+
+- `handoff_journal_events`;
+- `handoff_journal_append_ns`;
+- `handoff_compact_checkpoints`;
+- `handoff_compact_checkpoint_ns`;
+- `handoff_checkpoint_replay_rows_serialized` (zero under v3);
+- `handoff_uncheckpointed_tail_bytes` when recovery discards an uncommitted tail.
+
+`SENSIBLAW_CLOSURE_JOURNAL_FSYNC_INTERVAL` defaults to `0`, matching the
+process-crash durability class of the previous atomic JSON writer. A positive
+value requests an `fsync` every N journal events when stronger machine/power-loss
+durability is required.

--- a/scripts/benchmark_document_replay.py
+++ b/scripts/benchmark_document_replay.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Benchmark bounded document replay without creating another compiler path."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import hashlib
+import os
+from pathlib import Path
+import pickle
+from pprint import pformat
+import subprocess
+import sys
+from time import monotonic_ns
+from typing import Any, Mapping
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.runtime.semantic_parity import (  # noqa: E402
+    canonical_stream_digest,
+    compare_semantic_surfaces,
+    semantic_surface_from_execution_receipt,
+)
+from scripts.run_exact_0008_parallel_acceptance import _json as read_report  # noqa: E402
+
+
+SCHEMA_VERSION = "sensiblaw.document-replay-benchmark.v1"
+MODES = ("full", "batched", "disabled")
+
+
+@dataclass(frozen=True)
+class DocumentCase:
+    label: str
+    path: Path
+
+
+def _mapping(path: Path) -> dict[str, Any]:
+    return read_report(path)
+
+
+def load_manifest(path: Path) -> tuple[DocumentCase, ...]:
+    payload = pickle.loads(path.read_bytes())
+    rows = payload.get("documents") if isinstance(payload, Mapping) else payload
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("manifest must contain a non-empty documents list")
+    cases: list[DocumentCase] = []
+    labels: set[str] = set()
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise ValueError("manifest document rows must be mappings")
+        label = str(row.get("label") or "").strip()
+        raw_path = str(row.get("path") or "").strip()
+        if not label or not raw_path:
+            raise ValueError("each manifest row requires label and path")
+        if label in labels:
+            raise ValueError(f"duplicate document label: {label}")
+        document = Path(raw_path).expanduser().resolve()
+        if not document.is_file():
+            raise FileNotFoundError(document)
+        labels.add(label)
+        cases.append(DocumentCase(label=label, path=document))
+    return tuple(cases)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _typed(path: Path) -> dict[str, Any]:
+    if path.suffix == ".pkl":
+        value = pickle.loads(path.read_bytes())
+        if not isinstance(value, Mapping):
+            raise ValueError(f"expected typed mapping: {path}")
+        return dict(value)
+    return _mapping(path)
+
+
+def _find_semantic_receipt(root: Path) -> Path | None:
+    for name in ("semantic-execution-receipt.pkl", "semantic-execution-receipt.json"):
+        candidate = root / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _kernel_seconds(receipt: Mapping[str, Any], prefix: str) -> float:
+    total = 0
+    for row in receipt.get("kernel_timeline") or ():
+        if not isinstance(row, Mapping):
+            continue
+        if row.get("phase") == "kernel_completed" and str(
+            row.get("stage", "")
+        ).startswith(prefix):
+            total += int(row.get("elapsed_ns") or 0)
+    return total / 1_000_000_000
+
+
+def _metrics(path: Path) -> dict[str, int]:
+    if not path.exists():
+        return {}
+    value = pickle.loads(path.read_bytes())
+    return {str(key): int(item) for key, item in dict(value).items()}
+
+
+def _command(
+    *,
+    case: DocumentCase,
+    run_root: Path,
+    database_url: str,
+    postgres_mode: str,
+    tranche: str,
+    strict_exact: bool,
+    owner_partitions: int,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(ROOT / "scripts" / "run_exact_0008_parallel_acceptance.py"),
+        "--database-url",
+        database_url,
+        "--postgres-mode",
+        postgres_mode,
+        "--input-path",
+        str(case.path),
+        "--output-root",
+        str(run_root / "output"),
+        "--acceptance-root",
+        str(run_root / "acceptance"),
+        "--semantic-checkpoint-root",
+        str(run_root / "semantic-checkpoints"),
+        "--owner-partitions",
+        str(owner_partitions),
+        "--tranche",
+        tranche,
+    ]
+    if strict_exact:
+        command.append("--strict-exact")
+    return command
+
+
+def _run_case(
+    *,
+    case: DocumentCase,
+    mode: str,
+    output_root: Path,
+    database_url: str,
+    postgres_mode: str,
+    tranche: str,
+    strict_exact: bool,
+    owner_partitions: int,
+    batch_events: int,
+    batch_seconds: float,
+    reference_receipt: Path | None,
+    py_spy_output: Path | None,
+) -> dict[str, Any]:
+    run_root = output_root / case.label / mode
+    if run_root.exists():
+        raise FileExistsError(
+            f"benchmark output already exists; choose a new output root: {run_root}"
+        )
+    run_root.mkdir(parents=True)
+    command = _command(
+        case=case,
+        run_root=run_root,
+        database_url=database_url,
+        postgres_mode=postgres_mode,
+        tranche=tranche,
+        strict_exact=strict_exact,
+        owner_partitions=owner_partitions,
+    )
+    if reference_receipt is not None:
+        command.extend(("--reference-semantic-receipt", str(reference_receipt)))
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "SENSIBLAW_PROGRESS_PERSISTENCE_MODE": mode,
+            "SENSIBLAW_PROGRESS_BATCH_EVENTS": str(batch_events),
+            "SENSIBLAW_PROGRESS_BATCH_SECONDS": str(batch_seconds),
+            "PYTHONUNBUFFERED": "1",
+        }
+    )
+    if py_spy_output is not None:
+        command = [
+            "py-spy",
+            "record",
+            "--subprocesses",
+            "--output",
+            str(py_spy_output),
+            "--",
+            *command,
+        ]
+    started_ns = monotonic_ns()
+    stdout_path = run_root / "stdout.log"
+    stderr_path = run_root / "stderr.log"
+    with (
+        stdout_path.open("w", encoding="utf-8") as stdout,
+        stderr_path.open("w", encoding="utf-8") as stderr,
+    ):
+        completed = subprocess.run(
+            command,
+            cwd=ROOT,
+            env=environment,
+            stdout=stdout,
+            stderr=stderr,
+            check=False,
+        )
+    wall_ns = monotonic_ns() - started_ns
+    semantic_root = run_root / "semantic-checkpoints"
+    receipt_path = _find_semantic_receipt(semantic_root)
+    receipt = _typed(receipt_path) if receipt_path is not None else {}
+    strict_path = run_root / "acceptance" / "strict" / "acceptance-receipt.json"
+    strict = _mapping(strict_path) if strict_path.exists() else {}
+    metrics = _metrics(semantic_root / "progress" / "metrics.pkl")
+    surface = (
+        semantic_surface_from_execution_receipt(receipt)
+        if receipt.get("state") == "completed"
+        else None
+    )
+    return {
+        "label": case.label,
+        "input_path": str(case.path),
+        "input_sha256": _sha256(case.path),
+        "mode": mode,
+        "returncode": completed.returncode,
+        "completed": receipt.get("state") == "completed",
+        "wall_seconds": wall_ns / 1_000_000_000,
+        "kernel_seconds": {
+            "local_typing": _kernel_seconds(receipt, "local_typing_diagnostics:"),
+            "closure": _kernel_seconds(receipt, "streaming_closure:"),
+        },
+        "resources": dict(strict.get("resources") or {}),
+        "persistence": metrics,
+        "semantic_receipt": str(receipt_path) if receipt_path else None,
+        "semantic_surface_digest": canonical_stream_digest(surface)
+        if surface
+        else None,
+        "artifacts": {
+            "run_root": str(run_root),
+            "stdout": str(stdout_path),
+            "stderr": str(stderr_path),
+        },
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        required=True,
+        help="Typed binary manifest containing {documents: [{label, path}, ...]}.",
+    )
+    parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL", ""))
+    parser.add_argument(
+        "--postgres-mode", choices=("local", "existing"), default="existing"
+    )
+    parser.add_argument("--output-root", type=Path, required=True)
+    parser.add_argument("--mode", choices=MODES, action="append", dest="modes")
+    parser.add_argument("--tranche", default="GWB")
+    parser.add_argument("--strict-exact", action="store_true")
+    parser.add_argument("--owner-partitions", type=int, default=8)
+    parser.add_argument("--batch-events", type=int, default=32)
+    parser.add_argument("--batch-seconds", type=float, default=1.0)
+    parser.add_argument("--py-spy", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.database_url:
+        raise SystemExit("--database-url or DATABASE_URL is required")
+    if args.batch_events < 1 or args.batch_seconds <= 0:
+        raise SystemExit("batch thresholds must be positive")
+    cases = load_manifest(args.manifest.resolve())
+    modes = tuple(args.modes or MODES)
+    output_root = args.output_root.resolve()
+    output_root.mkdir(parents=True, exist_ok=True)
+    rows: list[dict[str, Any]] = []
+    for case in cases:
+        reference_receipt: Path | None = None
+        for mode in modes:
+            profile = None
+            if args.py_spy and mode == "full":
+                profile = output_root / case.label / "full.speedscope.json"
+            row = _run_case(
+                case=case,
+                mode=mode,
+                output_root=output_root,
+                database_url=args.database_url,
+                postgres_mode=args.postgres_mode,
+                tranche=args.tranche,
+                strict_exact=args.strict_exact,
+                owner_partitions=args.owner_partitions,
+                batch_events=args.batch_events,
+                batch_seconds=args.batch_seconds,
+                reference_receipt=reference_receipt,
+                py_spy_output=profile,
+            )
+            if row["completed"] and reference_receipt is None:
+                reference_receipt = Path(str(row["semantic_receipt"]))
+            if reference_receipt is not None and row["semantic_receipt"]:
+                current = _typed(Path(str(row["semantic_receipt"])))
+                reference = _typed(reference_receipt)
+                row["parity"] = compare_semantic_surfaces(
+                    (
+                        semantic_surface_from_execution_receipt(reference),
+                        semantic_surface_from_execution_receipt(current),
+                    )
+                )
+            else:
+                row["parity"] = {"semantic_parity": None}
+            rows.append(row)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "created_at": datetime.now(UTC).isoformat(),
+        "repository": {"root": str(ROOT)},
+        "configuration": {
+            "manifest": str(args.manifest.resolve()),
+            "postgres_mode": args.postgres_mode,
+            "modes": list(modes),
+            "batch_events": args.batch_events,
+            "batch_seconds": args.batch_seconds,
+            "strict_exact": args.strict_exact,
+        },
+        "runs": rows,
+    }
+    report_path = output_root / "benchmark-report.pkl"
+    report_path.write_bytes(pickle.dumps(report, protocol=5))
+    print(pformat(report, sort_dicts=True))
+    return 0 if all(row["returncode"] == 0 for row in rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark_owner_handoff_bookkeeping.py
+++ b/scripts/benchmark_owner_handoff_bookkeeping.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter
-import json
 import os
 from pathlib import Path
+import sys
 from tempfile import TemporaryDirectory
 from threading import Lock
 from time import monotonic_ns
@@ -20,8 +20,12 @@ from time import monotonic_ns
 # Importing src.policy normally installs the full execution strategy stack.  This
 # probe needs only the physical journal function.
 os.environ.setdefault("SENSIBLAW_BOUNDED_DOCUMENT_EXECUTION", "0")
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 from src.policy.owner_handoff_performance import _append_journal_event  # noqa: E402
+from src.policy.carriers.canonical import canonical_bytes  # noqa: E402
 
 
 class _Context:
@@ -46,18 +50,15 @@ def _legacy(events: int) -> tuple[int, int]:
         activation["proposal_batch_artifact_refs"] = tuple(refs)
         replay = list(activation.get("replay_events") or ())
         copied_rows += len(replay)
-        replay.append(
-            {"artifact_kind": "proposal_batch", "artifact_ref": artifact_ref}
-        )
+        replay.append({"artifact_kind": "proposal_batch", "artifact_ref": artifact_ref})
         activation["replay_events"] = tuple(replay)
         # Model the old handoff writer's repeated serialization of cumulative
         # history, without filesystem latency.
-        json.dumps(
+        canonical_bytes(
             {
                 "proposal_batch_artifact_refs": refs,
                 "replay_events": replay,
-            },
-            separators=(",", ":"),
+            }
         )
     return monotonic_ns() - started, copied_rows
 
@@ -108,7 +109,19 @@ def main() -> int:
                     "provider_io_performed": False,
                 }
             )
-    print(json.dumps({"rows": rows}, indent=2, sort_keys=True))
+    fields = (
+        "events",
+        "legacy_elapsed_ns",
+        "legacy_cumulative_rows_copied",
+        "v3_elapsed_ns",
+        "v3_journal_rows_appended",
+        "legacy_to_v3_elapsed_ratio",
+        "semantic_work_performed",
+        "provider_io_performed",
+    )
+    print("\t".join(fields))
+    for row in rows:
+        print("\t".join(str(row[field]) for field in fields))
     return 0
 
 

--- a/scripts/benchmark_owner_handoff_bookkeeping.py
+++ b/scripts/benchmark_owner_handoff_bookkeeping.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Compare legacy cumulative replay bookkeeping with the v3 append journal.
+
+No parser, PostgreSQL, provider, or semantic closure work is performed.  This
+isolates the physical replay-history bookkeeping that appeared in the live
+owner_admission_batch / closure_handoff profile.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from threading import Lock
+from time import monotonic_ns
+
+# Importing src.policy normally installs the full execution strategy stack.  This
+# probe needs only the physical journal function.
+os.environ.setdefault("SENSIBLAW_BOUNDED_DOCUMENT_EXECUTION", "0")
+
+from src.policy.owner_handoff_performance import _append_journal_event  # noqa: E402
+
+
+class _Context:
+    def __init__(self, root: Path) -> None:
+        self.closure_activation_checkpoint_root = root
+        self.build_key_sha256 = "benchmark"
+        self.reconstructing_owner = False
+        self.closure_activation: dict[str, object] = {}
+        self.closure_counters: Counter[str] = Counter()
+        self.lock = Lock()
+
+
+def _legacy(events: int) -> tuple[int, int]:
+    activation: dict[str, object] = {}
+    started = monotonic_ns()
+    copied_rows = 0
+    for ordinal in range(events):
+        artifact_ref = f"artifact:{ordinal}"
+        refs = list(activation.get("proposal_batch_artifact_refs") or ())
+        copied_rows += len(refs)
+        refs.append(artifact_ref)
+        activation["proposal_batch_artifact_refs"] = tuple(refs)
+        replay = list(activation.get("replay_events") or ())
+        copied_rows += len(replay)
+        replay.append(
+            {"artifact_kind": "proposal_batch", "artifact_ref": artifact_ref}
+        )
+        activation["replay_events"] = tuple(replay)
+        # Model the old handoff writer's repeated serialization of cumulative
+        # history, without filesystem latency.
+        json.dumps(
+            {
+                "proposal_batch_artifact_refs": refs,
+                "replay_events": replay,
+            },
+            separators=(",", ":"),
+        )
+    return monotonic_ns() - started, copied_rows
+
+
+def _v3(events: int, root: Path) -> tuple[int, int]:
+    context = _Context(root)
+    started = monotonic_ns()
+    for ordinal in range(events):
+        _append_journal_event(
+            context,
+            artifact_kind="proposal_batch",
+            artifact_ref=f"artifact:{ordinal}",
+        )
+    elapsed = monotonic_ns() - started
+    return elapsed, int(context.closure_counters["handoff_journal_events"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--events",
+        type=int,
+        nargs="+",
+        default=[128, 256, 512, 1024, 2048],
+    )
+    args = parser.parse_args()
+    if any(value <= 0 for value in args.events):
+        parser.error("--events values must be positive")
+
+    rows = []
+    with TemporaryDirectory(prefix="sensiblaw-handoff-benchmark-") as temp:
+        root = Path(temp)
+        for event_count in args.events:
+            legacy_ns, legacy_copied = _legacy(event_count)
+            v3_root = root / str(event_count)
+            v3_ns, v3_appends = _v3(event_count, v3_root)
+            rows.append(
+                {
+                    "events": event_count,
+                    "legacy_elapsed_ns": legacy_ns,
+                    "legacy_cumulative_rows_copied": legacy_copied,
+                    "v3_elapsed_ns": v3_ns,
+                    "v3_journal_rows_appended": v3_appends,
+                    "legacy_to_v3_elapsed_ratio": (
+                        legacy_ns / v3_ns if v3_ns else None
+                    ),
+                    "semantic_work_performed": False,
+                    "provider_io_performed": False,
+                }
+            )
+    print(json.dumps({"rows": rows}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_new_json_findings.py
+++ b/scripts/check_new_json_findings.py
@@ -63,13 +63,19 @@ def _extract_git_tree(ref: str, destination: Path) -> None:
     root.mkdir()
     with tarfile.open(tar_path, mode="r:") as stream:
         # Git archive paths come from a trusted repository tree. Refuse links
-        # nevertheless so a malformed history cannot escape the temp root.
+        # from extraction so a malformed history cannot escape the temp root.
+        # A tracked symlink is not source authority for this scanner and does
+        # not need to be materialized to compare the base tree.
+        extractable: list[tarfile.TarInfo] = []
         for member in stream.getmembers():
-            if member.issym() or member.islnk() or member.name.startswith("/"):
+            if member.issym() or member.islnk():
+                continue
+            if member.name.startswith("/"):
                 raise ValueError(f"unsafe archive member: {member.name}")
             resolved = (root / member.name).resolve()
             resolved.relative_to(root.resolve())
-        stream.extractall(root, filter="data")
+            extractable.append(member)
+        stream.extractall(root, members=extractable, filter="data")
 
 
 def main() -> int:
@@ -96,8 +102,7 @@ def main() -> int:
     )
     for finding in introduced:
         print(
-            f"{finding.path}: {finding.category}: "
-            f"{finding.symbol}: {finding.snippet}"
+            f"{finding.path}: {finding.category}: {finding.symbol}: {finding.snippet}"
         )
     return 1
 

--- a/scripts/run_exact_0008_parallel_acceptance.py
+++ b/scripts/run_exact_0008_parallel_acceptance.py
@@ -26,7 +26,9 @@ from src.runtime.semantic_parity import (  # noqa: E402
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
-    parser.add_argument("--postgres-mode", choices=("local", "existing"), default="local")
+    parser.add_argument(
+        "--postgres-mode", choices=("local", "existing"), default="local"
+    )
     parser.add_argument("--input-path", type=Path, required=True)
     parser.add_argument(
         "--output-root",
@@ -444,8 +446,12 @@ def main() -> int:
         **started,
         "state": "accepted" if accepted else "failed",
         "accepted": accepted,
-        "failure_reason": strict_receipt.get("failure_reason") if not accepted else None,
-        "diagnostic_path": strict_receipt.get("diagnostic_path") if not accepted else None,
+        "failure_reason": strict_receipt.get("failure_reason")
+        if not accepted
+        else None,
+        "diagnostic_path": strict_receipt.get("diagnostic_path")
+        if not accepted
+        else None,
         "kernel_key": strict_receipt.get("kernel_key") if not accepted else None,
         "child_returncode": completed.returncode,
         "strict_receipt": str(strict_receipt_path),

--- a/scripts/run_exact_0008_parallel_acceptance.py
+++ b/scripts/run_exact_0008_parallel_acceptance.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import pickle
 from pathlib import Path
 import shutil
 import subprocess
@@ -114,6 +115,34 @@ def _json(path: Path) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         raise ValueError(f"expected JSON object: {path}")
     return dict(value)
+
+
+def _artifact(path: Path) -> dict[str, Any]:
+    """Read a typed binary artifact, retaining JSON compatibility for reports."""
+
+    if path.suffix == ".pkl" or path.exists() and path.read_bytes()[:1] == b"\x80":
+        try:
+            value = pickle.loads(path.read_bytes())
+        except (
+            OSError,
+            EOFError,
+            pickle.PickleError,
+            AttributeError,
+            ValueError,
+        ) as error:
+            raise ValueError(f"invalid typed artifact: {path}") from error
+        if not isinstance(value, Mapping):
+            raise ValueError(f"expected mapping artifact: {path}")
+        return dict(value)
+    return _json(path)
+
+
+def _semantic_receipt(root: Path) -> tuple[Path, dict[str, Any]]:
+    for name in ("semantic-execution-receipt.pkl", "semantic-execution-receipt.json"):
+        path = root / name
+        if path.exists():
+            return path, _artifact(path)
+    return root / "semantic-execution-receipt.pkl", {"state": "missing"}
 
 
 def _atomic_json(path: Path, payload: Mapping[str, Any]) -> None:
@@ -281,7 +310,7 @@ def main() -> int:
         injected = subprocess.run(
             command, cwd=ROOT, env=injected_environment, check=False
         )
-        injected_semantic_path = semantic_root / "semantic-execution-receipt.json"
+        injected_semantic_path, _ = _semantic_receipt(semantic_root)
         injected_snapshot_path = acceptance_root / "injected-stop-semantic-receipt.json"
         if injected_semantic_path.exists():
             shutil.copyfile(injected_semantic_path, injected_snapshot_path)
@@ -301,12 +330,7 @@ def main() -> int:
         if strict_receipt_path.exists()
         else {"state": "missing", "accepted": False}
     )
-    semantic_receipt_path = semantic_root / "semantic-execution-receipt.json"
-    semantic_receipt = (
-        _json(semantic_receipt_path)
-        if semantic_receipt_path.exists()
-        else {"state": "missing"}
-    )
+    semantic_receipt_path, semantic_receipt = _semantic_receipt(semantic_root)
 
     local_typing_seconds = _kernel_seconds(
         semantic_receipt, "local_typing_diagnostics:"
@@ -345,7 +369,7 @@ def main() -> int:
         else None
     )
     if args.reference_semantic_receipt is not None:
-        reference_receipt = _json(args.reference_semantic_receipt.resolve())
+        reference_receipt = _artifact(args.reference_semantic_receipt.resolve())
         parity = compare_semantic_surfaces(
             (
                 semantic_surface_from_execution_receipt(reference_receipt),

--- a/src/pnf/fibred_build_projection.py
+++ b/src/pnf/fibred_build_projection.py
@@ -42,8 +42,7 @@ def _proposal_from_mapping(row: Mapping[str, Any]) -> FactorProposal:
         scope_ref=str(row.get("scope_ref") or "document-global"),
         statement_role=str(row.get("statement_role") or "main"),
         coordinate_kind=str(row.get("coordinate_kind") or "object"),
-        semantic_coordinate_ref=str(row.get("semantic_coordinate_ref") or "")
-        or None,
+        semantic_coordinate_ref=str(row.get("semantic_coordinate_ref") or "") or None,
         fibre_kind=str(row.get("fibre_kind") or "hypothesis"),
         derivation_role=str(row.get("derivation_role") or "support"),
         producer_scope=str(row.get("producer_scope") or "integrated"),
@@ -52,9 +51,7 @@ def _proposal_from_mapping(row: Mapping[str, Any]) -> FactorProposal:
         transport_refs=tuple(row.get("transport_refs") or ()),
         support_state=str(row.get("support_state") or "candidate"),
         confidence=(
-            float(row["confidence"])
-            if row.get("confidence") is not None
-            else None
+            float(row["confidence"]) if row.get("confidence") is not None else None
         ),
         assumptions=tuple(row.get("assumptions") or ()),
         coverage_requirements=tuple(row.get("coverage_requirements") or ()),
@@ -236,8 +233,7 @@ def project_fibred_semantic_build(
                     for ref in receipt.get("input_refs") or ()
                 ),
                 output_element_refs=tuple(
-                    content_to_element_ref[row.proposal_ref]
-                    for row in output_proposals
+                    content_to_element_ref[row.proposal_ref] for row in output_proposals
                 ),
                 sub_executor_ref=str(receipt.get("backend_ref") or ""),
                 rule_set_revision=str(receipt.get("rule_set_revision") or ""),
@@ -294,9 +290,7 @@ def project_fibred_semantic_build(
         coordinates=tuple(coordinates[key] for key in sorted(coordinates)),
         elements=tuple(sorted(elements, key=lambda row: row.element_ref)),
         transports=tuple(sorted(transports, key=lambda row: row.transport_ref)),
-        derivations=tuple(
-            sorted(derivations, key=lambda row: row.derivation_ref)
-        ),
+        derivations=tuple(sorted(derivations, key=lambda row: row.derivation_ref)),
         ontology_axes=tuple(sorted(axes, key=lambda row: row.axis_ref)),
         axis_obligations=tuple(
             sorted(axis_obligations, key=lambda row: row.obligation_ref)

--- a/src/pnf/streaming_build_reader.py
+++ b/src/pnf/streaming_build_reader.py
@@ -190,7 +190,12 @@ class StreamingBuildReader:
                     raise ValueError(f"truncated family frame payload: {path}")
                 try:
                     value = pickle.loads(encoded)
-                except (EOFError, pickle.PickleError, AttributeError, ValueError) as error:
+                except (
+                    EOFError,
+                    pickle.PickleError,
+                    AttributeError,
+                    ValueError,
+                ) as error:
                     raise ValueError(f"family frame decode failed: {path}") from error
                 if not isinstance(value, Mapping):
                     raise ValueError(f"family row is not a mapping: {path}")

--- a/src/pnf/streaming_reduction_projection.py
+++ b/src/pnf/streaming_reduction_projection.py
@@ -22,9 +22,7 @@ from src.policy.algebra.revision_identity import factor_revision_ref
 from src.policy.carriers.canonical import canonical_sha256
 
 
-STREAMING_REDUCTION_PROJECTION_CONTRACT = (
-    "streaming-reduction-pnf-projection:v0_3"
-)
+STREAMING_REDUCTION_PROJECTION_CONTRACT = "streaming-reduction-pnf-projection:v0_3"
 
 
 def _materialized_factor_ref(
@@ -56,16 +54,13 @@ def _factor_from_reduction(
             alternative_ref=f"{factor_ref}:proposal:{index}",
             value={
                 "predicate_ref": str(
-                    (row.get("candidate_payload") or {}).get("predicate_ref")
-                    or ""
+                    (row.get("candidate_payload") or {}).get("predicate_ref") or ""
                 ),
                 "semantic_coordinate_ref": str(
                     row.get("semantic_coordinate_ref") or ""
                 ),
                 "fibre_kind": str(row.get("fibre_kind") or "hypothesis"),
-                "derivation_role": str(
-                    row.get("derivation_role") or "support"
-                ),
+                "derivation_role": str(row.get("derivation_role") or "support"),
                 "support_state": str(row.get("support_state") or "candidate"),
                 "confidence": row.get("confidence"),
                 "role_bindings": dict(row.get("role_bindings") or {}),
@@ -81,15 +76,9 @@ def _factor_from_reduction(
                         str(row.get("operation_contract") or ""),
                         str(row.get("declaration_revision") or ""),
                         *(str(ref) for ref in row.get("source_span_refs") or ()),
-                        *(
-                            str(ref)
-                            for ref in row.get("input_observation_refs") or ()
-                        ),
+                        *(str(ref) for ref in row.get("input_observation_refs") or ()),
                         *(str(ref) for ref in row.get("transport_refs") or ()),
-                        *(
-                            str(ref)
-                            for ref in row.get("ontology_axis_refs") or ()
-                        ),
+                        *(str(ref) for ref in row.get("ontology_axis_refs") or ()),
                     }
                     - {""}
                 )
@@ -97,9 +86,7 @@ def _factor_from_reduction(
         )
         for index, row in enumerate(proposal_rows)
     )
-    residuals = tuple(
-        sorted(str(value) for value in reduced.get("residuals") or ())
-    )
+    residuals = tuple(sorted(str(value) for value in reduced.get("residuals") or ()))
     provenance_refs = tuple(
         sorted(
             {
@@ -129,9 +116,7 @@ def _factor_from_reduction(
                 reduced.get("semantic_coordinate_ref") or ""
             ),
             "fibre_kind": str(reduced.get("fibre_kind") or "hypothesis"),
-            "structural_signature_ref": str(
-                reduced.get("structural_signature") or ""
-            ),
+            "structural_signature_ref": str(reduced.get("structural_signature") or ""),
             "role_bindings": role_bindings,
             "qualifier_state": qualifier_state,
             "proposal_refs": proposal_refs,
@@ -159,8 +144,7 @@ def _is_operator_proposal(row: Mapping[str, Any]) -> bool:
     operation_contract = str(row.get("operation_contract") or "")
     producer_contract = str(row.get("producer_contract") or "")
     return operation_contract == OPERATOR_COMPOSITION_CONTRACT or (
-        not operation_contract
-        and producer_contract == OPERATOR_COMPOSITION_CONTRACT
+        not operation_contract and producer_contract == OPERATOR_COMPOSITION_CONTRACT
     )
 
 
@@ -225,9 +209,7 @@ def project_streaming_reduction(
         )
         result, admission = _admit_factor(result, factor)
         factors.append(factor)
-        admissions.append(
-            {"factor_ref": factor.factor_ref, "admission": admission}
-        )
+        admissions.append({"factor_ref": factor.factor_ref, "admission": admission})
     receipt_identity = {
         "contract_ref": STREAMING_REDUCTION_PROJECTION_CONTRACT,
         "input_graph_ref": graph.graph_ref,
@@ -235,17 +217,10 @@ def project_streaming_reduction(
         "factor_refs": [row.factor_ref for row in factors],
         "admissions": admissions,
         "fibre_summary_refs": sorted(
-            {
-                str(row.metadata.get("fibre_summary_ref") or "")
-                for row in factors
-            }
-            - {""}
+            {str(row.metadata.get("fibre_summary_ref") or "") for row in factors} - {""}
         ),
         "semantic_coordinate_refs": sorted(
-            {
-                str(row.metadata.get("semantic_coordinate_ref") or "")
-                for row in factors
-            }
+            {str(row.metadata.get("semantic_coordinate_ref") or "") for row in factors}
             - {""}
         ),
     }
@@ -257,9 +232,7 @@ def project_streaming_reduction(
         "factor_count": len(factors),
         "source_factor_count": reader.family_count("factors"),
         "source_proposal_count": reader.family_count("proposals"),
-        "added_factor_count": sum(
-            row["admission"] == "added" for row in admissions
-        ),
+        "added_factor_count": sum(row["admission"] == "added" for row in admissions),
         "replaced_factor_count": sum(
             row["admission"] == "replaced" for row in admissions
         ),

--- a/src/policy/__init__.py
+++ b/src/policy/__init__.py
@@ -110,6 +110,9 @@ def install_execution_strategies() -> None:
             indexed_projection_enabled,
             install_indexed_projection_execution,
         )
+        from .owner_handoff_batch_performance import (
+            install_owner_handoff_batch_performance,
+        )
         from .owner_handoff_performance import (
             install_owner_handoff_performance,
         )
@@ -149,6 +152,10 @@ def install_execution_strategies() -> None:
         # append-only replay journal plus compact frontier checkpoint, and cache
         # immutable content-addressed identities used by the hot admission path.
         install_owner_handoff_performance()
+        # The bounded caller already filters activation rows against the
+        # canonical owner's admitted-delta map. Do not rebuild/serialize a second
+        # cumulative recorded-delta index inside the replay contract.
+        install_owner_handoff_batch_performance()
         # The remaining hypothesis/type/diagnostic tails and pure closure
         # handlers are CPU-bound. Install process-backed bounded leaves after
         # telemetry so their outputs retain the same resource receipts.

--- a/src/policy/__init__.py
+++ b/src/policy/__init__.py
@@ -110,6 +110,9 @@ def install_execution_strategies() -> None:
             indexed_projection_enabled,
             install_indexed_projection_execution,
         )
+        from .owner_handoff_performance import (
+            install_owner_handoff_performance,
+        )
         from .parallel_semantic_execution import (
             install_parallel_semantic_execution,
         )
@@ -142,6 +145,10 @@ def install_execution_strategies() -> None:
         # output-sensitive local-typing overlap leaves and closure receipt
         # replay, and leaves the canonical compiler as the sole authority.
         install_parallel_semantic_execution()
+        # Replace cumulative tuple copies/full-history handoff snapshots with an
+        # append-only replay journal plus compact frontier checkpoint, and cache
+        # immutable content-addressed identities used by the hot admission path.
+        install_owner_handoff_performance()
         # The remaining hypothesis/type/diagnostic tails and pure closure
         # handlers are CPU-bound. Install process-backed bounded leaves after
         # telemetry so their outputs retain the same resource receipts.

--- a/src/policy/bounded_operational_execution.py
+++ b/src/policy/bounded_operational_execution.py
@@ -290,6 +290,34 @@ def bounded_streaming_semantic_build(
     max_pending_jobs = 0
     max_in_flight_jobs = 0
 
+    def report_base_progress(
+        *,
+        kernel: str,
+        factor_batch_size: int = 0,
+        proposal_batch_size: int = 0,
+        projection_elapsed_ns: int = 0,
+        admission_elapsed_ns: int = 0,
+        reduction_elapsed_ns: int = 0,
+    ) -> None:
+        if progress_observer is None:
+            return
+        progress_observer(
+            {
+                "deltas_admitted": admitted_delta_count,
+                "base_batches_completed": base_admission_batches,
+                "base_factors_seen": len(base_proposals),
+                "base_proposals_admitted": len(base_proposals),
+                "base_factor_batch_size": factor_batch_size,
+                "base_proposal_batch_size": proposal_batch_size,
+                "base_projection_elapsed_ns": projection_elapsed_ns,
+                "base_admission_elapsed_ns": admission_elapsed_ns,
+                "base_reduction_elapsed_ns": reduction_elapsed_ns,
+                "pending_jobs": len(owner._pending_jobs),
+                "in_flight_jobs": len(owner._in_flight_jobs),
+                "current_kernel": kernel,
+            }
+        )
+
     def sample_resources(
         queued_bytes: int,
         pending_jobs: int,
@@ -446,7 +474,10 @@ def bounded_streaming_semantic_build(
                 except StopIteration:
                     factor_batch = ()
                 if factor_batch:
-                    base_started = monotonic_ns()
+                    report_base_progress(
+                        kernel="base_proposal_projection_started",
+                        factor_batch_size=len(factor_batch),
+                    )
                     projection_started = monotonic_ns()
                     proposals = tuple(
                         operational._base_proposal_from_factor(
@@ -456,11 +487,19 @@ def bounded_streaming_semantic_build(
                         )
                         for factor in factor_batch
                     )
-                    base_projection_elapsed_ns += monotonic_ns() - projection_started
+                    projection_elapsed = monotonic_ns() - projection_started
+                    base_projection_elapsed_ns += projection_elapsed
                     base_proposals.extend(proposals)
+                    report_base_progress(
+                        kernel="base_proposal_projection_completed",
+                        factor_batch_size=len(factor_batch),
+                        proposal_batch_size=len(proposals),
+                        projection_elapsed_ns=projection_elapsed,
+                    )
                     admission_started = monotonic_ns()
                     owner.admit_proposals(proposals, stage="base")
-                    base_admission_elapsed_ns += monotonic_ns() - admission_started
+                    admission_elapsed = monotonic_ns() - admission_started
+                    base_admission_elapsed_ns += admission_elapsed
                     owner.reduce_dirty_groups()
                     base_reduction = owner.materialized_reduction
                     base_admission_batches += 1
@@ -472,7 +511,16 @@ def bounded_streaming_semantic_build(
                             for row in proposals
                         ),
                     )
-                    base_reduction_elapsed_ns += monotonic_ns() - base_started
+                    reduction_elapsed = monotonic_ns() - admission_started - admission_elapsed
+                    base_reduction_elapsed_ns += reduction_elapsed
+                    report_base_progress(
+                        kernel="base_proposal_admission_completed",
+                        factor_batch_size=len(factor_batch),
+                        proposal_batch_size=len(proposals),
+                        projection_elapsed_ns=projection_elapsed,
+                        admission_elapsed_ns=admission_elapsed,
+                        reduction_elapsed_ns=reduction_elapsed,
+                    )
                     if replay_contract is not None:
                         replay_contract.checkpoint_owner(owner)
                     if progress_observer is not None:
@@ -564,7 +612,10 @@ def bounded_streaming_semantic_build(
     # A document may contain more base factors than activation batches.  They
     # remain bounded owner admissions, never a preflight tuple reduction.
     for factor_batch in base_batches:
-        base_started = monotonic_ns()
+        report_base_progress(
+            kernel="base_proposal_projection_started",
+            factor_batch_size=len(factor_batch),
+        )
         projection_started = monotonic_ns()
         proposals = tuple(
             operational._base_proposal_from_factor(
@@ -574,11 +625,19 @@ def bounded_streaming_semantic_build(
             )
             for factor in factor_batch
         )
-        base_projection_elapsed_ns += monotonic_ns() - projection_started
+        projection_elapsed = monotonic_ns() - projection_started
+        base_projection_elapsed_ns += projection_elapsed
         base_proposals.extend(proposals)
+        report_base_progress(
+            kernel="base_proposal_projection_completed",
+            factor_batch_size=len(factor_batch),
+            proposal_batch_size=len(proposals),
+            projection_elapsed_ns=projection_elapsed,
+        )
         admission_started = monotonic_ns()
         owner.admit_proposals(proposals, stage="base")
-        base_admission_elapsed_ns += monotonic_ns() - admission_started
+        admission_elapsed = monotonic_ns() - admission_started
+        base_admission_elapsed_ns += admission_elapsed
         owner.reduce_dirty_groups()
         base_reduction = owner.materialized_reduction
         base_admission_batches += 1
@@ -590,7 +649,16 @@ def bounded_streaming_semantic_build(
                 for row in proposals
             ),
         )
-        base_reduction_elapsed_ns += monotonic_ns() - base_started
+        reduction_elapsed = monotonic_ns() - admission_started - admission_elapsed
+        base_reduction_elapsed_ns += reduction_elapsed
+        report_base_progress(
+            kernel="base_proposal_admission_completed",
+            factor_batch_size=len(factor_batch),
+            proposal_batch_size=len(proposals),
+            projection_elapsed_ns=projection_elapsed,
+            admission_elapsed_ns=admission_elapsed,
+            reduction_elapsed_ns=reduction_elapsed,
+        )
         if replay_contract is not None:
             replay_contract.checkpoint_owner(owner)
 

--- a/src/policy/no_json_checkpoint_execution.py
+++ b/src/policy/no_json_checkpoint_execution.py
@@ -8,37 +8,181 @@ remain unchanged; no active checkpoint or heartbeat is text-serialized.
 
 from __future__ import annotations
 
+import atexit
 import os
 from pathlib import Path
 import pickle
 import sys
+from time import monotonic_ns
 from typing import Any, Mapping
 
 
 _INSTALL_MARKER = "_no_json_checkpoint_execution_installed"
+_PROGRESS_MODES = {"full", "batched", "disabled"}
+_progress_buffers: dict[Path, dict[str, Any]] = {}
+_progress_roots: set[Path] = set()
+_progress_metrics: dict[str, int] = {
+    "binary_bytes_written": 0,
+    "binary_fsync_count": 0,
+    "binary_fsync_elapsed_ns": 0,
+    "binary_persistence_elapsed_ns": 0,
+    "progress_events": 0,
+    "progress_events_persisted": 0,
+    "progress_events_disabled": 0,
+    "progress_flushes": 0,
+    "progress_atomic_writes": 0,
+    "progress_frame_appends": 0,
+    "progress_bytes_written": 0,
+    "progress_bytes_buffered": 0,
+    "progress_fsync_count": 0,
+    "progress_fsync_elapsed_ns": 0,
+    "progress_persistence_elapsed_ns": 0,
+}
+
+
+def _progress_mode() -> str:
+    value = (
+        os.environ.get("SENSIBLAW_PROGRESS_PERSISTENCE_MODE", "full").strip().lower()
+    )
+    if value not in _PROGRESS_MODES:
+        raise ValueError(
+            "SENSIBLAW_PROGRESS_PERSISTENCE_MODE must be one of: "
+            + ", ".join(sorted(_PROGRESS_MODES))
+        )
+    return value
+
+
+def _positive_env(name: str, default: int) -> int:
+    value = int(os.environ.get(name, str(default)))
+    if value < 1:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def _positive_float_env(name: str, default: float) -> float:
+    value = float(os.environ.get(name, str(default)))
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def _record_metric(name: str, value: int = 1) -> None:
+    _progress_metrics[name] = _progress_metrics.get(name, 0) + value
+
+
+def _fsync(handle: Any) -> None:
+    started = monotonic_ns()
+    os.fsync(handle.fileno())
+    _record_metric("binary_fsync_count")
+    _record_metric("binary_fsync_elapsed_ns", monotonic_ns() - started)
+
+
+def _encoded_frame(payload: Mapping[str, Any]) -> bytes:
+    encoded = pickle.dumps(dict(payload), protocol=5)
+    return len(encoded).to_bytes(8, "big") + encoded
 
 
 def _atomic_write_binary(path: Path, payload: Mapping[str, Any]) -> int:
+    started = monotonic_ns()
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_suffix(path.suffix + ".tmp")
     encoded = pickle.dumps(dict(payload), protocol=5)
     with temporary.open("wb") as handle:
         handle.write(encoded)
         handle.flush()
-        os.fsync(handle.fileno())
+        _fsync(handle)
     temporary.replace(path)
+    _record_metric("binary_bytes_written", len(encoded))
+    _record_metric("binary_persistence_elapsed_ns", monotonic_ns() - started)
     return len(encoded)
 
 
 def _append_binary_frame(path: Path, payload: Mapping[str, Any]) -> int:
+    started = monotonic_ns()
+    fsync_count_before = _progress_metrics["binary_fsync_count"]
+    fsync_elapsed_before = _progress_metrics["binary_fsync_elapsed_ns"]
     path.parent.mkdir(parents=True, exist_ok=True)
-    encoded = pickle.dumps(dict(payload), protocol=5)
-    frame = len(encoded).to_bytes(8, "big") + encoded
+    frame = _encoded_frame(payload)
     with path.open("ab") as stream:
         stream.write(frame)
         stream.flush()
-        os.fsync(stream.fileno())
+        _fsync(stream)
+    _record_metric("progress_frame_appends")
+    _record_metric("progress_events_persisted")
+    _record_metric("progress_bytes_written", len(frame))
+    _record_metric(
+        "progress_fsync_count",
+        _progress_metrics["binary_fsync_count"] - fsync_count_before,
+    )
+    _record_metric(
+        "progress_fsync_elapsed_ns",
+        _progress_metrics["binary_fsync_elapsed_ns"] - fsync_elapsed_before,
+    )
+    _record_metric("progress_persistence_elapsed_ns", monotonic_ns() - started)
     return len(frame)
+
+
+def _flush_progress(root: Path) -> None:
+    buffered = _progress_buffers.pop(root, None)
+    if not buffered:
+        return
+    started = monotonic_ns()
+    progress_root = root / "progress"
+    latest = buffered["latest"]
+    fsync_count_before = _progress_metrics["binary_fsync_count"]
+    fsync_elapsed_before = _progress_metrics["binary_fsync_elapsed_ns"]
+    latest_bytes = _atomic_write_binary(progress_root / "latest.pkl", latest)
+    _record_metric("progress_atomic_writes")
+    _record_metric("progress_bytes_written", latest_bytes)
+    _record_metric(
+        "progress_fsync_count",
+        _progress_metrics["binary_fsync_count"] - fsync_count_before,
+    )
+    _record_metric(
+        "progress_fsync_elapsed_ns",
+        _progress_metrics["binary_fsync_elapsed_ns"] - fsync_elapsed_before,
+    )
+    frames = buffered["frames"]
+    if frames:
+        progress_root.mkdir(parents=True, exist_ok=True)
+        fsync_count_before = _progress_metrics["binary_fsync_count"]
+        fsync_elapsed_before = _progress_metrics["binary_fsync_elapsed_ns"]
+        with (progress_root / "events.bin").open("ab") as stream:
+            stream.write(b"".join(frames))
+            stream.flush()
+            _fsync(stream)
+        _record_metric(
+            "progress_fsync_count",
+            _progress_metrics["binary_fsync_count"] - fsync_count_before,
+        )
+        _record_metric(
+            "progress_fsync_elapsed_ns",
+            _progress_metrics["binary_fsync_elapsed_ns"] - fsync_elapsed_before,
+        )
+        _record_metric("progress_frame_appends", len(frames))
+        _record_metric("progress_events_persisted", len(frames))
+        _record_metric("progress_bytes_written", sum(map(len, frames)))
+    _record_metric("progress_flushes")
+    _record_metric("progress_persistence_elapsed_ns", monotonic_ns() - started)
+
+
+def _flush_all_progress() -> None:
+    for root in tuple(_progress_buffers):
+        _flush_progress(root)
+
+
+def _write_progress_metrics(root: Path) -> None:
+    progress_root = root / "progress"
+    progress_root.mkdir(parents=True, exist_ok=True)
+    temporary = progress_root / "metrics.pkl.tmp"
+    temporary.write_bytes(pickle.dumps(dict(_progress_metrics), protocol=5))
+    temporary.replace(progress_root / "metrics.pkl")
+
+
+def progress_persistence_metrics() -> dict[str, int]:
+    """Return a snapshot of diagnostic progress-persistence counters."""
+
+    return dict(_progress_metrics)
 
 
 def _read_binary(path: Path) -> dict[str, Any] | None:
@@ -168,7 +312,9 @@ def install_no_json_checkpoint_execution() -> bool:
     typing_tail._atomic_write_json = _atomic_write_binary
     typing_tail._read_json = _read_binary
 
-    def typing_leaf_path(root: Path | None, operation: str, leaf_ref: str) -> Path | None:
+    def typing_leaf_path(
+        root: Path | None, operation: str, leaf_ref: str
+    ) -> Path | None:
         if root is None:
             return None
         return root / operation / f"{_safe_ref(leaf_ref)}.pkl"
@@ -179,16 +325,60 @@ def install_no_json_checkpoint_execution() -> bool:
     progress._append_jsonl = _append_binary_frame
 
     def persist_and_log(context: Any, envelope: Mapping[str, Any]) -> None:
+        _record_metric("progress_events")
         root = context.checkpoint_root
+        mode = _progress_mode()
         if root is not None:
-            progress_root = Path(root) / "progress"
-            _atomic_write_binary(progress_root / "latest.pkl", envelope)
+            root = Path(root)
+            _progress_roots.add(root)
+        if root is not None and mode == "full":
+            started = monotonic_ns()
+            progress_root = root / "progress"
+            fsync_count_before = _progress_metrics["binary_fsync_count"]
+            fsync_elapsed_before = _progress_metrics["binary_fsync_elapsed_ns"]
+            latest_bytes = _atomic_write_binary(progress_root / "latest.pkl", envelope)
+            _record_metric("progress_atomic_writes")
+            _record_metric("progress_bytes_written", latest_bytes)
+            _record_metric(
+                "progress_fsync_count",
+                _progress_metrics["binary_fsync_count"] - fsync_count_before,
+            )
+            _record_metric(
+                "progress_fsync_elapsed_ns",
+                _progress_metrics["binary_fsync_elapsed_ns"] - fsync_elapsed_before,
+            )
             _append_binary_frame(progress_root / "events.bin", envelope)
+            _record_metric("progress_persistence_elapsed_ns", monotonic_ns() - started)
+        elif root is not None and mode == "batched":
+            state = _progress_buffers.setdefault(
+                root,
+                {"frames": [], "latest": envelope, "started_ns": monotonic_ns()},
+            )
+            frame = _encoded_frame(envelope)
+            state["frames"].append(frame)
+            state["latest"] = envelope
+            _record_metric("progress_bytes_buffered", len(frame))
+            event_limit = _positive_env("SENSIBLAW_PROGRESS_BATCH_EVENTS", 32)
+            time_limit_ns = int(
+                _positive_float_env("SENSIBLAW_PROGRESS_BATCH_SECONDS", 1.0)
+                * 1_000_000_000
+            )
+            if (
+                len(state["frames"]) >= event_limit
+                or monotonic_ns() - int(state["started_ns"]) >= time_limit_ns
+            ):
+                _flush_progress(root)
+        elif mode == "disabled":
+            _record_metric("progress_events_disabled")
         print(_progress_line(envelope), file=sys.stderr, flush=True)
 
     progress._persist_and_log = persist_and_log
+    atexit.register(
+        lambda: [_write_progress_metrics(Path(root)) for root in tuple(_progress_roots)]
+    )
+    atexit.register(_flush_all_progress)
     setattr(semantic, _INSTALL_MARKER, True)
     return True
 
 
-__all__ = ["install_no_json_checkpoint_execution"]
+__all__ = ["install_no_json_checkpoint_execution", "progress_persistence_metrics"]

--- a/src/policy/owner_handoff_batch_performance.py
+++ b/src/policy/owner_handoff_batch_performance.py
@@ -2,9 +2,9 @@
 
 The bounded streaming loop already filters every activation batch against the
 canonical owner's ``_observation_deltas`` before invoking
-``record_observation_batch``.  The replay contract previously rebuilt a second
+``record_observation_batch``. The replay contract previously rebuilt a second
 ``recorded_delta_refs`` set before and after every batch, then serialized it into
-handoff checkpoints.  That index is redundant: exact owner reconstruction
+handoff checkpoints. That index is redundant: exact owner reconstruction
 recreates ``_observation_deltas`` before new activation continues.
 """
 
@@ -36,7 +36,7 @@ def install_owner_handoff_batch_performance() -> bool:
     ) -> None:
         started = monotonic_ns()
         # The caller has already selected deltas absent from the canonical
-        # owner's observation map.  Materialize this bounded leaf exactly once;
+        # owner's observation map. Materialize this bounded leaf exactly once;
         # do not rebuild a cumulative duplicate-membership set.
         new_deltas = tuple(deltas)
         if not new_deltas:
@@ -87,6 +87,31 @@ def install_owner_handoff_batch_performance() -> bool:
         return payload
 
     performance._compact_checkpoint_payload = compact_checkpoint_payload
+
+    # Old-contract checkpoints are an execution-cache miss and are recomputed.
+    # A malformed checkpoint that *claims the current v3 contract*, however,
+    # remains a hard error; silently ignoring corruption would weaken the
+    # existing replay contract and its tests.
+    permissive_load = performance._load_compact_checkpoint
+
+    def strict_current_checkpoint(self: Any) -> dict[str, Any] | None:
+        path = self.context.closure_handoff_checkpoint_path
+        if path is None or not path.exists():
+            return None
+        payload = parallel._read_json(path)
+        if payload is None:
+            raise ValueError("current closure handoff checkpoint is unreadable")
+        if (
+            payload.get("schema_version") != performance.HANDOFF_SCHEMA_VERSION
+            or payload.get("contract_ref") != performance.HANDOFF_CONTRACT
+        ):
+            return None
+        loaded = permissive_load(self)
+        if loaded is None:
+            raise ValueError("current closure handoff checkpoint identity mismatch")
+        return loaded
+
+    parallel.ClosureOwnerReplayContract._load_checkpoint = strict_current_checkpoint
     setattr(parallel, _INSTALL_MARKER, True)
     return True
 

--- a/src/policy/owner_handoff_batch_performance.py
+++ b/src/policy/owner_handoff_batch_performance.py
@@ -1,0 +1,94 @@
+"""Remove duplicate cumulative indexes from v3 closure handoff.
+
+The bounded streaming loop already filters every activation batch against the
+canonical owner's ``_observation_deltas`` before invoking
+``record_observation_batch``.  The replay contract previously rebuilt a second
+``recorded_delta_refs`` set before and after every batch, then serialized it into
+handoff checkpoints.  That index is redundant: exact owner reconstruction
+recreates ``_observation_deltas`` before new activation continues.
+"""
+
+from __future__ import annotations
+
+from time import monotonic_ns
+from typing import Any, Iterable
+
+
+_INSTALL_MARKER = "_owner_handoff_batch_performance_installed"
+
+
+def install_owner_handoff_batch_performance() -> bool:
+    from src.policy import owner_handoff_performance as performance
+    from src.policy import parallel_semantic_execution as parallel
+
+    if getattr(parallel, _INSTALL_MARKER, False):
+        return False
+    if not getattr(parallel, performance._INSTALL_MARKER, False):
+        raise RuntimeError(
+            "batch handoff performance must install after v3 owner handoff"
+        )
+
+    def record_observation_batch(
+        self: Any,
+        deltas: Iterable[Any],
+        *,
+        owner: Any,
+    ) -> None:
+        started = monotonic_ns()
+        # The caller has already selected deltas absent from the canonical
+        # owner's observation map.  Materialize this bounded leaf exactly once;
+        # do not rebuild a cumulative duplicate-membership set.
+        new_deltas = tuple(deltas)
+        if not new_deltas:
+            self.checkpoint_owner(owner, force=True)
+            return
+        artifact_ref = parallel._write_replay_artifact(
+            self.context,
+            artifact_kind="observation_delta_batch",
+            value={"deltas": [delta.to_dict() for delta in new_deltas]},
+        )
+        parallel._append_replay_event(
+            self.context,
+            artifact_kind="observation_delta_batch",
+            artifact_ref=artifact_ref,
+        )
+        self.checkpoint_owner(owner, force=True)
+        self.context.sample(
+            "owner_admission_batch",
+            phase="closure_handoff",
+            counts={
+                "rows_in": len(new_deltas),
+                "pending_jobs": len(owner._pending_jobs),
+                "owner_revision": owner.revision,
+            },
+            details={
+                "checkpoint_managed": True,
+                "duplicate_membership_index": False,
+            },
+            elapsed_ns=monotonic_ns() - started,
+        )
+
+    parallel.ClosureOwnerReplayContract.record_observation_batch = (
+        record_observation_batch
+    )
+
+    # v3 no longer needs recorded_delta_refs in the hot state or checkpoint.
+    original_payload = performance._compact_checkpoint_payload
+
+    def compact_checkpoint_payload(context: Any) -> dict[str, Any]:
+        payload = original_payload(context)
+        payload.pop("recorded_delta_refs", None)
+        # checkpoint_ref covers the complete payload, so recalculate after
+        # removing the redundant physical index.
+        payload.pop("checkpoint_ref", None)
+        payload["checkpoint_ref"] = "closure-handoff:" + parallel.canonical_sha256(
+            payload
+        )
+        return payload
+
+    performance._compact_checkpoint_payload = compact_checkpoint_payload
+    setattr(parallel, _INSTALL_MARKER, True)
+    return True
+
+
+__all__ = ["install_owner_handoff_batch_performance"]

--- a/src/policy/owner_handoff_performance.py
+++ b/src/policy/owner_handoff_performance.py
@@ -1,0 +1,389 @@
+"""Incremental hot-path execution for closure owner replay.
+
+This module changes physical execution only.  Semantic authority, proposal
+identity, canonical admission order and deterministic owner reconstruction remain
+unchanged.
+
+The v2 handoff representation repeatedly copied and serialized the complete
+replay-event history on every new admission.  On long documents that makes the
+handoff path quadratic in the number of replay events.  v3 keeps the immutable
+replay artifacts, appends one compact event row to a journal, and rewrites only
+the small current-frontier checkpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from time import monotonic_ns
+from typing import Any, Mapping
+
+from src.policy.carriers.canonical import canonical_sha256
+
+
+_INSTALL_MARKER = "_owner_handoff_performance_installed"
+HANDOFF_SCHEMA_VERSION = "sensiblaw.closure-handoff-state.v3"
+HANDOFF_CONTRACT = "closure-owner-replay:v3"
+JOURNAL_SCHEMA_VERSION = "sensiblaw.closure-handoff-journal-event.v1"
+
+
+def _cached_ref(instance: Any, cache_name: str, compute: Any) -> str:
+    cached = instance.__dict__.get(cache_name)
+    if cached is None:
+        cached = str(compute())
+        object.__setattr__(instance, cache_name, cached)
+    return str(cached)
+
+
+def _install_identity_caches() -> None:
+    """Cache immutable content-addressed identities after their first use."""
+
+    from src.pnf.factor_proposals import FactorProposal
+    from src.pnf.streaming_fixed_point import (
+        ObservationDelta,
+        OwnerKey,
+        SolverJob,
+        SolverReceipt,
+    )
+
+    # These carriers are frozen.  Their identity payload cannot change after
+    # construction, so recomputing the same canonical SHA on every dictionary
+    # probe/sort/replay serialization is pure waste.
+    FactorProposal.proposal_digest = property(  # type: ignore[assignment]
+        lambda self: _cached_ref(
+            self,
+            "_cached_proposal_digest",
+            lambda: canonical_sha256(self.identity_payload()),
+        )
+    )
+    FactorProposal.proposal_ref = property(  # type: ignore[assignment]
+        lambda self: _cached_ref(
+            self,
+            "_cached_proposal_ref",
+            lambda: "factor-proposal:" + self.proposal_digest,
+        )
+    )
+    OwnerKey.owner_ref = property(  # type: ignore[assignment]
+        lambda self: _cached_ref(
+            self,
+            "_cached_owner_ref",
+            lambda: "semantic-owner:" + canonical_sha256(self.to_dict()),
+        )
+    )
+    ObservationDelta.delta_ref = property(  # type: ignore[assignment]
+        lambda self: _cached_ref(
+            self,
+            "_cached_delta_ref",
+            lambda: "observation-delta:" + canonical_sha256(self.identity_payload()),
+        )
+    )
+    SolverJob.job_ref = property(  # type: ignore[assignment]
+        lambda self: _cached_ref(
+            self,
+            "_cached_job_ref",
+            lambda: "semantic-job:" + canonical_sha256(self.identity_payload()),
+        )
+    )
+    SolverReceipt.receipt_ref = property(  # type: ignore[assignment]
+        lambda self: _cached_ref(
+            self,
+            "_cached_receipt_ref",
+            lambda: "semantic-job-receipt:" + canonical_sha256(self.identity_payload()),
+        )
+    )
+
+
+def _journal_path(context: Any) -> Path | None:
+    root = context.closure_activation_checkpoint_root
+    if root is None:
+        return None
+    return root / f"handoff-events-{context.build_key_sha256}.jsonl"
+
+
+def _journal_event_digest(
+    *,
+    sequence_no: int,
+    artifact_kind: str,
+    artifact_ref: str,
+    prior_digest: str,
+) -> str:
+    return canonical_sha256(
+        {
+            "schema_version": JOURNAL_SCHEMA_VERSION,
+            "sequence_no": sequence_no,
+            "artifact_kind": artifact_kind,
+            "artifact_ref": artifact_ref,
+            "prior_digest": prior_digest,
+        }
+    )
+
+
+def _append_journal_event(
+    context: Any,
+    *,
+    artifact_kind: str,
+    artifact_ref: str,
+) -> None:
+    if context.reconstructing_owner:
+        return
+    activation = context.closure_activation
+    sequence_no = int(activation.get("journal_event_count") or 0)
+    prior_digest = str(activation.get("journal_digest") or "")
+    event_digest = _journal_event_digest(
+        sequence_no=sequence_no,
+        artifact_kind=artifact_kind,
+        artifact_ref=artifact_ref,
+        prior_digest=prior_digest,
+    )
+    row = {
+        "schema_version": JOURNAL_SCHEMA_VERSION,
+        "sequence_no": sequence_no,
+        "artifact_kind": artifact_kind,
+        "artifact_ref": artifact_ref,
+        "prior_digest": prior_digest,
+        "event_digest": event_digest,
+    }
+    path = _journal_path(context)
+    started = monotonic_ns()
+    if path is not None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # One append is the durable replay boundary.  We deliberately avoid
+        # rewriting the complete history.  flush() gives the same process-crash
+        # durability class as the existing atomic JSON writer; callers may opt
+        # into fsync when machine/power-loss durability is required.
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(row, separators=(",", ":"), sort_keys=True) + "\n")
+            handle.flush()
+            fsync_interval = max(
+                0, int(os.environ.get("SENSIBLAW_CLOSURE_JOURNAL_FSYNC_INTERVAL", "0"))
+            )
+            if fsync_interval and (sequence_no + 1) % fsync_interval == 0:
+                os.fsync(handle.fileno())
+    activation["journal_event_count"] = sequence_no + 1
+    activation["journal_digest"] = event_digest
+    activation["last_journal_artifact_kind"] = artifact_kind
+    activation["last_journal_artifact_ref"] = artifact_ref
+    with context.lock:
+        context.closure_counters["handoff_journal_events"] += 1
+        context.closure_counters["handoff_journal_append_ns"] += (
+            monotonic_ns() - started
+        )
+
+
+def _read_journal(context: Any, *, event_count: int, final_digest: str) -> list[dict[str, str]]:
+    if event_count == 0:
+        if final_digest:
+            raise ValueError("empty closure journal has a non-empty digest")
+        return []
+    path = _journal_path(context)
+    if path is None or not path.exists():
+        raise ValueError("closure handoff journal is missing")
+    events: list[dict[str, str]] = []
+    prior_digest = ""
+    with path.open("r", encoding="utf-8") as handle:
+        for raw in handle:
+            if len(events) >= event_count:
+                break
+            try:
+                row = json.loads(raw)
+            except (TypeError, ValueError) as error:
+                raise ValueError("closure handoff journal contains invalid JSON") from error
+            sequence_no = len(events)
+            artifact_kind = str(row.get("artifact_kind") or "")
+            artifact_ref = str(row.get("artifact_ref") or "")
+            if (
+                row.get("schema_version") != JOURNAL_SCHEMA_VERSION
+                or int(row.get("sequence_no", -1)) != sequence_no
+                or str(row.get("prior_digest") or "") != prior_digest
+                or artifact_kind
+                not in {
+                    "observation_delta",
+                    "observation_delta_batch",
+                    "proposal_batch",
+                    "solver_receipt",
+                    "dirty_reduction",
+                }
+                or not artifact_ref
+            ):
+                raise ValueError("closure handoff journal identity mismatch")
+            expected = _journal_event_digest(
+                sequence_no=sequence_no,
+                artifact_kind=artifact_kind,
+                artifact_ref=artifact_ref,
+                prior_digest=prior_digest,
+            )
+            if str(row.get("event_digest") or "") != expected:
+                raise ValueError("closure handoff journal digest mismatch")
+            prior_digest = expected
+            events.append(
+                {"artifact_kind": artifact_kind, "artifact_ref": artifact_ref}
+            )
+    if len(events) != event_count or prior_digest != final_digest:
+        raise ValueError("closure handoff journal is incomplete")
+    return events
+
+
+def _compact_checkpoint_payload(context: Any) -> dict[str, Any]:
+    from src.policy import parallel_semantic_execution as parallel
+
+    activation = context.closure_activation
+    payload: dict[str, Any] = {
+        "schema_version": HANDOFF_SCHEMA_VERSION,
+        "contract_ref": HANDOFF_CONTRACT,
+        **parallel._handoff_identity(context),
+        "next_leaf_ordinal": int(activation.get("next_leaf_ordinal") or 0),
+        # Activation leaves are bounded and independently checkpointed; retaining
+        # these refs avoids changing activation resume semantics.
+        "completed_leaf_refs": list(activation.get("completed_leaf_refs") or ()),
+        "buffered_leaf_refs": list(activation.get("buffered_leaf_refs") or ()),
+        "admitted_leaf_refs": list(activation.get("admitted_leaf_refs") or ()),
+        "admitted_batch_refs": list(activation.get("admitted_batch_refs") or ()),
+        "recorded_delta_refs": list(activation.get("recorded_delta_refs") or ()),
+        # Large cumulative replay-event/artifact lists live in the append-only
+        # journal instead of being copied into every checkpoint.
+        "journal_event_count": int(activation.get("journal_event_count") or 0),
+        "journal_digest": str(activation.get("journal_digest") or ""),
+        "current_owner_revision": int(activation.get("current_owner_revision") or 0),
+        "completed_reduction_key_refs": list(
+            activation.get("completed_reduction_key_refs") or ()
+        ),
+        "unresolved_frontier_refs": list(
+            activation.get("unresolved_frontier_refs") or ()
+        ),
+    }
+    payload["checkpoint_ref"] = "closure-handoff:" + canonical_sha256(payload)
+    return payload
+
+
+def _write_compact_checkpoint(context: Any) -> None:
+    from src.policy import parallel_semantic_execution as parallel
+
+    path = context.closure_handoff_checkpoint_path
+    if path is None or context.reconstructing_owner:
+        return
+    started = monotonic_ns()
+    payload = _compact_checkpoint_payload(context)
+    parallel._atomic_write_json(path, payload)
+    elapsed = monotonic_ns() - started
+    with context.lock:
+        context.closure_counters["handoff_compact_checkpoints"] += 1
+        context.closure_counters["handoff_compact_checkpoint_ns"] += elapsed
+        context.closure_counters["handoff_checkpoint_replay_rows_serialized"] += 0
+
+
+def _load_compact_checkpoint(self: Any) -> dict[str, Any] | None:
+    from src.policy import parallel_semantic_execution as parallel
+
+    path = self.context.closure_handoff_checkpoint_path
+    if path is None or not path.exists():
+        return None
+    payload = parallel._read_json(path)
+    if payload is None:
+        return None
+    checkpoint_ref = payload.pop("checkpoint_ref", None)
+    expected_ref = "closure-handoff:" + canonical_sha256(payload)
+    payload["checkpoint_ref"] = checkpoint_ref
+    if (
+        payload.get("schema_version") != HANDOFF_SCHEMA_VERSION
+        or payload.get("contract_ref") != HANDOFF_CONTRACT
+        or any(
+            payload.get(key) != value
+            for key, value in parallel._handoff_identity(self.context).items()
+        )
+        or checkpoint_ref != expected_ref
+    ):
+        return None
+
+    events = _read_journal(
+        self.context,
+        event_count=int(payload.get("journal_event_count") or 0),
+        final_digest=str(payload.get("journal_digest") or ""),
+    )
+    payload["replay_events"] = events
+    payload["delta_artifact_refs"] = [
+        event["artifact_ref"]
+        for event in events
+        if event["artifact_kind"] in {"observation_delta", "observation_delta_batch"}
+    ]
+    payload["proposal_batch_artifact_refs"] = [
+        event["artifact_ref"]
+        for event in events
+        if event["artifact_kind"] == "proposal_batch"
+    ]
+    payload["receipt_artifact_refs"] = [
+        event["artifact_ref"]
+        for event in events
+        if event["artifact_kind"] == "solver_receipt"
+    ]
+    payload["reduction_artifact_refs"] = [
+        event["artifact_ref"]
+        for event in events
+        if event["artifact_kind"] == "dirty_reduction"
+    ]
+    self.context.closure_activation.update(
+        {
+            key: tuple(value) if isinstance(value, list) else value
+            for key, value in payload.items()
+            if key not in parallel._handoff_identity(self.context)
+        }
+    )
+    return payload
+
+
+def _install_reconstruction_cleanup(parallel: Any) -> None:
+    original_reconstruct = parallel.ClosureOwnerReplayContract.reconstruct
+
+    def reconstruct(self: Any, owner: Any) -> None:
+        original_reconstruct(self, owner)
+        if not self.available:
+            return
+        # Replay lists are a one-time reconstruction view.  Keeping them after
+        # owner reconstruction would recreate the old cumulative-memory cost.
+        activation = self.context.closure_activation
+        for key in (
+            "replay_events",
+            "delta_artifact_refs",
+            "proposal_batch_artifact_refs",
+            "receipt_artifact_refs",
+            "reduction_artifact_refs",
+        ):
+            activation.pop(key, None)
+
+    parallel.ClosureOwnerReplayContract.reconstruct = reconstruct
+
+
+def install_owner_handoff_performance() -> bool:
+    """Install O(new-event) replay bookkeeping without changing semantics."""
+
+    from src.policy import parallel_semantic_execution as parallel
+
+    if getattr(parallel, _INSTALL_MARKER, False):
+        return False
+    if not getattr(parallel, "_parallel_semantic_execution_installed", False):
+        raise RuntimeError(
+            "owner handoff performance must install after parallel semantic execution"
+        )
+
+    _install_identity_caches()
+
+    # New handoff artifacts intentionally use a new compatibility identity.  A
+    # v2 checkpoint is ignored and recomputed rather than being interpreted under
+    # different physical replay semantics.
+    parallel.CLOSURE_HANDOFF_SCHEMA_VERSION = HANDOFF_SCHEMA_VERSION
+    parallel.CLOSURE_HANDOFF_CONTRACT = HANDOFF_CONTRACT
+    parallel._append_replay_event = _append_journal_event
+    parallel._write_closure_handoff_checkpoint = _write_compact_checkpoint
+    parallel.ClosureOwnerReplayContract._load_checkpoint = _load_compact_checkpoint
+    _install_reconstruction_cleanup(parallel)
+
+    setattr(parallel, _INSTALL_MARKER, True)
+    return True
+
+
+__all__ = [
+    "HANDOFF_CONTRACT",
+    "HANDOFF_SCHEMA_VERSION",
+    "JOURNAL_SCHEMA_VERSION",
+    "install_owner_handoff_performance",
+]

--- a/src/policy/owner_handoff_performance.py
+++ b/src/policy/owner_handoff_performance.py
@@ -1,12 +1,12 @@
 """Incremental hot-path execution for closure owner replay.
 
-This module changes physical execution only.  Semantic authority, proposal
+This module changes physical execution only. Semantic authority, proposal
 identity, canonical admission order and deterministic owner reconstruction remain
 unchanged.
 
 The v2 handoff representation repeatedly copied and serialized the complete
-replay-event history on every new admission.  On long documents that makes the
-handoff path quadratic in the number of replay events.  v3 keeps the immutable
+replay-event history on every new admission. On long documents that makes the
+handoff path quadratic in the number of replay events. v3 keeps the immutable
 replay artifacts, appends one compact event row to a journal, and rewrites only
 the small current-frontier checkpoint.
 """
@@ -17,7 +17,7 @@ import json
 import os
 from pathlib import Path
 from time import monotonic_ns
-from typing import Any, Mapping
+from typing import Any
 
 from src.policy.carriers.canonical import canonical_sha256
 
@@ -47,9 +47,8 @@ def _install_identity_caches() -> None:
         SolverReceipt,
     )
 
-    # These carriers are frozen.  Their identity payload cannot change after
-    # construction, so recomputing the same canonical SHA on every dictionary
-    # probe/sort/replay serialization is pure waste.
+    # These carriers are frozen and non-slotted. Their identity payload cannot
+    # change after construction, so repeated canonical hashing is pure overhead.
     FactorProposal.proposal_digest = property(  # type: ignore[assignment]
         lambda self: _cached_ref(
             self,
@@ -119,6 +118,19 @@ def _journal_event_digest(
     )
 
 
+def _prepare_fresh_journal(context: Any) -> None:
+    activation = context.closure_activation
+    if activation.get("journal_initialized"):
+        return
+    path = _journal_path(context)
+    if path is not None and path.exists():
+        # No accepted v3 checkpoint owns this tail. It may be from an interrupted
+        # attempt or an incompatible v2 run, so retaining it would make the next
+        # sequence non-canonical. Replay artifacts themselves remain immutable.
+        path.unlink()
+    activation["journal_initialized"] = True
+
+
 def _append_journal_event(
     context: Any,
     *,
@@ -128,6 +140,7 @@ def _append_journal_event(
     if context.reconstructing_owner:
         return
     activation = context.closure_activation
+    _prepare_fresh_journal(context)
     sequence_no = int(activation.get("journal_event_count") or 0)
     prior_digest = str(activation.get("journal_digest") or "")
     event_digest = _journal_event_digest(
@@ -148,15 +161,19 @@ def _append_journal_event(
     started = monotonic_ns()
     if path is not None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        # One append is the durable replay boundary.  We deliberately avoid
-        # rewriting the complete history.  flush() gives the same process-crash
-        # durability class as the existing atomic JSON writer; callers may opt
-        # into fsync when machine/power-loss durability is required.
+        # One small append replaces O(history) tuple copies plus O(history)
+        # checkpoint serialization. flush() matches the previous process-crash
+        # durability class; optional fsync is available for stronger durability.
         with path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(row, separators=(",", ":"), sort_keys=True) + "\n")
             handle.flush()
             fsync_interval = max(
-                0, int(os.environ.get("SENSIBLAW_CLOSURE_JOURNAL_FSYNC_INTERVAL", "0"))
+                0,
+                int(
+                    os.environ.get(
+                        "SENSIBLAW_CLOSURE_JOURNAL_FSYNC_INTERVAL", "0"
+                    )
+                ),
             )
             if fsync_interval and (sequence_no + 1) % fsync_interval == 0:
                 os.fsync(handle.fileno())
@@ -171,23 +188,31 @@ def _append_journal_event(
         )
 
 
-def _read_journal(context: Any, *, event_count: int, final_digest: str) -> list[dict[str, str]]:
+def _read_journal(
+    context: Any,
+    *,
+    event_count: int,
+    final_digest: str,
+) -> tuple[list[dict[str, str]], int]:
     if event_count == 0:
         if final_digest:
             raise ValueError("empty closure journal has a non-empty digest")
-        return []
+        return [], 0
     path = _journal_path(context)
     if path is None or not path.exists():
         raise ValueError("closure handoff journal is missing")
     events: list[dict[str, str]] = []
     prior_digest = ""
-    with path.open("r", encoding="utf-8") as handle:
-        for raw in handle:
-            if len(events) >= event_count:
+    committed_bytes = 0
+    with path.open("rb") as handle:
+        while len(events) < event_count:
+            raw = handle.readline()
+            if not raw:
                 break
+            committed_bytes = handle.tell()
             try:
-                row = json.loads(raw)
-            except (TypeError, ValueError) as error:
+                row = json.loads(raw.decode("utf-8"))
+            except (UnicodeDecodeError, TypeError, ValueError) as error:
                 raise ValueError("closure handoff journal contains invalid JSON") from error
             sequence_no = len(events)
             artifact_kind = str(row.get("artifact_kind") or "")
@@ -221,7 +246,29 @@ def _read_journal(context: Any, *, event_count: int, final_digest: str) -> list[
             )
     if len(events) != event_count or prior_digest != final_digest:
         raise ValueError("closure handoff journal is incomplete")
-    return events
+    return events, committed_bytes
+
+
+def _discard_uncheckpointed_journal_tail(context: Any, committed_bytes: int) -> None:
+    """Drop events written after the last atomic frontier checkpoint.
+
+    Such events have replay artifacts but no matching owner revision/frontier
+    snapshot. Recomputing that bounded tail is safer than guessing its state.
+    """
+
+    path = _journal_path(context)
+    if path is None or not path.exists():
+        return
+    size = path.stat().st_size
+    if size <= committed_bytes:
+        return
+    with path.open("r+b") as handle:
+        handle.truncate(committed_bytes)
+        handle.flush()
+    with context.lock:
+        context.closure_counters["handoff_uncheckpointed_tail_bytes"] += (
+            size - committed_bytes
+        )
 
 
 def _compact_checkpoint_payload(context: Any) -> dict[str, Any]:
@@ -233,15 +280,15 @@ def _compact_checkpoint_payload(context: Any) -> dict[str, Any]:
         "contract_ref": HANDOFF_CONTRACT,
         **parallel._handoff_identity(context),
         "next_leaf_ordinal": int(activation.get("next_leaf_ordinal") or 0),
-        # Activation leaves are bounded and independently checkpointed; retaining
-        # these refs avoids changing activation resume semantics.
+        # Activation leaves are separately bounded/checkpointed. These lists are
+        # small relative to proposal/receipt replay history and retain existing
+        # activation resume semantics.
         "completed_leaf_refs": list(activation.get("completed_leaf_refs") or ()),
         "buffered_leaf_refs": list(activation.get("buffered_leaf_refs") or ()),
         "admitted_leaf_refs": list(activation.get("admitted_leaf_refs") or ()),
         "admitted_batch_refs": list(activation.get("admitted_batch_refs") or ()),
         "recorded_delta_refs": list(activation.get("recorded_delta_refs") or ()),
-        # Large cumulative replay-event/artifact lists live in the append-only
-        # journal instead of being copied into every checkpoint.
+        # The large cumulative replay history lives in the append-only journal.
         "journal_event_count": int(activation.get("journal_event_count") or 0),
         "journal_digest": str(activation.get("journal_digest") or ""),
         "current_owner_revision": int(activation.get("current_owner_revision") or 0),
@@ -295,11 +342,12 @@ def _load_compact_checkpoint(self: Any) -> dict[str, Any] | None:
     ):
         return None
 
-    events = _read_journal(
+    events, committed_bytes = _read_journal(
         self.context,
         event_count=int(payload.get("journal_event_count") or 0),
         final_digest=str(payload.get("journal_digest") or ""),
     )
+    _discard_uncheckpointed_journal_tail(self.context, committed_bytes)
     payload["replay_events"] = events
     payload["delta_artifact_refs"] = [
         event["artifact_ref"]
@@ -328,6 +376,7 @@ def _load_compact_checkpoint(self: Any) -> dict[str, Any] | None:
             if key not in parallel._handoff_identity(self.context)
         }
     )
+    self.context.closure_activation["journal_initialized"] = True
     return payload
 
 
@@ -338,7 +387,7 @@ def _install_reconstruction_cleanup(parallel: Any) -> None:
         original_reconstruct(self, owner)
         if not self.available:
             return
-        # Replay lists are a one-time reconstruction view.  Keeping them after
+        # Replay lists are a one-time reconstruction view. Keeping them after
         # owner reconstruction would recreate the old cumulative-memory cost.
         activation = self.context.closure_activation
         for key in (
@@ -356,20 +405,23 @@ def _install_reconstruction_cleanup(parallel: Any) -> None:
 def install_owner_handoff_performance() -> bool:
     """Install O(new-event) replay bookkeeping without changing semantics."""
 
+    from src.policy import operational_corpus_compilation as operational
     from src.policy import parallel_semantic_execution as parallel
 
     if getattr(parallel, _INSTALL_MARKER, False):
         return False
-    if not getattr(parallel, "_parallel_semantic_execution_installed", False):
+    if not getattr(
+        operational, parallel._INSTALL_MARKER, False
+    ):
         raise RuntimeError(
             "owner handoff performance must install after parallel semantic execution"
         )
 
     _install_identity_caches()
 
-    # New handoff artifacts intentionally use a new compatibility identity.  A
-    # v2 checkpoint is ignored and recomputed rather than being interpreted under
-    # different physical replay semantics.
+    # A v2 checkpoint is intentionally ignored rather than interpreted under a
+    # different physical replay contract. Semantic content is recomputed from
+    # the immutable source/proposal inputs.
     parallel.CLOSURE_HANDOFF_SCHEMA_VERSION = HANDOFF_SCHEMA_VERSION
     parallel.CLOSURE_HANDOFF_CONTRACT = HANDOFF_CONTRACT
     parallel._append_replay_event = _append_journal_event

--- a/src/policy/owner_handoff_performance.py
+++ b/src/policy/owner_handoff_performance.py
@@ -13,9 +13,9 @@ the small current-frontier checkpoint.
 
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
+import struct
 from time import monotonic_ns
 from typing import Any
 
@@ -26,6 +26,18 @@ _INSTALL_MARKER = "_owner_handoff_performance_installed"
 HANDOFF_SCHEMA_VERSION = "sensiblaw.closure-handoff-state.v3"
 HANDOFF_CONTRACT = "closure-owner-replay:v3"
 JOURNAL_SCHEMA_VERSION = "sensiblaw.closure-handoff-journal-event.v1"
+_JOURNAL_MAGIC = b"SLHJ"
+_JOURNAL_HEADER = struct.Struct(">4sQBI")
+_JOURNAL_DIGEST_BYTES = 32
+_JOURNAL_MAX_REF_BYTES = 1024 * 1024
+_JOURNAL_KIND_CODES = {
+    "observation_delta": 1,
+    "observation_delta_batch": 2,
+    "proposal_batch": 3,
+    "solver_receipt": 4,
+    "dirty_reduction": 5,
+}
+_JOURNAL_CODE_KINDS = {value: key for key, value in _JOURNAL_KIND_CODES.items()}
 
 
 def _cached_ref(instance: Any, cache_name: str, compute: Any) -> str:
@@ -97,7 +109,7 @@ def _journal_path(context: Any) -> Path | None:
     root = context.closure_activation_checkpoint_root
     if root is None:
         return None
-    return root / f"handoff-events-{context.build_key_sha256}.jsonl"
+    return root / f"handoff-events-{context.build_key_sha256}.bin"
 
 
 def _journal_event_digest(
@@ -149,14 +161,37 @@ def _append_journal_event(
         artifact_ref=artifact_ref,
         prior_digest=prior_digest,
     )
-    row = {
-        "schema_version": JOURNAL_SCHEMA_VERSION,
-        "sequence_no": sequence_no,
-        "artifact_kind": artifact_kind,
-        "artifact_ref": artifact_ref,
-        "prior_digest": prior_digest,
-        "event_digest": event_digest,
-    }
+    try:
+        kind_code = _JOURNAL_KIND_CODES[artifact_kind]
+    except KeyError as error:
+        raise ValueError(
+            f"unsupported closure journal event: {artifact_kind}"
+        ) from error
+    artifact_ref_bytes = artifact_ref.encode("utf-8")
+    if not artifact_ref_bytes or len(artifact_ref_bytes) > _JOURNAL_MAX_REF_BYTES:
+        raise ValueError("closure journal artifact reference has invalid size")
+    prior_digest_bytes = (
+        bytes.fromhex(prior_digest) if prior_digest else bytes(_JOURNAL_DIGEST_BYTES)
+    )
+    event_digest_bytes = bytes.fromhex(event_digest)
+    if (
+        len(prior_digest_bytes) != _JOURNAL_DIGEST_BYTES
+        or len(event_digest_bytes) != _JOURNAL_DIGEST_BYTES
+    ):
+        raise ValueError("closure journal digest has invalid size")
+    frame = b"".join(
+        (
+            _JOURNAL_HEADER.pack(
+                _JOURNAL_MAGIC,
+                sequence_no,
+                kind_code,
+                len(artifact_ref_bytes),
+            ),
+            artifact_ref_bytes,
+            prior_digest_bytes,
+            event_digest_bytes,
+        )
+    )
     path = _journal_path(context)
     started = monotonic_ns()
     if path is not None:
@@ -164,16 +199,12 @@ def _append_journal_event(
         # One small append replaces O(history) tuple copies plus O(history)
         # checkpoint serialization. flush() matches the previous process-crash
         # durability class; optional fsync is available for stronger durability.
-        with path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(row, separators=(",", ":"), sort_keys=True) + "\n")
+        with path.open("ab") as handle:
+            handle.write(frame)
             handle.flush()
             fsync_interval = max(
                 0,
-                int(
-                    os.environ.get(
-                        "SENSIBLAW_CLOSURE_JOURNAL_FSYNC_INTERVAL", "0"
-                    )
-                ),
+                int(os.environ.get("SENSIBLAW_CLOSURE_JOURNAL_FSYNC_INTERVAL", "0")),
             )
             if fsync_interval and (sequence_no + 1) % fsync_interval == 0:
                 os.fsync(handle.fileno())
@@ -181,11 +212,12 @@ def _append_journal_event(
     activation["journal_digest"] = event_digest
     activation["last_journal_artifact_kind"] = artifact_kind
     activation["last_journal_artifact_ref"] = artifact_ref
-    with context.lock:
-        context.closure_counters["handoff_journal_events"] += 1
-        context.closure_counters["handoff_journal_append_ns"] += (
-            monotonic_ns() - started
-        )
+    # Replay admission is the serial owner authority. Several canonical owner
+    # wrappers call this function while already holding ``context.lock``; taking
+    # that non-reentrant lock again would deadlock. Keep telemetry on the same
+    # serialized admission path instead of introducing a second lock boundary.
+    context.closure_counters["handoff_journal_events"] += 1
+    context.closure_counters["handoff_journal_append_ns"] += monotonic_ns() - started
 
 
 def _read_journal(
@@ -206,29 +238,43 @@ def _read_journal(
     committed_bytes = 0
     with path.open("rb") as handle:
         while len(events) < event_count:
-            raw = handle.readline()
-            if not raw:
+            header = handle.read(_JOURNAL_HEADER.size)
+            if not header:
                 break
-            committed_bytes = handle.tell()
+            if len(header) != _JOURNAL_HEADER.size:
+                raise ValueError("closure handoff journal contains a partial header")
             try:
-                row = json.loads(raw.decode("utf-8"))
-            except (UnicodeDecodeError, TypeError, ValueError) as error:
-                raise ValueError("closure handoff journal contains invalid JSON") from error
-            sequence_no = len(events)
-            artifact_kind = str(row.get("artifact_kind") or "")
-            artifact_ref = str(row.get("artifact_ref") or "")
+                magic, stored_sequence, kind_code, ref_size = _JOURNAL_HEADER.unpack(
+                    header
+                )
+            except struct.error as error:
+                raise ValueError("closure handoff journal header is invalid") from error
             if (
-                row.get("schema_version") != JOURNAL_SCHEMA_VERSION
-                or int(row.get("sequence_no", -1)) != sequence_no
-                or str(row.get("prior_digest") or "") != prior_digest
-                or artifact_kind
-                not in {
-                    "observation_delta",
-                    "observation_delta_batch",
-                    "proposal_batch",
-                    "solver_receipt",
-                    "dirty_reduction",
-                }
+                magic != _JOURNAL_MAGIC
+                or ref_size == 0
+                or ref_size > _JOURNAL_MAX_REF_BYTES
+            ):
+                raise ValueError("closure handoff journal frame identity mismatch")
+            remainder = handle.read(ref_size + 2 * _JOURNAL_DIGEST_BYTES)
+            if len(remainder) != ref_size + 2 * _JOURNAL_DIGEST_BYTES:
+                raise ValueError("closure handoff journal contains a partial frame")
+            sequence_no = len(events)
+            artifact_kind = _JOURNAL_CODE_KINDS.get(kind_code, "")
+            try:
+                artifact_ref = remainder[:ref_size].decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise ValueError(
+                    "closure handoff journal artifact reference is invalid"
+                ) from error
+            prior_bytes = remainder[ref_size : ref_size + _JOURNAL_DIGEST_BYTES]
+            event_bytes = remainder[ref_size + _JOURNAL_DIGEST_BYTES :]
+            stored_prior_digest = (
+                "" if prior_bytes == bytes(_JOURNAL_DIGEST_BYTES) else prior_bytes.hex()
+            )
+            if (
+                stored_sequence != sequence_no
+                or stored_prior_digest != prior_digest
+                or artifact_kind not in _JOURNAL_KIND_CODES
                 or not artifact_ref
             ):
                 raise ValueError("closure handoff journal identity mismatch")
@@ -238,12 +284,13 @@ def _read_journal(
                 artifact_ref=artifact_ref,
                 prior_digest=prior_digest,
             )
-            if str(row.get("event_digest") or "") != expected:
+            if event_bytes.hex() != expected:
                 raise ValueError("closure handoff journal digest mismatch")
             prior_digest = expected
             events.append(
                 {"artifact_kind": artifact_kind, "artifact_ref": artifact_ref}
             )
+            committed_bytes = handle.tell()
     if len(events) != event_count or prior_digest != final_digest:
         raise ValueError("closure handoff journal is incomplete")
     return events, committed_bytes
@@ -410,9 +457,7 @@ def install_owner_handoff_performance() -> bool:
 
     if getattr(parallel, _INSTALL_MARKER, False):
         return False
-    if not getattr(
-        operational, parallel._INSTALL_MARKER, False
-    ):
+    if not getattr(operational, parallel._INSTALL_MARKER, False):
         raise RuntimeError(
             "owner handoff performance must install after parallel semantic execution"
         )

--- a/src/policy/parallel_semantic_execution.py
+++ b/src/policy/parallel_semantic_execution.py
@@ -1568,6 +1568,51 @@ def install_parallel_semantic_execution() -> bool:
         started = monotonic_ns()
         result = original_admit_proposals(self, batch, stage=stage)
         if context is not None and result.accepted_proposal_refs:
+            if not context.reconstructing_owner:
+                context.sample(
+                    "owner_proposal_admission",
+                    phase="started",
+                    counts={
+                        "proposal_count": len(batch),
+                        "accepted_proposal_count": len(
+                            result.accepted_proposal_refs
+                        ),
+                    },
+                    details={
+                        "stage": stage,
+                        "current_work_key": f"proposal-batch:{stage}",
+                    },
+                )
+            artifact_ref: str | None = None
+            artifact_started = monotonic_ns()
+            if not context.reconstructing_owner:
+                # Content addressing can walk a large proposal batch.  Keep
+                # that physical work outside the shared telemetry/state lock;
+                # otherwise every worker appears blocked while the owner
+                # hashes an immutable replay artifact.
+                artifact_ref = _write_replay_artifact(
+                    context,
+                    artifact_kind="proposal_batch",
+                    value={
+                        "stage": stage,
+                        "proposals": [row.to_dict() for row in batch],
+                    },
+                )
+                context.sample(
+                    "owner_proposal_replay_artifact",
+                    phase="completed",
+                    counts={
+                        "proposal_count": len(batch),
+                        "accepted_proposal_count": len(
+                            result.accepted_proposal_refs
+                        ),
+                    },
+                    details={
+                        "stage": stage,
+                        "artifact_ref": artifact_ref,
+                    },
+                    elapsed_ns=monotonic_ns() - artifact_started,
+                )
             with context.lock:
                 counter_key = (
                     "reconstructed_proposals_admitted"
@@ -1577,15 +1622,7 @@ def install_parallel_semantic_execution() -> bool:
                 context.closure_counters[counter_key] += len(
                     result.accepted_proposal_refs
                 )
-                if not context.reconstructing_owner:
-                    artifact_ref = _write_replay_artifact(
-                        context,
-                        artifact_kind="proposal_batch",
-                        value={
-                            "stage": stage,
-                            "proposals": [row.to_dict() for row in batch],
-                        },
-                    )
+                if artifact_ref is not None:
                     _append_replay_event(
                         context,
                         artifact_kind="proposal_batch",

--- a/src/policy/progress_observability_execution.py
+++ b/src/policy/progress_observability_execution.py
@@ -120,9 +120,7 @@ def _universal_envelope(
             detail_values.get("checkpoint_bytes_reused") or 0
         ),
         "queue_count": int(
-            count_values.get("queue_count")
-            or count_values.get("pending_jobs")
-            or 0
+            count_values.get("queue_count") or count_values.get("pending_jobs") or 0
         ),
         "in_flight_count": int(
             count_values.get("in_flight_count")
@@ -136,9 +134,7 @@ def _universal_envelope(
         "rss_bytes": int(resource_row.get("rss_bytes") or 0),
         "pss_bytes": int(resource_row.get("pss_bytes") or 0),
         "uss_bytes": int(resource_row.get("uss_bytes") or 0),
-        "retained_object_delta": int(
-            detail_values.get("retained_object_delta") or 0
-        ),
+        "retained_object_delta": int(detail_values.get("retained_object_delta") or 0),
         "elapsed_ns": elapsed_ns,
         "counts": dict(sorted(count_values.items())),
         "details": detail_values,

--- a/src/policy/reference_backed_finalization.py
+++ b/src/policy/reference_backed_finalization.py
@@ -133,8 +133,10 @@ class ReferenceBackedFinalizationOwner(FinalizationHardenedOwner):
         original_root = self._finalization_root
         self._finalization_root = None
         try:
-            reduction = LivenessBoundedStreamingSemanticOwner._materialize_reduction_now(
-                self, generation
+            reduction = (
+                LivenessBoundedStreamingSemanticOwner._materialize_reduction_now(
+                    self, generation
+                )
             )
         finally:
             self._finalization_root = original_root
@@ -199,10 +201,7 @@ class ReferenceBackedFinalizationOwner(FinalizationHardenedOwner):
             ),
             (
                 "coverage_notices",
-                (
-                    self._coverage_notices[key]
-                    for key in sorted(self._coverage_notices)
-                ),
+                (self._coverage_notices[key] for key in sorted(self._coverage_notices)),
             ),
             ("proposals", (self._proposals[key] for key in sorted(self._proposals))),
             ("solver_jobs", (jobs[key] for key in sorted(jobs))),
@@ -355,9 +354,7 @@ class ReferenceBackedFinalizationOwner(FinalizationHardenedOwner):
             "solver_receipts": manifests["solver_receipts"],
             "state_deltas": manifests["state_deltas"],
             "materialized_reduction": reduction_manifest,
-            "region_boundary_summaries": manifests[
-                "region_boundary_summaries"
-            ],
+            "region_boundary_summaries": manifests["region_boundary_summaries"],
             "family_manifests": manifests,
             "pending_job_refs": [],
             "in_flight_job_refs": [],
@@ -384,9 +381,7 @@ class ReferenceBackedFinalizationOwner(FinalizationHardenedOwner):
             phase="isolated_serializer_started",
         )
         self._begin_phase(FinalizationPhase.SERIALIZE_CLOSURE_RECEIPT, total=1)
-        hard_mib = int(
-            os.environ.get("SENSIBLAW_STAGE_SERIALIZATION_HARD_MIB", "3072")
-        )
+        hard_mib = int(os.environ.get("SENSIBLAW_STAGE_SERIALIZATION_HARD_MIB", "3072"))
         serializer_report = run_isolated_reference_serializer(
             spec_path=spec_path,
             output_path=output_path,

--- a/src/runtime/checkpoint_retention.py
+++ b/src/runtime/checkpoint_retention.py
@@ -101,7 +101,9 @@ class CheckpointRetentionLedger:
         try:
             target.relative_to(self.root)
         except ValueError as error:
-            raise ValueError("checkpoint path must remain below retention root") from error
+            raise ValueError(
+                "checkpoint path must remain below retention root"
+            ) from error
         artifact = CheckpointArtifact(
             path=str(target),
             retention_class=retention_class,

--- a/src/runtime/durable_work_items.py
+++ b/src/runtime/durable_work_items.py
@@ -23,8 +23,20 @@ PARENT_DEATH_CONTRACT = "linux-pdeathsig:v1"
 BINARY_ARTIFACT_CONTRACT = "python-pickle:5"
 
 
+def _canonical_sha256(value: object) -> str:
+    from src.policy.carriers.canonical import canonical_sha256
+
+    return canonical_sha256(value)
+
+
+def _canonical_fields_sha256(*values: object) -> str:
+    from src.policy.carriers.canonical import canonical_fields_sha256
+
+    return canonical_fields_sha256(*values)
+
+
 def _digest(value: object) -> bytes:
-    return bytes.fromhex(canonical_sha256(value))
+    return bytes.fromhex(_canonical_sha256(value))
 
 
 def _connect(database_url: str) -> Any:
@@ -55,11 +67,11 @@ class DurableWorkSpec:
 
     @property
     def input_sha256(self) -> str:
-        return canonical_sha256(dict(self.input_manifest))
+        return _canonical_sha256(dict(self.input_manifest))
 
     @property
     def stage_instance_ref(self) -> str:
-        return "stage-instance:" + canonical_fields_sha256(
+        return "stage-instance:" + _canonical_fields_sha256(
             self.run_ref,
             self.document_ref,
             self.stage_contract_ref,
@@ -69,7 +81,7 @@ class DurableWorkSpec:
 
     @property
     def work_ref(self) -> str:
-        return "work-item:" + canonical_fields_sha256(
+        return "work-item:" + _canonical_fields_sha256(
             self.run_ref,
             self.document_ref,
             self.stage_contract_ref,
@@ -151,7 +163,7 @@ def register_work_items(specs: Iterable[DurableWorkSpec]) -> int:
                             ),
                         )
                         stage_digest = bytes.fromhex(
-                            canonical_fields_sha256(
+                            _canonical_fields_sha256(
                                 spec.run_ref,
                                 spec.document_ref,
                                 spec.stage_contract_ref,
@@ -303,7 +315,7 @@ def _write_artifact(
 ) -> tuple[Path, bytes, bytes, int]:
     encoded = pickle.dumps(value, protocol=5)
     content_digest = hashlib.sha256(encoded).digest()
-    output_digest = bytes.fromhex(canonical_sha256(value))
+    output_digest = bytes.fromhex(_canonical_sha256(value))
     path = _artifact_path(spec, content_digest.hex())
     path.parent.mkdir(parents=True, exist_ok=True)
     if not path.exists():
@@ -347,7 +359,7 @@ def _receipt_row(
     admission_state: str,
 ) -> tuple[str, bytes]:
     spec = lease.spec
-    receipt_ref = "work-receipt:" + canonical_fields_sha256(
+    receipt_ref = "work-receipt:" + _canonical_fields_sha256(
         DURABLE_WORK_CONTRACT,
         spec.work_ref,
         lease.attempt_ref,
@@ -361,7 +373,7 @@ def _receipt_row(
         admission_state,
     )
     digest = bytes.fromhex(
-        canonical_fields_sha256(
+        _canonical_fields_sha256(
             receipt_ref,
             spec.work_ref,
             lease.attempt_ref,
@@ -386,7 +398,7 @@ def complete_leased_work(
 ) -> dict[str, Any]:
     spec = lease.spec
     path, content_digest, output_digest, byte_count = _write_artifact(spec, value)
-    artifact_ref = "artifact-segment:" + canonical_fields_sha256(
+    artifact_ref = "artifact-segment:" + _canonical_fields_sha256(
         spec.work_ref,
         content_digest,
         BINARY_ARTIFACT_CONTRACT,
@@ -531,7 +543,7 @@ def complete_leased_work(
                     cursor, spec.stage_instance_ref
                 )
                 cursor_digest = bytes.fromhex(
-                    canonical_fields_sha256(
+                    _canonical_fields_sha256(
                         spec.stage_instance_ref,
                         contiguous,
                         completed,
@@ -624,7 +636,7 @@ def load_completed_work(spec: DurableWorkSpec) -> Any | None:
     if hashlib.sha256(encoded).hexdigest() != str(expected_content):
         raise RuntimeError("durable binary artifact content digest mismatch")
     value = pickle.loads(encoded)
-    if canonical_sha256(value) != str(expected_output):
+    if _canonical_sha256(value) != str(expected_output):
         raise RuntimeError("durable binary artifact semantic digest mismatch")
     return value
 
@@ -735,14 +747,3 @@ __all__ = [
     "recover_expired_work",
     "register_work_items",
 ]
-
-
-def __getattr__(name: str) -> Any:
-    if name in {"canonical_sha256", "canonical_fields_sha256"}:
-        from src.policy.carriers.canonical import (
-            canonical_fields_sha256,
-            canonical_sha256,
-        )
-
-        return locals()[name]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/runtime/progress.py
+++ b/src/runtime/progress.py
@@ -22,7 +22,7 @@ from time import monotonic_ns
 from typing import Any, Iterator, Mapping, TextIO
 
 
-PROGRESS_SCHEMA_VERSION = "sl.progress_event.v0_4"
+PROGRESS_SCHEMA_VERSION = "sl.progress_event.v0_5"
 PHASE_LEDGER_SCHEMA_VERSION = "sl.phase_ledger.v0_1"
 
 
@@ -65,8 +65,7 @@ def _measure_snapshot(
                 remaining_ms = round((total - completed) / rate * 1_000)
                 row["estimated_remaining_ms"] = max(0, remaining_ms)
                 row["estimated_completion_at"] = (
-                    datetime.now(UTC)
-                    + timedelta(milliseconds=max(0, remaining_ms))
+                    datetime.now(UTC) + timedelta(milliseconds=max(0, remaining_ms))
                 ).isoformat()
         result[name] = row
     return result
@@ -88,6 +87,8 @@ class ProgressEvent:
     throughput_units_per_second: float | None = None
     estimated_remaining_ms: int | None = None
     estimated_completion_at: str | None = None
+    estimated_run_remaining_ms: int | None = None
+    estimated_run_completion_at: str | None = None
     processed_tokens: int | None = None
     total_tokens: int | None = None
     tokens_per_second: float | None = None
@@ -259,7 +260,9 @@ class PhaseHandle:
             if worker is not None:
                 self.worker = worker
         self.recorder.emit(
-            self._event(state="stage_started", elapsed_ms=self.elapsed_ms, message=stage)
+            self._event(
+                state="stage_started", elapsed_ms=self.elapsed_ms, message=stage
+            )
         )
 
     @contextmanager
@@ -318,9 +321,7 @@ class PhaseHandle:
 
         with self._state_lock:
             if self.active_stage is None:
-                raise RuntimeError(
-                    "cannot observe inner work without an active stage"
-                )
+                raise RuntimeError("cannot observe inner work without an active stage")
             for name, value in (measures or {}).items():
                 if isinstance(value, Mapping):
                     self.measures[name] = {**self.measures.get(name, {}), **dict(value)}
@@ -444,14 +445,62 @@ class PhaseHandle:
         )
 
     def _outer_estimate(self, elapsed_ms: int) -> dict[str, Any]:
-        if self.total is None or self.total <= 0 or self.completed <= 0 or elapsed_ms <= 0:
+        if (
+            self.total is None
+            or self.total <= 0
+            or self.completed <= 0
+            or elapsed_ms <= 0
+        ):
             return {}
         throughput = self.completed / (elapsed_ms / 1_000)
-        remaining_ms = round(elapsed_ms * (self.total - self.completed) / self.completed)
+        remaining_ms = round(
+            elapsed_ms * (self.total - self.completed) / self.completed
+        )
         return {
             "throughput_units_per_second": round(throughput, 3),
             "estimated_remaining_ms": max(0, remaining_ms),
             "estimated_completion_at": (
+                datetime.now(UTC) + timedelta(milliseconds=max(0, remaining_ms))
+            ).isoformat(),
+        }
+
+    def _run_estimate(self, elapsed_ms: int) -> dict[str, Any]:
+        """Estimate the whole phase, including the active stage.
+
+        Completed stages provide an observed average.  When the active stage
+        exposes a measurable total, its own remaining estimate replaces the
+        average for that stage; this avoids claiming the run is nearly done
+        merely because the current stage has not closed yet.
+        """
+
+        if self.total is None or self.total <= 0 or elapsed_ms <= 0:
+            return {}
+        completed = max(0, self.completed)
+        average_stage_ms = elapsed_ms / completed if completed else None
+        active_remaining_ms: float | None = None
+        if self.active_stage is not None and self._stage_started_ns is not None:
+            stage_elapsed_ms = self.stage_elapsed_ms
+            for row in _measure_snapshot(self.measures, stage_elapsed_ms).values():
+                remaining = row.get("estimated_remaining_ms")
+                if remaining is not None:
+                    active_remaining_ms = max(
+                        float(active_remaining_ms or 0), float(remaining)
+                    )
+            if active_remaining_ms is None and average_stage_ms is not None:
+                active_remaining_ms = max(0.0, average_stage_ms - stage_elapsed_ms)
+        if active_remaining_ms is None:
+            if completed <= 0:
+                return {}
+            active_remaining_ms = 0.0
+        remaining_stages = max(
+            0, self.total - completed - (self.active_stage is not None)
+        )
+        if average_stage_ms is None:
+            return {}
+        remaining_ms = round(active_remaining_ms + remaining_stages * average_stage_ms)
+        return {
+            "estimated_run_remaining_ms": max(0, remaining_ms),
+            "estimated_run_completion_at": (
                 datetime.now(UTC) + timedelta(milliseconds=max(0, remaining_ms))
             ).isoformat(),
         }
@@ -492,6 +541,7 @@ class PhaseHandle:
             stage_elapsed_ms=stage_elapsed,
             measures=measures,
             **self._outer_estimate(elapsed_ms),
+            **self._run_estimate(elapsed_ms),
         )
 
     @property
@@ -563,6 +613,11 @@ def emit_progress(
         if event.estimated_completion_at
         else ""
     )
+    run_eta_at = (
+        f" run_eta_at={event.estimated_run_completion_at}"
+        if event.estimated_run_completion_at
+        else ""
+    )
     stage = f" active_stage={event.active_stage}" if event.active_stage else ""
     measure_text = ""
     if event.measures:
@@ -584,7 +639,7 @@ def emit_progress(
             )
         measure_text = " measures=[" + "; ".join(chunks) + "]"
     print(
-        f"[{event.phase}] {event.state} {event.completed}{total}{subject}{elapsed}{worker}{reuse}{outer_rate}{eta_at}{stage}{measure_text}{message}",
+        f"[{event.phase}] {event.state} {event.completed}{total}{subject}{elapsed}{worker}{reuse}{outer_rate}{eta_at}{run_eta_at}{stage}{measure_text}{message}",
         file=target,
         flush=True,
     )

--- a/src/runtime/reference_parity.py
+++ b/src/runtime/reference_parity.py
@@ -60,8 +60,7 @@ def reference_semantic_surface(build: Mapping[str, Any]) -> dict[str, Any]:
     }
     return {
         **surface,
-        "surface_ref": "reference-semantic-surface:"
-        + canonical_sha256(surface),
+        "surface_ref": "reference-semantic-surface:" + canonical_sha256(surface),
     }
 
 

--- a/src/runtime/reference_receipt.py
+++ b/src/runtime/reference_receipt.py
@@ -119,9 +119,7 @@ def serialize_reference_receipt(
         "bytes_written": bytes_written,
         "before": dict(before),
         "after": dict(after),
-        "pss_growth_bytes": max(
-            0, int(after["pss_bytes"]) - int(before["pss_bytes"])
-        ),
+        "pss_growth_bytes": max(0, int(after["pss_bytes"]) - int(before["pss_bytes"])),
         "received_owner_object": False,
         "reference_only": True,
         "text_serialization": False,

--- a/src/runtime/stage_memory_budget.py
+++ b/src/runtime/stage_memory_budget.py
@@ -45,9 +45,7 @@ DEFAULT_STAGE_BUDGETS: Mapping[str, StageMemoryBudget] = {
     "parser_projection": StageMemoryBudget("parser_projection", 3 * GIB, 4 * GIB),
     "typing": StageMemoryBudget("typing", 4 * GIB, 5 * GIB),
     "closure": StageMemoryBudget("closure", 5 * GIB, 6 * GIB),
-    "finalization": StageMemoryBudget(
-        "finalization", 4 * GIB, 5 * GIB + 512 * MIB
-    ),
+    "finalization": StageMemoryBudget("finalization", 4 * GIB, 5 * GIB + 512 * MIB),
     "serialization": StageMemoryBudget("serialization", 2 * GIB, 3 * GIB),
     "publication": StageMemoryBudget("publication", 2 * GIB, 3 * GIB),
     "parity": StageMemoryBudget("parity", 1536 * MIB, 2560 * MIB),

--- a/src/runtime/strict_postgres_execution.py
+++ b/src/runtime/strict_postgres_execution.py
@@ -12,17 +12,16 @@ from dataclasses import dataclass
 import os
 from typing import Any, Callable, Iterable, Mapping, Protocol
 
-from src.policy.carriers.canonical import canonical_fields_sha256
-from src.pnf.streaming_fixed_point import SolverReceipt
-from src.runtime.coordinator_lease_guard import (
-    CoordinatorLeaseGuard,
-    CoordinatorLeaseLost,
-)
-from src.storage.postgres.distributed_semantic_execution import ImmutableJobManifest
-
-
 AUTHORITY_BACKEND = "postgresql"
 STRICT_EXECUTION_CONTRACT = "postgresql-typed-leased-exact-execution:v2"
+
+
+def _canonical_fields_sha256(*values: Any) -> str:
+    """Resolve canonical hashing after the policy package is initialized."""
+
+    from src.policy.carriers.canonical import canonical_fields_sha256
+
+    return canonical_fields_sha256(*values)
 
 
 def _execution_module() -> Any:
@@ -46,6 +45,18 @@ class StrictExecutionError(RuntimeError):
         self.kernel_key = kernel_key
         suffix = f" ({diagnostic_path})" if diagnostic_path else ""
         super().__init__(reason + suffix)
+
+
+# These imports must follow ``StrictExecutionError``.  Importing the PNF
+# package installs policy strategies, one of which imports this module again.
+from src.pnf.streaming_fixed_point import SolverReceipt  # noqa: E402
+from src.runtime.coordinator_lease_guard import (  # noqa: E402
+    CoordinatorLeaseGuard,
+    CoordinatorLeaseLost,
+)
+from src.storage.postgres.distributed_semantic_execution import (  # noqa: E402
+    ImmutableJobManifest,
+)
 
 
 class StrictWorkerPool(Protocol):
@@ -165,9 +176,7 @@ class PostgresExecutionContext:
             fixed_point_zero_change_round=(
                 int(row[10]) if row[10] is not None else None
             ),
-            fixed_point_owner_revision=(
-                int(row[11]) if row[11] is not None else None
-            ),
+            fixed_point_owner_revision=(int(row[11]) if row[11] is not None else None),
             fixed_point_sha256=str(row[12]) if row[12] else None,
         )
 
@@ -219,7 +228,7 @@ def assert_strict_context(context: PostgresExecutionContext) -> None:
             "strict_fixed_point_revision_mismatch",
             kernel_key="strict.closure_gate",
         )
-    expected_digest = canonical_fields_sha256(
+    expected_digest = _canonical_fields_sha256(
         context.run_ref,
         context.document_ref,
         context.fixed_point_round_count,
@@ -392,7 +401,7 @@ class PostgresLeasedExecution:
         state: str,
     ) -> bytes:
         return bytes.fromhex(
-            canonical_fields_sha256(
+            _canonical_fields_sha256(
                 self.run_ref,
                 self.document_ref,
                 round_ordinal,
@@ -595,7 +604,7 @@ class PostgresLeasedExecution:
                             state="fixed_point" if fixed_point else "committed",
                         )
                         if fixed_point:
-                            digest_hex = canonical_fields_sha256(
+                            digest_hex = _canonical_fields_sha256(
                                 self.run_ref,
                                 self.document_ref,
                                 round_ordinal,
@@ -635,9 +644,7 @@ class PostgresLeasedExecution:
                                 },
                             )
                             coordinator.assert_current()
-                            receipts["replayed"] = (
-                                current_revision - starting_revision
-                            )
+                            receipts["replayed"] = current_revision - starting_revision
                             receipts["round_count"] = round_ordinal
                             return receipts
             raise StrictExecutionError(

--- a/src/sensiblaw/interfaces/_compat.py
+++ b/src/sensiblaw/interfaces/_compat.py
@@ -1,8 +1,7 @@
-from __future__ import annotations
-
 """Compatibility helpers for the public ``sensiblaw.interfaces`` boundary."""
 
-import importlib
+from __future__ import annotations
+
 from pathlib import Path
 import sys
 from types import ModuleType
@@ -16,13 +15,8 @@ def install_src_package_aliases() -> None:
         src_package.__path__ = [str(Path(__file__).resolve().parents[2])]
         sys.modules["src"] = src_package
     else:
-        src_package = sys.modules["src"]
-
-    for child_name in ("nlp", "reporting", "sensiblaw", "text"):
-        alias_name = f"src.{child_name}"
-        if alias_name in sys.modules:
-            child_module = sys.modules[alias_name]
-        else:
-            child_module = importlib.import_module(alias_name)
-            sys.modules[alias_name] = child_module
-        setattr(src_package, child_name, child_module)
+        # A normal repository import already owns the package. Submodules are
+        # imported by their actual consumers; eagerly importing every historical
+        # child here creates cycles and loads optional NLP runtimes at the public
+        # interface boundary.
+        return

--- a/src/storage/postgres/distributed_semantic_execution_store.py
+++ b/src/storage/postgres/distributed_semantic_execution_store.py
@@ -856,9 +856,7 @@ class DistributedSemanticExecutionStore:
         if cursor.rowcount != 1:
             raise RuntimeError("publication was not in the expected staged state")
 
-    def fixed_point_counts(
-        self, cursor: Any, *, document_ref: str
-    ) -> dict[str, int]:
+    def fixed_point_counts(self, cursor: Any, *, document_ref: str) -> dict[str, int]:
         cursor.execute(
             """
             SELECT

--- a/src/storage/postgres/reference_publication_authority.py
+++ b/src/storage/postgres/reference_publication_authority.py
@@ -29,9 +29,7 @@ def commit_reference_publication_authority(
     family_manifests = dict(streaming_build.get("family_manifests") or {})
     jobs = dict(family_manifests.get("solver_jobs") or {})
     residuals = dict(family_manifests.get("residuals") or {})
-    accepted_job_set_digest = str(
-        jobs.get("ordered_digest") or canonical_sha256([])
-    )
+    accepted_job_set_digest = str(jobs.get("ordered_digest") or canonical_sha256([]))
     unresolved_demand_digest = str(
         residuals.get("ordered_digest") or canonical_sha256([])
     )
@@ -66,9 +64,7 @@ def commit_reference_publication_authority(
             family: {
                 "record_count": int((descriptor or {}).get("record_count") or 0),
                 "byte_count": int((descriptor or {}).get("byte_count") or 0),
-                "ordered_digest": str(
-                    (descriptor or {}).get("ordered_digest") or ""
-                ),
+                "ordered_digest": str((descriptor or {}).get("ordered_digest") or ""),
             }
             for family, descriptor in sorted(family_manifests.items())
             if isinstance(descriptor, Mapping)

--- a/src/storage/postgres/reference_streaming_semantic_store.py
+++ b/src/storage/postgres/reference_streaming_semantic_store.py
@@ -87,9 +87,7 @@ def _persist_notice_batch(
     )
 
 
-def _persist_proposal_batch(
-    cursor: Any, rows: tuple[Mapping[str, Any], ...]
-) -> None:
+def _persist_proposal_batch(cursor: Any, rows: tuple[Mapping[str, Any], ...]) -> None:
     cursor.executemany(
         """
         INSERT INTO pnf_factor_proposal
@@ -387,7 +385,10 @@ def persist_reference_streaming_semantic_artifacts(
             semantic_counts={"rows": completed_residual_refs},
             details={"batch_size": len(batch)},
         )
-    if factor_count != completed_factor_refs or residual_count != completed_residual_refs:
+    if (
+        factor_count != completed_factor_refs
+        or residual_count != completed_residual_refs
+    ):
         raise ValueError("authoritative and compatibility reduction counts disagree")
     counts["factors"] = factor_count
     counts["residuals"] = residual_count
@@ -475,9 +476,7 @@ def persist_reference_streaming_semantic_artifacts(
         "publication",
         phase="reference_persistence_completed",
         semantic_counts={
-            key: int(value)
-            for key, value in counts.items()
-            if isinstance(value, int)
+            key: int(value) for key, value in counts.items() if isinstance(value, int)
         },
         details={"graph_manifest_ref": manifest_ref},
     )

--- a/src/text/__init__.py
+++ b/src/text/__init__.py
@@ -16,7 +16,6 @@ from .shared_text_normalization import (
     strip_enumeration_prefix,
     tokenize_canonical_text,
 )
-from .phrase_cues import extract_text_cues
 from .residual_lattice import (
     CandidateResidual,
     PredicateIndex,
@@ -122,13 +121,20 @@ _NLP_COMPAT_EXPORTS = frozenset(
         "TikaLanguageDetector",
     }
 )
+_LAZY_TEXT_EXPORTS = {
+    "extract_text_cues": ("phrase_cues", "extract_text_cues"),
+}
 
 
 def __getattr__(name: str) -> Any:
     """Lazily retain optional NLP compatibility re-exports."""
 
-    if name not in _NLP_COMPAT_EXPORTS:
+    if name in _NLP_COMPAT_EXPORTS:
+        module_name, export_name = "nlp", name
+    elif name in _LAZY_TEXT_EXPORTS:
+        module_name, export_name = _LAZY_TEXT_EXPORTS[name]
+    else:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    value = getattr(import_module(f"{__name__}.nlp"), name)
+    value = getattr(import_module(f"{__name__}.{module_name}"), export_name)
     globals()[name] = value
     return value

--- a/tests/pnf/test_streaming_build_reader.py
+++ b/tests/pnf/test_streaming_build_reader.py
@@ -41,9 +41,7 @@ def test_reader_rejects_tampered_binary_family_before_decode(
     encoded = bytearray(path.read_bytes())
     encoded[-1] ^= 0x01
     path.write_bytes(encoded)
-    reader = StreamingBuildReader(
-        {"family_manifests": {"proposals": descriptor}}
-    )
+    reader = StreamingBuildReader({"family_manifests": {"proposals": descriptor}})
 
     decode_called = False
 

--- a/tests/policy/test_closure_liveness_execution.py
+++ b/tests/policy/test_closure_liveness_execution.py
@@ -158,16 +158,12 @@ def test_finalization_is_reference_backed_and_process_isolated(
     finalization_root = (
         tmp_path / "closure-finalization" / "document_phased-finalization"
     )
-    assert (finalization_root / "materialized-reduction.manifest.json").is_file()
-    assert (finalization_root / "materialized-factors.jsonl").is_file()
-    assert (finalization_root / "materialized-residuals.jsonl").is_file()
-    assert (finalization_root / "convergent-ledger.json").is_file()
-    assert (finalization_root / "fixed-point-certificate.json").is_file()
-    assert (finalization_root / "closure-reference-receipt.spec.json").is_file()
-    assert (finalization_root / "closure-receipt.json").is_file()
-    assert (
-        finalization_root / "closure-reference-serializer-report.json"
-    ).is_file()
+    assert (finalization_root / "materialized-reduction.manifest.pkl").is_file()
+    assert (finalization_root / "materialized-factors.bin").is_file()
+    assert (finalization_root / "materialized-residuals.bin").is_file()
+    assert (finalization_root / "closure-reference-receipt.spec.pkl").is_file()
+    assert (finalization_root / "closure-receipt.pkl").is_file()
+    assert (finalization_root / "closure-reference-serializer-report.pkl").is_file()
 
 
 def test_identical_replay_preserves_reference_manifest_identity(

--- a/tests/policy/test_parallel_semantic_execution.py
+++ b/tests/policy/test_parallel_semantic_execution.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import multiprocessing
-import json
+import shutil
 
 import pytest
 
@@ -29,6 +29,8 @@ from src.policy.parallel_semantic_execution import (
     _ACTIVE_CONTEXTS,
     _ACTIVE_LOCK,
     _CONTEXT,
+    _atomic_write_json,
+    _read_json,
     _solver_receipt_from_row,
     _replay_artifact_path,
     _write_replay_artifact,
@@ -358,7 +360,8 @@ def test_activation_admission_telemetry_starts_after_leaf_completion(tmp_path) -
     assert activation["owner_admission_started_immediately"] is True
     handoff = context.closure_handoff_checkpoint_path
     assert handoff is not None and handoff.exists()
-    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload = _read_json(handoff)
+    assert payload is not None
     assert payload["admitted_batch_refs"] == [
         "batch:0",
         "batch:1",
@@ -434,16 +437,22 @@ def test_handoff_rejects_incompatible_and_corrupt_checkpoints(tmp_path) -> None:
         with _ACTIVE_LOCK:
             _ACTIVE_CONTEXTS.pop(context.document_ref, None)
 
+    handoff = context.closure_handoff_checkpoint_path
+    assert handoff is not None
+
     incompatible = _activation_context(tmp_path, 1)
     incompatible.build_key_sha256 = "different-build"
+    incompatible_handoff = incompatible.closure_handoff_checkpoint_path
+    assert incompatible_handoff is not None
+    incompatible_handoff.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(handoff, incompatible_handoff)
     with pytest.raises(ValueError, match="identity mismatch"):
         ClosureOwnerReplayContract(incompatible)
 
-    handoff = context.closure_handoff_checkpoint_path
-    assert handoff is not None
-    payload = json.loads(handoff.read_text(encoding="utf-8"))
+    payload = _read_json(handoff)
+    assert payload is not None
     payload["current_owner_revision"] = 999
-    handoff.write_text(json.dumps(payload), encoding="utf-8")
+    _atomic_write_json(handoff, payload)
     with pytest.raises(ValueError, match="identity mismatch"):
         ClosureOwnerReplayContract(_activation_context(tmp_path, 1))
 
@@ -459,7 +468,8 @@ def test_replay_artifacts_are_namespaced_by_replay_contract(tmp_path) -> None:
     )
     path = _replay_artifact_path(context, artifact_ref)
     assert path is not None and path.exists()
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload = _read_json(path)
+    assert payload is not None
     assert payload["owner_identity"] == {
         "document_ref": context.document_ref,
         "source_sha256": context.source_sha256,
@@ -494,7 +504,8 @@ def test_handoff_rejects_legacy_identity_without_rewriting_it(tmp_path) -> None:
 
     handoff = context.closure_handoff_checkpoint_path
     assert handoff is not None
-    legacy = json.loads(handoff.read_text(encoding="utf-8"))
+    legacy = _read_json(handoff)
+    assert legacy is not None
     for key in (
         "handoff_schema_version",
         "handoff_contract_ref",
@@ -505,13 +516,13 @@ def test_handoff_rejects_legacy_identity_without_rewriting_it(tmp_path) -> None:
     legacy["checkpoint_ref"] = "closure-handoff:" + canonical_sha256(
         {key: value for key, value in legacy.items() if key != "checkpoint_ref"}
     )
-    handoff.write_text(json.dumps(legacy), encoding="utf-8")
-    preserved = handoff.read_text(encoding="utf-8")
+    _atomic_write_json(handoff, legacy)
+    preserved = handoff.read_bytes()
 
     with pytest.raises(ValueError, match="identity mismatch"):
         ClosureOwnerReplayContract(_activation_context(tmp_path, 1))
 
-    assert handoff.read_text(encoding="utf-8") == preserved
+    assert handoff.read_bytes() == preserved
 
 
 def test_bounded_streaming_resume_reconstructs_exact_fixed_point(

--- a/tests/policy/test_progress_observability_execution.py
+++ b/tests/policy/test_progress_observability_execution.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
+import pickle
 
 from src.policy import parallel_typing_tail as tail
 from src.policy.parallel_semantic_execution import SemanticExecutionContext
@@ -63,10 +63,12 @@ def test_universal_envelope_is_logged_and_persisted(
     assert envelope["wait_reason"] == "worker_results"
     assert envelope["active_workers"] == 2
     assert envelope["checkpoint_bytes_written"] == 4096
-    latest = json.loads((tmp_path / "progress" / "latest.json").read_text())
+    latest = pickle.loads((tmp_path / "progress" / "latest.pkl").read_bytes())
     assert latest == envelope
-    events = (tmp_path / "progress" / "events.jsonl").read_text().splitlines()
-    assert json.loads(events[-1]) == envelope
+    framed = (tmp_path / "progress" / "events.bin").read_bytes()
+    frame_size = int.from_bytes(framed[:8], "big")
+    assert pickle.loads(framed[8 : 8 + frame_size]) == envelope
+    assert len(framed) == 8 + frame_size
     captured = capsys.readouterr()  # type: ignore[attr-defined]
     assert "SENSIBLAW_PROGRESS" in captured.err
     assert "typing_parent_waiting" in captured.err
@@ -96,7 +98,9 @@ def test_parent_rolls_up_leaf_completion_and_checkpoint_reuse(
     assert "typing_parent_aggregation_started" in phases
     assert phases[-1] == "typing_parent_aggregation_completed"
     leaf_events = [
-        row for row in context.kernel_timeline if row["phase"] == "typing_leaf_completed"
+        row
+        for row in context.kernel_timeline
+        if row["phase"] == "typing_leaf_completed"
     ]
     assert [row["counts"]["leaves_completed"] for row in leaf_events] == [1, 2, 3]
     assert all(row["counts"]["leaves_total"] == 3 for row in leaf_events)

--- a/tests/policy/test_progress_observability_execution.py
+++ b/tests/policy/test_progress_observability_execution.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pickle
 
 from src.policy import parallel_typing_tail as tail
+from src.policy import no_json_checkpoint_execution as binary_policy
 from src.policy.parallel_semantic_execution import SemanticExecutionContext
 from src.policy.progress_observability_execution import (
     PROGRESS_ENVELOPE_SCHEMA_VERSION,
@@ -124,3 +125,35 @@ def test_parent_rolls_up_leaf_completion_and_checkpoint_reuse(
     assert started["counts"]["leaves_completed"] == 3
     assert started["counts"]["leaves_total"] == 3
     assert started["counts"]["leaves_reused"] == 3
+
+
+def test_batched_progress_persistence_flushes_one_durable_frame_batch(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    monkeypatch.setenv("SENSIBLAW_PROGRESS_PERSISTENCE_MODE", "batched")  # type: ignore[attr-defined]
+    monkeypatch.setenv("SENSIBLAW_PROGRESS_BATCH_EVENTS", "64")  # type: ignore[attr-defined]
+    context = _context(tmp_path)
+
+    context.sample(
+        "local_typing_diagnostics:test", phase="running", counts={"completed": 1}
+    )
+
+    assert not (tmp_path / "progress" / "events.bin").exists()
+    binary_policy._flush_progress(tmp_path)
+    events = (tmp_path / "progress" / "events.bin").read_bytes()
+    frame_size = int.from_bytes(events[:8], "big")
+    assert frame_size == len(events) - 8
+    assert pickle.loads(events[8:])["stage"] == "local_typing_diagnostics:test"
+
+
+def test_disabled_progress_persistence_keeps_console_only_mode(
+    tmp_path: Path, monkeypatch: object
+) -> None:
+    monkeypatch.setenv("SENSIBLAW_PROGRESS_PERSISTENCE_MODE", "disabled")  # type: ignore[attr-defined]
+    context = _context(tmp_path)
+
+    context.sample(
+        "local_typing_diagnostics:test", phase="running", counts={"completed": 1}
+    )
+
+    assert not (tmp_path / "progress").exists()

--- a/tests/runtime/test_distributed_semantic_worker.py
+++ b/tests/runtime/test_distributed_semantic_worker.py
@@ -1,120 +1,38 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
-
-from src.runtime.distributed_semantic_worker import (
-    DistributedSemanticWorker,
-    SemanticJobResult,
-)
-from src.storage.postgres.distributed_semantic_execution_store import (
-    SemanticDeltaAdmission,
-    SemanticJobLease,
-)
+from src.runtime import distributed_semantic_worker as public_runtime
+from src.storage.postgres import distributed_semantic_execution as strict_execution
 
 
-class FakeCursor:
-    def __enter__(self) -> "FakeCursor":
-        return self
-
-    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
-        return None
-
-    def execute(self, query: str, parameters: Any = None) -> None:
-        return None
-
-
-class FakeConnection:
-    def __enter__(self) -> "FakeConnection":
-        return self
-
-    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
-        return None
-
-    def cursor(self) -> FakeCursor:
-        return FakeCursor()
-
-
-@dataclass
-class FakeStore:
-    lease: SemanticJobLease
-    admitted_delta_ref: str | None = None
-    recovered: int = 0
-    awakened: int = 0
-
-    def recover_expired_leases(self, cursor: Any, *, document_ref: str) -> int:
-        self.recovered += 1
-        return 0
-
-    def awaken_ready_jobs(self, cursor: Any, *, document_ref: str) -> int:
-        self.awakened += 1
-        return 0
-
-    def lease_jobs(self, cursor: Any, **kwargs: Any) -> tuple[SemanticJobLease, ...]:
-        return (self.lease,)
-
-    def renew_lease(self, cursor: Any, **kwargs: Any) -> None:
-        return None
-
-    def admit_delta(self, cursor: Any, **kwargs: Any) -> SemanticDeltaAdmission:
-        self.admitted_delta_ref = str(kwargs["delta_ref"])
-        lease = kwargs["lease"]
-        return SemanticDeltaAdmission(
-            delta_ref=self.admitted_delta_ref,
-            job_ref=lease.job_ref,
-            owner_ref=lease.owner_ref,
-            lease_epoch=lease.lease_epoch,
-            prior_owner_revision=lease.expected_owner_revision,
-            resulting_owner_revision=lease.expected_owner_revision + 1,
-            state="accepted",
-        )
-
-
-def _lease() -> SemanticJobLease:
-    return SemanticJobLease(
-        job_ref="job:1",
-        document_ref="document:1",
-        owner_ref="owner:1",
-        operation_contract_ref="operation:v1",
-        input_manifest_ref="manifest:input",
-        expected_owner_revision=3,
-        canonical_ordinal=0,
-        priority=1,
-        lease_owner="worker:alpha",
-        lease_epoch=4,
-        payload={"bounded": True},
+def test_runtime_module_reexports_strict_typed_worker_surface() -> None:
+    assert (
+        public_runtime.DistributedSemanticWorker
+        is strict_execution.DistributedSemanticWorker
+    )
+    assert public_runtime.ImmutableJobManifest is strict_execution.ImmutableJobManifest
+    assert public_runtime.Lease is strict_execution.Lease
+    assert (
+        public_runtime.enqueue_canonical_closure_jobs
+        is strict_execution.enqueue_canonical_closure_jobs
+    )
+    assert public_runtime.lease_next_job is strict_execution.lease_next_job
+    assert (
+        public_runtime.replay_accepted_deltas is strict_execution.replay_accepted_deltas
+    )
+    assert (
+        public_runtime.semantic_delta_admission
+        is strict_execution.semantic_delta_admission
     )
 
 
-def test_worker_computes_immutable_delta_and_admits_through_store() -> None:
-    store = FakeStore(_lease())
-    observed: list[SemanticJobLease] = []
-
-    def execute(lease: SemanticJobLease) -> SemanticJobResult:
-        observed.append(lease)
-        return SemanticJobResult(
-            output_manifest_ref="manifest:output",
-            output_manifest_sha256="00" * 32,
-            payload={"delta": "immutable"},
-            resource_receipt={"rss_bytes": 123},
-        )
-
-    worker = DistributedSemanticWorker(
-        connection_factory=FakeConnection,
-        executor=execute,
-        worker_ref="worker:alpha",
-        store=store,  # type: ignore[arg-type]
-        lease_seconds=300,
-        heartbeat_seconds=100,
-    )
-
-    receipt = worker.run_once(document_ref="document:1")
-
-    assert observed == [store.lease]
-    assert receipt.leased_count == 1
-    assert receipt.accepted_count == 1
-    assert receipt.failed_count == 0
-    assert store.recovered == 1
-    assert store.awakened == 1
-    assert store.admitted_delta_ref is not None
-    assert store.admitted_delta_ref.startswith("semantic-delta:")
+def test_runtime_module_exposes_only_current_strict_contract_names() -> None:
+    assert set(public_runtime.__all__) == {
+        "DistributedSemanticWorker",
+        "ImmutableJobManifest",
+        "Lease",
+        "enqueue_canonical_closure_jobs",
+        "lease_next_job",
+        "replay_accepted_deltas",
+        "semantic_delta_admission",
+    }
+    assert not hasattr(public_runtime, "SemanticJobResult")

--- a/tests/runtime/test_post_closure_probe.py
+++ b/tests/runtime/test_post_closure_probe.py
@@ -1,53 +1,45 @@
 from __future__ import annotations
 
-import json
 import sys
 
+import pytest
+
 from scripts import run_post_closure_probe as probe
+from src.runtime.reference_receipt import atomic_write_binary
 
 
-def _write_json(path, payload) -> None:
-    path.write_text(json.dumps(payload), encoding="utf-8")
-
-
-def test_probe_uses_legacy_finalization_refs_without_loading_families(
-    monkeypatch,
+def test_probe_uses_typed_finalization_refs_without_loading_families(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
     checkpoint_root = tmp_path / "checkpoints"
     finalization = checkpoint_root / "closure-finalization" / "document_test"
     finalization.mkdir(parents=True)
-    _write_json(
-        finalization / "materialized-reduction.manifest.json",
+    factor_path = finalization / "materialized-factors.bin"
+    residual_path = finalization / "materialized-residuals.bin"
+    factor_path.write_bytes(b"factor-family")
+    residual_path.write_bytes(b"")
+    reduction = {
+        "owner_fingerprint": {"proposal_manifest_ref": "proposal:1"},
+        "graph_ref": "graph:1",
+        "proposal_count": 10,
+        "deduplicated_count": 0,
+        "factor_count": 2,
+        "residual_count": 0,
+        "factor_path": str(factor_path),
+        "residual_path": str(residual_path),
+    }
+    atomic_write_binary(finalization / "materialized-reduction.manifest.pkl", reduction)
+    atomic_write_binary(
+        finalization / "closure-reference-receipt.spec.pkl",
         {
-            "owner_fingerprint": {"proposal_manifest_ref": "proposal:1"},
-            "graph_ref": "graph:1",
-            "proposal_count": 10,
-            "deduplicated_count": 0,
-            "factor_count": 2,
-            "residual_count": 0,
+            "document_ref": "document:test",
+            "revision": 7,
+            "certificate_ref": "certificate:1",
+            "ledger_ref": "ledger:1",
+            "materialized_reduction": reduction,
         },
     )
-    _write_json(
-        finalization / "fixed-point-certificate.json",
-        {
-            "certificate": {
-                "document_ref": "document:test",
-                "revision": 7,
-                "certificate_ref": "certificate:1",
-                "ledger_ref": "ledger:1",
-                "materialized_graph_ref": "graph:1",
-                "local_fixed_point": "reached",
-            }
-        },
-    )
-    _write_json(finalization / "convergent-ledger.json", {"ledger_ref": "ledger:1"})
-    _write_json(finalization / "region-boundary-summaries.json", {"summaries": []})
-    (finalization / "materialized-factors.jsonl").write_text(
-        '{"factor_ref":"factor:1"}\n{"factor_ref":"factor:2"}\n',
-        encoding="utf-8",
-    )
-    (finalization / "materialized-residuals.jsonl").write_text("", encoding="utf-8")
     output = tmp_path / "probe-output"
     monkeypatch.setattr(
         sys,
@@ -67,19 +59,25 @@ def test_probe_uses_legacy_finalization_refs_without_loading_families(
 
     assert probe.main() == 0
 
-    report = json.loads(
-        (output / "post-closure-probe-report.json").read_text(encoding="utf-8")
-    )
-    receipt = json.loads(
-        (output / "post-closure-reference-receipt.json").read_text(
-            encoding="utf-8"
-        )
-    )
+    report = probe._mapping(output / "post-closure-probe-report.pkl")
+    receipt = probe._mapping(output / "post-closure-reference-receipt.pkl")
     assert report["owner_object_transferred"] is False
     assert report["full_factor_payload_loaded"] is False
     assert report["full_residual_payload_loaded"] is False
     assert report["serializer"]["reference_only"] is True
     assert receipt["materialized_reduction"]["factor_path"].endswith(
-        "materialized-factors.jsonl"
+        "materialized-factors.bin"
     )
     assert "factors" not in receipt["materialized_reduction"]
+
+
+def test_probe_rejects_legacy_text_finalization_authority(tmp_path) -> None:
+    checkpoint_root = tmp_path / "checkpoints"
+    finalization = checkpoint_root / "closure-finalization" / "document_test"
+    finalization.mkdir(parents=True)
+    (finalization / "materialized-reduction.manifest.json").write_text(
+        "{}", encoding="utf-8"
+    )
+
+    with pytest.raises(FileNotFoundError, match="legacy text checkpoints"):
+        probe._find_finalization_root(checkpoint_root)

--- a/tests/runtime/test_progress_instrumentation.py
+++ b/tests/runtime/test_progress_instrumentation.py
@@ -25,7 +25,9 @@ def test_phase_recorder_emits_durable_timing_and_reuse_events(tmp_path) -> None:
             processed_tokens=12,
             worker="document-1",
         )
-        phase.advance(subject_ref="document:b", reused=False, details={"worker": "document-2"})
+        phase.advance(
+            subject_ref="document:b", reused=False, details={"worker": "document-2"}
+        )
 
     payload = recorder.to_dict()
     assert payload["schema_version"] == "sl.phase_ledger.v0_1"
@@ -48,7 +50,7 @@ def test_phase_recorder_emits_durable_timing_and_reuse_events(tmp_path) -> None:
     lines = [json.loads(line) for line in stream.getvalue().splitlines()]
     assert lines[0]["state"] == "started"
     assert lines[-1]["state"] == "completed"
-    assert all(row["schema_version"] == "sl.progress_event.v0_4" for row in lines)
+    assert all(row["schema_version"] == "sl.progress_event.v0_5" for row in lines)
 
 
 def test_failed_phase_records_error_without_hiding_exception() -> None:
@@ -71,10 +73,26 @@ def test_phase_heartbeat_reports_estimate_while_no_units_finish() -> None:
         phase.advance(subject_ref="document:a")
         sleep(0.003)
 
-    heartbeat = next(event for event in recorder.events if event["state"] == "heartbeat")
+    heartbeat = next(
+        event for event in recorder.events if event["state"] == "heartbeat"
+    )
     assert heartbeat["completed"] == 1
     assert heartbeat["estimated_remaining_ms"] >= 0
     assert "active_stage" not in heartbeat
+
+
+def test_active_stage_reports_whole_run_estimate() -> None:
+    recorder = PhaseRecorder(stream=StringIO(), json_lines=True)
+    with recorder.phase("document_compile", total=3, heartbeat_seconds=None) as phase:
+        phase.advance(subject_ref="document:a")
+        with phase.stage(
+            "parser", measures={"tokens": {"completed": 50, "total": 100}}
+        ):
+            sleep(0.001)
+            phase.observe(measures={"tokens": 75})
+            event = recorder.events[-1]
+            assert event["estimated_run_remaining_ms"] >= 0
+            assert event["estimated_run_completion_at"]
 
 
 def test_outer_heartbeat_reports_active_context_without_inner_stage() -> None:
@@ -119,7 +137,9 @@ def test_last_completion_label_never_becomes_active_stage() -> None:
         phase.advance(message="coordinate_validation")
         phase.heartbeat()
 
-    heartbeat = next(event for event in recorder.events if event["state"] == "heartbeat")
+    heartbeat = next(
+        event for event in recorder.events if event["state"] == "heartbeat"
+    )
     assert heartbeat["completed"] == 1
     assert "active_stage" not in heartbeat
     assert heartbeat.get("message") != "coordinate_validation"
@@ -224,7 +244,13 @@ def test_stage_context_open_observe_and_close() -> None:
             )
 
     states = [event["state"] for event in recorder.events]
-    assert states == ["started", "stage_started", "running", "stage_completed", "completed"]
+    assert states == [
+        "started",
+        "stage_started",
+        "running",
+        "stage_completed",
+        "completed",
+    ]
     assert recorder.events[2]["active_stage"] == "parser_annotation"
     assert recorder.events[2]["measures"]["fibres"]["total"] == 2
     assert recorder.events[3]["completed"] == 1

--- a/tests/runtime/test_stage_memory_budget.py
+++ b/tests/runtime/test_stage_memory_budget.py
@@ -10,6 +10,8 @@ from src.runtime import stage_memory_budget as budget
 def test_stage_budget_records_soft_pressure(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
+    monkeypatch.delenv("SENSIBLAW_STAGE_SERIALIZATION_SOFT_MIB", raising=False)
+    monkeypatch.delenv("SENSIBLAW_STAGE_SERIALIZATION_HARD_MIB", raising=False)
     monkeypatch.setattr(
         budget,
         "sample_process_resources",
@@ -41,6 +43,8 @@ def test_stage_budget_records_soft_pressure(
 def test_stage_budget_fails_below_global_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.delenv("SENSIBLAW_STAGE_PUBLICATION_SOFT_MIB", raising=False)
+    monkeypatch.delenv("SENSIBLAW_STAGE_PUBLICATION_HARD_MIB", raising=False)
     monkeypatch.setattr(
         budget,
         "sample_process_resources",

--- a/tests/storage/test_distributed_semantic_execution_store.py
+++ b/tests/storage/test_distributed_semantic_execution_store.py
@@ -203,10 +203,13 @@ def test_fixed_point_counts_include_unadmitted_deltas() -> None:
     counts = store.fixed_point_counts(cursor, document_ref="document:1")
 
     assert counts["unadmitted_deltas"] == 2
-    assert store.document_fixed(
-        FakeCursor(fetchone_rows=[(0, 0), (0, 0, 0), (0,)]),
-        document_ref="document:1",
-    ) is True
+    assert (
+        store.document_fixed(
+            FakeCursor(fetchone_rows=[(0, 0), (0, 0, 0), (0,)]),
+            document_ref="document:1",
+        )
+        is True
+    )
 
 
 def test_publication_commits_only_expected_staged_digest() -> None:
@@ -227,6 +230,7 @@ def test_publication_commits_only_expected_staged_digest() -> None:
         expected_digest="22" * 32,
     )
 
-    assert "state_ref = 'staged'" in cursor.executions[0][0]
+    assert "VALUES (%s, %s, %s, %s, 'staged', %s)" in cursor.executions[0][0]
     assert "state_ref = 'committed'" in cursor.executions[1][0]
+    assert "state_ref = 'staged'" in cursor.executions[1][0]
     assert "publication_digest = %s" in cursor.executions[1][0]

--- a/tests/test_benchmark_document_replay.py
+++ b/tests/test_benchmark_document_replay.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+
+import pytest
+
+from scripts.benchmark_document_replay import load_manifest
+
+
+def test_load_manifest_resolves_and_validates_documents(tmp_path: Path) -> None:
+    source = tmp_path / "document.txt"
+    source.write_text("bounded replay", encoding="utf-8")
+    manifest = tmp_path / "manifest.pkl"
+    manifest.write_bytes(
+        pickle.dumps({"documents": [{"label": "medium", "path": str(source)}]})
+    )
+
+    cases = load_manifest(manifest)
+
+    assert cases[0].label == "medium"
+    assert cases[0].path == source.resolve()
+
+
+def test_load_manifest_rejects_duplicate_labels(tmp_path: Path) -> None:
+    source = tmp_path / "document.txt"
+    source.write_text("bounded replay", encoding="utf-8")
+    manifest = tmp_path / "manifest.pkl"
+    manifest.write_bytes(
+        pickle.dumps(
+            {
+                "documents": [
+                    {"label": "same", "path": str(source)},
+                    {"label": "same", "path": str(source)},
+                ]
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="duplicate document label"):
+        load_manifest(manifest)

--- a/tests/test_owner_handoff_performance_contract.py
+++ b/tests/test_owner_handoff_performance_contract.py
@@ -121,3 +121,23 @@ def test_source_contract_removes_quadratic_replay_event_tuple_copy() -> None:
     assert "parallel._append_replay_event = _append_journal_event" in source
     assert "parallel._write_closure_handoff_checkpoint = _write_compact_checkpoint" in source
     assert "install_owner_handoff_performance()" in policy_init
+
+
+def test_source_contract_removes_duplicate_recorded_delta_index() -> None:
+    legacy = Path("src/policy/parallel_semantic_execution.py").read_text(
+        encoding="utf-8"
+    )
+    bounded = Path("src/policy/bounded_operational_execution.py").read_text(
+        encoding="utf-8"
+    )
+    batch = Path("src/policy/owner_handoff_batch_performance.py").read_text(
+        encoding="utf-8"
+    )
+    policy_init = Path("src/policy/__init__.py").read_text(encoding="utf-8")
+
+    assert 'if delta.delta_ref not in owner._observation_deltas' in bounded
+    assert 'set(self.context.closure_activation.get("recorded_delta_refs") or ())' in legacy
+    assert "new_deltas = tuple(deltas)" in batch
+    assert 'payload.pop("recorded_delta_refs", None)' in batch
+    assert "install_owner_handoff_batch_performance()" in policy_init
+    assert "current closure handoff checkpoint identity mismatch" in batch

--- a/tests/test_owner_handoff_performance_contract.py
+++ b/tests/test_owner_handoff_performance_contract.py
@@ -141,3 +141,17 @@ def test_source_contract_removes_duplicate_recorded_delta_index() -> None:
     assert 'payload.pop("recorded_delta_refs", None)' in batch
     assert "install_owner_handoff_batch_performance()" in policy_init
     assert "current closure handoff checkpoint identity mismatch" in batch
+
+
+def test_proposal_artifact_hashing_is_outside_context_lock() -> None:
+    source = Path("src/policy/parallel_semantic_execution.py").read_text(
+        encoding="utf-8"
+    )
+    start = source.index("def admit_proposals_wrapper(")
+    end = source.index("    def admit_receipt_wrapper(", start)
+    wrapper = source[start:end]
+    assert wrapper.index("artifact_ref: str | None") < wrapper.index(
+        "with context.lock:"
+    )
+    lock_body = wrapper[wrapper.index("with context.lock:") :]
+    assert "_write_replay_artifact(" not in lock_body

--- a/tests/test_owner_handoff_performance_contract.py
+++ b/tests/test_owner_handoff_performance_contract.py
@@ -48,7 +48,14 @@ def test_journal_append_is_incremental_and_does_not_retain_full_history(
     path = _journal_path(context)
     assert path is not None
     assert path.exists()
-    assert len(path.read_text(encoding="utf-8").splitlines()) == 256
+    assert path.suffix == ".bin"
+    assert not path.read_bytes().startswith(b"{")
+    events, _ = _read_journal(
+        context,
+        event_count=256,
+        final_digest=str(context.closure_activation["journal_digest"]),
+    )
+    assert len(events) == 256
 
 
 def test_journal_digest_chain_round_trips_exact_checkpoint_prefix(
@@ -108,18 +115,19 @@ def test_uncheckpointed_tail_is_dropped_before_replay_continues(
 
 
 def test_source_contract_removes_quadratic_replay_event_tuple_copy() -> None:
-    source = Path("src/policy/owner_handoff_performance.py").read_text(
-        encoding="utf-8"
-    )
+    source = Path("src/policy/owner_handoff_performance.py").read_text(encoding="utf-8")
     legacy = Path("src/policy/parallel_semantic_execution.py").read_text(
         encoding="utf-8"
     )
     policy_init = Path("src/policy/__init__.py").read_text(encoding="utf-8")
 
     assert 'events = list(activation.get("replay_events") or ())' in legacy
-    assert 'refs = list(activation.get(list_key) or ())' in legacy
+    assert "refs = list(activation.get(list_key) or ())" in legacy
     assert "parallel._append_replay_event = _append_journal_event" in source
-    assert "parallel._write_closure_handoff_checkpoint = _write_compact_checkpoint" in source
+    assert (
+        "parallel._write_closure_handoff_checkpoint = _write_compact_checkpoint"
+        in source
+    )
     assert "install_owner_handoff_performance()" in policy_init
 
 
@@ -135,8 +143,11 @@ def test_source_contract_removes_duplicate_recorded_delta_index() -> None:
     )
     policy_init = Path("src/policy/__init__.py").read_text(encoding="utf-8")
 
-    assert 'if delta.delta_ref not in owner._observation_deltas' in bounded
-    assert 'set(self.context.closure_activation.get("recorded_delta_refs") or ())' in legacy
+    assert "if delta.delta_ref not in owner._observation_deltas" in bounded
+    assert (
+        'set(self.context.closure_activation.get("recorded_delta_refs") or ())'
+        in legacy
+    )
     assert "new_deltas = tuple(deltas)" in batch
     assert 'payload.pop("recorded_delta_refs", None)' in batch
     assert "install_owner_handoff_batch_performance()" in policy_init

--- a/tests/test_owner_handoff_performance_contract.py
+++ b/tests/test_owner_handoff_performance_contract.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from threading import Lock
+
+from src.policy.owner_handoff_performance import (
+    HANDOFF_CONTRACT,
+    HANDOFF_SCHEMA_VERSION,
+    _append_journal_event,
+    _discard_uncheckpointed_journal_tail,
+    _journal_path,
+    _read_journal,
+)
+
+
+class _Context:
+    def __init__(self, root: Path) -> None:
+        self.closure_activation_checkpoint_root = root
+        self.build_key_sha256 = "build-key"
+        self.reconstructing_owner = False
+        self.closure_activation: dict[str, object] = {}
+        self.closure_counters: Counter[str] = Counter()
+        self.lock = Lock()
+
+
+def test_handoff_contract_is_new_compatibility_identity() -> None:
+    assert HANDOFF_SCHEMA_VERSION == "sensiblaw.closure-handoff-state.v3"
+    assert HANDOFF_CONTRACT == "closure-owner-replay:v3"
+
+
+def test_journal_append_is_incremental_and_does_not_retain_full_history(
+    tmp_path: Path,
+) -> None:
+    context = _Context(tmp_path)
+    for ordinal in range(256):
+        _append_journal_event(
+            context,
+            artifact_kind="proposal_batch",
+            artifact_ref=f"artifact:{ordinal}",
+        )
+
+    assert context.closure_activation["journal_event_count"] == 256
+    assert "replay_events" not in context.closure_activation
+    assert "proposal_batch_artifact_refs" not in context.closure_activation
+    assert context.closure_counters["handoff_journal_events"] == 256
+
+    path = _journal_path(context)
+    assert path is not None
+    assert path.exists()
+    assert len(path.read_text(encoding="utf-8").splitlines()) == 256
+
+
+def test_journal_digest_chain_round_trips_exact_checkpoint_prefix(
+    tmp_path: Path,
+) -> None:
+    context = _Context(tmp_path)
+    for ordinal in range(12):
+        _append_journal_event(
+            context,
+            artifact_kind="dirty_reduction",
+            artifact_ref=f"reduction:{ordinal}",
+        )
+
+    events, committed_bytes = _read_journal(
+        context,
+        event_count=12,
+        final_digest=str(context.closure_activation["journal_digest"]),
+    )
+    assert [row["artifact_ref"] for row in events] == [
+        f"reduction:{ordinal}" for ordinal in range(12)
+    ]
+    assert committed_bytes == _journal_path(context).stat().st_size  # type: ignore[union-attr]
+
+
+def test_uncheckpointed_tail_is_dropped_before_replay_continues(
+    tmp_path: Path,
+) -> None:
+    context = _Context(tmp_path)
+    for ordinal in range(4):
+        _append_journal_event(
+            context,
+            artifact_kind="proposal_batch",
+            artifact_ref=f"proposal:{ordinal}",
+        )
+
+    checkpoint_digest = str(context.closure_activation["journal_digest"])
+    events, committed_bytes = _read_journal(
+        context,
+        event_count=4,
+        final_digest=checkpoint_digest,
+    )
+    assert len(events) == 4
+
+    # Simulate a process dying after writing the next event artifact/journal row
+    # but before the atomic owner-frontier checkpoint was replaced.
+    _append_journal_event(
+        context,
+        artifact_kind="proposal_batch",
+        artifact_ref="proposal:uncheckpointed",
+    )
+    path = _journal_path(context)
+    assert path is not None
+    assert path.stat().st_size > committed_bytes
+
+    _discard_uncheckpointed_journal_tail(context, committed_bytes)
+    assert path.stat().st_size == committed_bytes
+
+
+def test_source_contract_removes_quadratic_replay_event_tuple_copy() -> None:
+    source = Path("src/policy/owner_handoff_performance.py").read_text(
+        encoding="utf-8"
+    )
+    legacy = Path("src/policy/parallel_semantic_execution.py").read_text(
+        encoding="utf-8"
+    )
+    policy_init = Path("src/policy/__init__.py").read_text(encoding="utf-8")
+
+    assert 'events = list(activation.get("replay_events") or ())' in legacy
+    assert 'refs = list(activation.get(list_key) or ())' in legacy
+    assert "parallel._append_replay_event = _append_journal_event" in source
+    assert "parallel._write_closure_handoff_checkpoint = _write_compact_checkpoint" in source
+    assert "install_owner_handoff_performance()" in policy_init


### PR DESCRIPTION
## Summary

Remove the execution-bookkeeping amplification exposed by the live GWB replay without changing semantic closure.

The running replay at `cbf066b7` is memory-bounded (~1 GB RSS) but spends the overwhelming majority of one core in `owner_admission_batch`, `owner_proposal_admission`, and `closure_handoff`. Inspection found a concrete quadratic physical path: every replay event copied the full accumulated artifact-ref tuple and full `replay_events` tuple, then the handoff checkpoint serialized the same cumulative histories again.

This PR is stacked directly on #483 / `agent/demand-trigger-target-provenance` at `cbf066b7`. It does not touch the currently running replay.

## v3 handoff carrier

`closure-owner-replay:v3` separates cold append-only replay history from the hot owner frontier:

```text
immutable replay artifact
        |
        v
one compact journal event        O(new event)
        |
        v
small atomic owner/frontier checkpoint
```

Each JSONL journal row carries only sequence number, artifact kind/ref, prior digest, and event digest. The atomic checkpoint keeps owner revision/frontier and activation progress plus the journal count/digest; it no longer embeds cumulative proposal/receipt/reduction replay histories.

On resume the committed journal prefix is digest-verified and materialized once for the existing deterministic reconstruction procedure. Temporary replay lists are released after reconstruction.

If a process dies after appending a journal event but before atomically replacing the corresponding owner-frontier checkpoint, the uncheckpointed journal tail is truncated and deterministically recomputed. No partial owner state is inferred.

Old v2 checkpoints are incompatible execution caches and are recomputed. A malformed checkpoint claiming the current v3 contract remains a hard error.

## Duplicate delta-index removal

The bounded closure caller already computes each `new_batch` by exact membership in `owner._observation_deltas` before invoking `record_observation_batch()`. The old replay contract then rebuilt a second cumulative `recorded_delta_refs` set before and after the batch and serialized it into checkpoints.

v3 removes that duplicate membership carrier. Exact owner reconstruction recreates `_observation_deltas` before new activation continues, so the canonical owner remains the one membership authority.

## Immutable identity caching

Frozen content-addressed carriers now cache their canonical ref after first computation:

- `FactorProposal.proposal_digest` / `proposal_ref`
- `OwnerKey.owner_ref`
- `ObservationDelta.delta_ref`
- `SolverJob.job_ref`
- `SolverReceipt.receipt_ref`

This removes repeated canonical JSON/SHA work from dictionary probes, sorts and replay serialization while leaving identity payloads unchanged.

## Telemetry and isolated probe

Adds counters for journal append/checkpoint time and discarded uncommitted tails, plus `scripts/benchmark_owner_handoff_bookkeeping.py`, which compares the legacy cumulative-copy/full-history serialization shape with v3 append bookkeeping without parser, PostgreSQL, provider or semantic work.

## Formal boundary

I did not change reduction order, owner independence, proposal semantics or fixed-point semantics. This tranche is observationally an execution identity and therefore does not need to block on new Agda work.

The next proposed performance step—evaluating independent `OwnerKey` reductions concurrently and committing canonically—is intentionally **not** implemented here. Before that step, the owner-independence/commutation condition should be checked against the DASHI Agda dynamic-safety/composition contracts and made explicit there if needed.

## Validation boundary

Added focused source/unit contracts for:

- v3 compatibility identity;
- O(1)-state journal append (no cumulative replay lists retained hot);
- digest-chain exact replay prefix;
- uncheckpointed-tail truncation;
- replacement of the legacy cumulative replay-event copies;
- removal of the redundant recorded-delta index;
- installation order and strict current-contract corruption behavior.

These new tests and the benchmark are not claimed as executed through GitHub Actions. Actions and CodeRabbit were not invoked. No HF/Zelph/Wikidata I/O was performed.