### PR TITLE
Import theorem-backed Lean Wikidata ontology certificates

### DIFF
--- a/docs/lean_wikidata_certificate_bridge.md
+++ b/docs/lean_wikidata_certificate_bridge.md
@@ -1,92 +1,75 @@
 # Lean Wikidata certificate bridge
 
-## Purpose
+## Concrete source snapshot
 
-SensibLaw can now ingest theorem-backed results from an external executable Lean
-ontology kernel without copying that kernel into the repository or promoting its
-output to truth/edit authority.
+The bridge is now pinned to the Aristotle archive supplied on 2026-08-16 for request
+`ae06ae06-2580-422a-8fc3-92aeaaca8762`, attributed to James Michael DuPont. The archive
+contains the actual Lean 4 `RequestProject/` development rather than only the earlier
+status image.
 
-The immediate producer is the Wikidata Lean 4 work reported by James Michael
-DuPont on 2026-08-16 (Aristotle request
-`ae06ae06-2580-422a-8fc3-92aeaaca8762`). The reported surface includes
-`RequestProject/ClassAlgebra.lean`, executable `unionOk` / `interOk` checkers,
-and proof-backed Wikidata class/RDF semantics.
+The source snapshot confirms the exact executable/proof surface used here:
 
-This repository does not currently contain a public checkout of that WIP source.
-No Lean code is copied here. The bridge is an import contract for certificates
-exported by that project once its source/export surface is available.
+- `Wikidata.KB.unionOk` with soundness theorem `Wikidata.KB.isUnion_of_unionOk`;
+- `Wikidata.KB.interOk` with soundness theorem `Wikidata.KB.isIntersection_of_interOk`;
+- `Wikidata.Rdf.entails_sound`, `entails_sub_iff`, `entails_inst_iff`, and
+  `entails_iff_isSubclassOf` for the RDF/class-hierarchy layer;
+- `Wikidata.Diagnostics.errors_eq_nil_iff_valid` and witness-bearing diagnostics in the
+  source archive.
 
-## Contract
+`third_party/jmdupont_wikidata_lean/RequestProject/ClassAlgebra.lean` is a verbatim
+vendor snapshot of the imported class-algebra source. Its SHA-256 is
+`6ee3b2371498d67c159fe97389c9ca1e06144ad530e17554cb3f87968c9f899a`.
+`SOURCE_SNAPSHOT.md` also pins the RDF source hash.
+
+The archive contains no license file, so this repository does not claim to relicense the
+source. The snapshot is retained with explicit provenance, and commits importing it carry
+the Aristotle co-author attribution requested by the archive README.
+
+## Certificate contract
 
 `src/ontology/lean_wikidata_certificate.py` defines
-`sensiblaw.lean_wikidata_certificate.v0_1`.
+`sensiblaw.lean_wikidata_certificate.v0_1`. `theorem_backed=true` is no longer a free
+Boolean assertion: for the imported executable class-algebra lane the module,
+checker, theorem, relation kind, and Aristotle request ID must match the pinned source
+registry in `lean_wikidata_source_contract.py`.
 
-Each imported certificate records:
-
-- Aristotle/request identity;
-- Lean module, theorem and executable checker names;
-- source snapshot/fragment identity;
-- subject, predicate and object references;
-- bounded relation kind;
-- source references;
-- the executable Boolean result;
-- whether that result is covered by a theorem-backed checker contract.
-
-A positive result is admitted as `supported` only when both
-`checker_accepted == true` and `theorem_backed == true`.
-
-Every other case is `unresolved`.
-
-In particular:
+Thus a packet claiming `unionOk_sound`/`unionOk` is rejected as forged metadata; the
+source-faithful pair is:
 
 ```text
-checker failure != negative ontology fact
-missing edge     != contradiction
-unbacked result  != proof
+RequestProject.ClassAlgebra
+Wikidata.KB.unionOk
+Wikidata.KB.isUnion_of_unionOk
 ```
 
-This is required for open-world ontology diagnostics.
+The positive projection remains deliberately one-way:
+
+```text
+source-backed theorem contract + checker accepted -> supported
+failed checker / absent edge / unbacked result     -> unresolved
+```
+
+A failed Boolean checker does not mean the negation of the ontology relation.
 
 ## Cross-ontology comparison
 
-A Lean-backed Wikidata relation can be compared with a separately sourced
-external-ontology state:
+A Lean-backed relation can then be compared with separately sourced ontology evidence:
 
 ```text
 supported + supported     -> replicated
 supported + contradicted  -> conflicting
-anything involving unresolved -> unresolved
+anything unresolved       -> unresolved
 ```
 
-Only explicit opposition creates a
-`cross_ontology_explicit_relation_conflict` review issue. Replication is evidence
-but not an issue; unresolved comparison is never silently converted to negative
-evidence.
-
-This directly supports the Ontology Cleaning Task Force diagnostic idea of
-walking mapped external ontologies and checking whether class relationships are
-reproduced in Wikidata while preserving the possibility that sources disagree.
+Only explicit opposition creates a `cross_ontology_explicit_relation_conflict` review
+issue. This is the operational hook for walking SIO/BFO/other mappings without treating
+open-world absence as contradiction.
 
 ## Authority boundary
 
-Every imported receipt explicitly carries:
+Every receipt keeps `truth_authority=false` and `edit_authority=false`. The Lean theorem
+certifies the encoded fragment relative to its formal semantics; it does not promote that
+fragment to global real-world, legal, or Wikidata edit authority.
 
-```text
-truth_authority = false
-edit_authority  = false
-```
-
-The Lean kernel certifies a result relative to its encoded graph/semantics. It
-does not thereby become the authority for legal meaning, real-world truth, or
-Wikidata edits.
-
-The matching Agda-side certificate semantics live in
+The matching proof-side interpretation remains in
 `DASHI/Ontology/LeanWikidataCertificateBridge.agda` in `dashi_agda`.
-
-## Worked fixture
-
-`tests/fixtures/wikidata/lean_artist_union_certificate_v0_1.json` records the
-reported worked fragment where `artist` is checked as the overlapping union of
-`painter` and `sculptor`. It is a regression fixture for the import contract,
-not a claim that the identifiers in the stylised fragment are a complete live
-Wikidata snapshot.

--- a/docs/lean_wikidata_certificate_bridge.md
+++ b/docs/lean_wikidata_certificate_bridge.md
@@ -1,0 +1,92 @@
+# Lean Wikidata certificate bridge
+
+## Purpose
+
+SensibLaw can now ingest theorem-backed results from an external executable Lean
+ontology kernel without copying that kernel into the repository or promoting its
+output to truth/edit authority.
+
+The immediate producer is the Wikidata Lean 4 work reported by James Michael
+DuPont on 2026-08-16 (Aristotle request
+`ae06ae06-2580-422a-8fc3-92aeaaca8762`). The reported surface includes
+`RequestProject/ClassAlgebra.lean`, executable `unionOk` / `interOk` checkers,
+and proof-backed Wikidata class/RDF semantics.
+
+This repository does not currently contain a public checkout of that WIP source.
+No Lean code is copied here. The bridge is an import contract for certificates
+exported by that project once its source/export surface is available.
+
+## Contract
+
+`src/ontology/lean_wikidata_certificate.py` defines
+`sensiblaw.lean_wikidata_certificate.v0_1`.
+
+Each imported certificate records:
+
+- Aristotle/request identity;
+- Lean module, theorem and executable checker names;
+- source snapshot/fragment identity;
+- subject, predicate and object references;
+- bounded relation kind;
+- source references;
+- the executable Boolean result;
+- whether that result is covered by a theorem-backed checker contract.
+
+A positive result is admitted as `supported` only when both
+`checker_accepted == true` and `theorem_backed == true`.
+
+Every other case is `unresolved`.
+
+In particular:
+
+```text
+checker failure != negative ontology fact
+missing edge     != contradiction
+unbacked result  != proof
+```
+
+This is required for open-world ontology diagnostics.
+
+## Cross-ontology comparison
+
+A Lean-backed Wikidata relation can be compared with a separately sourced
+external-ontology state:
+
+```text
+supported + supported     -> replicated
+supported + contradicted  -> conflicting
+anything involving unresolved -> unresolved
+```
+
+Only explicit opposition creates a
+`cross_ontology_explicit_relation_conflict` review issue. Replication is evidence
+but not an issue; unresolved comparison is never silently converted to negative
+evidence.
+
+This directly supports the Ontology Cleaning Task Force diagnostic idea of
+walking mapped external ontologies and checking whether class relationships are
+reproduced in Wikidata while preserving the possibility that sources disagree.
+
+## Authority boundary
+
+Every imported receipt explicitly carries:
+
+```text
+truth_authority = false
+edit_authority  = false
+```
+
+The Lean kernel certifies a result relative to its encoded graph/semantics. It
+does not thereby become the authority for legal meaning, real-world truth, or
+Wikidata edits.
+
+The matching Agda-side certificate semantics live in
+`DASHI/Ontology/LeanWikidataCertificateBridge.agda` in `dashi_agda`.
+
+## Worked fixture
+
+`tests/fixtures/wikidata/lean_artist_union_certificate_v0_1.json` records the
+reported worked fragment where `artist` is checked as the overlapping union of
+`painter` and `sculptor`. It is a regression fixture for the import contract,
+not a claim that the identifiers in the stylised fragment are a complete live
+Wikidata snapshot.

--- a/src/ontology/lean_wikidata_certificate.py
+++ b/src/ontology/lean_wikidata_certificate.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Sequence
 
+from src.ontology.lean_wikidata_source_contract import (
+    ARISTOTLE_REQUEST_ID,
+    checker_contract_is_source_backed,
+)
+
 
 CONTRACT = "sensiblaw.lean_wikidata_certificate.v0_1"
 
@@ -68,13 +73,7 @@ class LeanOntologyCertificate:
 
     @property
     def epistemic_state(self) -> str:
-        """Project a positive theorem-backed checker result into evidence state.
-
-        A failed checker, missing theorem backing, or other non-positive result is
-        unresolved rather than contradicted.  This is deliberate: absence of an
-        edge in an open-world ontology is not evidence for its negation.
-        """
-
+        """Project a positive source-backed checker result into evidence state."""
         if self.checker_accepted and self.theorem_backed:
             return "supported"
         return "unresolved"
@@ -87,11 +86,33 @@ class LeanOntologyCertificate:
             raise LeanCertificateError(
                 f"relation_kind must be one of: {allowed}; got {relation_kind!r}"
             )
+
+        request_id = _required_text(row, "request_id")
+        module_name = _required_text(row, "module_name")
+        theorem_name = _required_text(row, "theorem_name")
+        checker_name = _required_text(row, "checker_name")
+        theorem_backed = _required_bool(row, "theorem_backed")
+
+        if theorem_backed:
+            if request_id != ARISTOTLE_REQUEST_ID:
+                raise LeanCertificateError(
+                    "theorem_backed certificate request_id does not match the pinned source snapshot"
+                )
+            if not checker_contract_is_source_backed(
+                relation_kind=relation_kind,
+                module_name=module_name,
+                checker_name=checker_name,
+                theorem_name=theorem_name,
+            ):
+                raise LeanCertificateError(
+                    "theorem_backed certificate does not match a checker/theorem pair in the pinned Lean source"
+                )
+
         return cls(
-            request_id=_required_text(row, "request_id"),
-            module_name=_required_text(row, "module_name"),
-            theorem_name=_required_text(row, "theorem_name"),
-            checker_name=_required_text(row, "checker_name"),
+            request_id=request_id,
+            module_name=module_name,
+            theorem_name=theorem_name,
+            checker_name=checker_name,
             source_snapshot=_required_text(row, "source_snapshot"),
             subject_ref=_required_text(row, "subject_ref"),
             predicate_ref=_required_text(row, "predicate_ref"),
@@ -101,7 +122,7 @@ class LeanOntologyCertificate:
                 row.get("source_references"), key="source_references"
             ),
             checker_accepted=_required_bool(row, "checker_accepted"),
-            theorem_backed=_required_bool(row, "theorem_backed"),
+            theorem_backed=theorem_backed,
         )
 
     def to_receipt(self) -> dict[str, Any]:
@@ -178,8 +199,7 @@ def compare_external_relation(
 
 
 def load_certificate_packet(payload: Mapping[str, Any]) -> list[LeanOntologyCertificate]:
-    """Load a deterministic certificate packet exported by a Lean-side adapter."""
-
+    """Load a deterministic certificate packet exported by the pinned Lean source."""
     if payload.get("contract") != CONTRACT:
         raise LeanCertificateError(f"unsupported certificate contract: {payload.get('contract')!r}")
     raw = payload.get("certificates")

--- a/src/ontology/lean_wikidata_certificate.py
+++ b/src/ontology/lean_wikidata_certificate.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+
+CONTRACT = "sensiblaw.lean_wikidata_certificate.v0_1"
+
+RELATION_KINDS = frozenset(
+    {
+        "instance_of",
+        "subclass_of",
+        "union_of",
+        "intersection_of",
+        "disjoint_union_of",
+        "disjoint_with",
+        "equivalent_class",
+        "rdf_entailment",
+    }
+)
+
+EPISTEMIC_STATES = frozenset({"supported", "unresolved", "contradicted"})
+
+
+class LeanCertificateError(ValueError):
+    """Raised when an imported theorem/checker certificate is malformed."""
+
+
+def _required_text(row: Mapping[str, Any], key: str) -> str:
+    value = row.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise LeanCertificateError(f"{key} must be a non-empty string")
+    return value.strip()
+
+
+def _required_bool(row: Mapping[str, Any], key: str) -> bool:
+    value = row.get(key)
+    if not isinstance(value, bool):
+        raise LeanCertificateError(f"{key} must be a boolean")
+    return value
+
+
+def _string_tuple(value: Any, *, key: str) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise LeanCertificateError(f"{key} must be a list of strings")
+    result: list[str] = []
+    for entry in value:
+        if not isinstance(entry, str) or not entry.strip():
+            raise LeanCertificateError(f"{key} entries must be non-empty strings")
+        result.append(entry.strip())
+    return tuple(result)
+
+
+@dataclass(frozen=True)
+class LeanOntologyCertificate:
+    request_id: str
+    module_name: str
+    theorem_name: str
+    checker_name: str
+    source_snapshot: str
+    subject_ref: str
+    predicate_ref: str
+    object_ref: str
+    relation_kind: str
+    source_references: tuple[str, ...]
+    checker_accepted: bool
+    theorem_backed: bool
+
+    @property
+    def epistemic_state(self) -> str:
+        """Project a positive theorem-backed checker result into evidence state.
+
+        A failed checker, missing theorem backing, or other non-positive result is
+        unresolved rather than contradicted.  This is deliberate: absence of an
+        edge in an open-world ontology is not evidence for its negation.
+        """
+
+        if self.checker_accepted and self.theorem_backed:
+            return "supported"
+        return "unresolved"
+
+    @classmethod
+    def from_mapping(cls, row: Mapping[str, Any]) -> "LeanOntologyCertificate":
+        relation_kind = _required_text(row, "relation_kind")
+        if relation_kind not in RELATION_KINDS:
+            allowed = ", ".join(sorted(RELATION_KINDS))
+            raise LeanCertificateError(
+                f"relation_kind must be one of: {allowed}; got {relation_kind!r}"
+            )
+        return cls(
+            request_id=_required_text(row, "request_id"),
+            module_name=_required_text(row, "module_name"),
+            theorem_name=_required_text(row, "theorem_name"),
+            checker_name=_required_text(row, "checker_name"),
+            source_snapshot=_required_text(row, "source_snapshot"),
+            subject_ref=_required_text(row, "subject_ref"),
+            predicate_ref=_required_text(row, "predicate_ref"),
+            object_ref=_required_text(row, "object_ref"),
+            relation_kind=relation_kind,
+            source_references=_string_tuple(
+                row.get("source_references"), key="source_references"
+            ),
+            checker_accepted=_required_bool(row, "checker_accepted"),
+            theorem_backed=_required_bool(row, "theorem_backed"),
+        )
+
+    def to_receipt(self) -> dict[str, Any]:
+        return {
+            "contract": CONTRACT,
+            "request_id": self.request_id,
+            "module_name": self.module_name,
+            "theorem_name": self.theorem_name,
+            "checker_name": self.checker_name,
+            "source_snapshot": self.source_snapshot,
+            "subject_ref": self.subject_ref,
+            "predicate_ref": self.predicate_ref,
+            "object_ref": self.object_ref,
+            "relation_kind": self.relation_kind,
+            "source_references": list(self.source_references),
+            "checker_accepted": self.checker_accepted,
+            "theorem_backed": self.theorem_backed,
+            "epistemic_state": self.epistemic_state,
+            "truth_authority": False,
+            "edit_authority": False,
+        }
+
+
+@dataclass(frozen=True)
+class CrossOntologyRelationComparison:
+    certificate: LeanOntologyCertificate
+    external_state: str
+    external_references: tuple[str, ...]
+
+    @property
+    def disposition(self) -> str:
+        local = self.certificate.epistemic_state
+        external = self.external_state
+        if local == "supported" and external == "supported":
+            return "replicated"
+        if (local, external) in {
+            ("supported", "contradicted"),
+            ("contradicted", "supported"),
+        }:
+            return "conflicting"
+        return "unresolved"
+
+    def to_receipt(self) -> dict[str, Any]:
+        return {
+            "contract": "sensiblaw.cross_ontology_relation_comparison.v0_1",
+            "lean_certificate": self.certificate.to_receipt(),
+            "external_state": self.external_state,
+            "external_references": list(self.external_references),
+            "disposition": self.disposition,
+            "truth_authority": False,
+            "edit_authority": False,
+        }
+
+
+def compare_external_relation(
+    certificate: LeanOntologyCertificate,
+    *,
+    external_state: str,
+    external_references: Iterable[str] = (),
+) -> CrossOntologyRelationComparison:
+    if external_state not in EPISTEMIC_STATES:
+        allowed = ", ".join(sorted(EPISTEMIC_STATES))
+        raise LeanCertificateError(
+            f"external_state must be one of: {allowed}; got {external_state!r}"
+        )
+    refs = tuple(external_references)
+    if not all(isinstance(ref, str) and ref.strip() for ref in refs):
+        raise LeanCertificateError("external_references entries must be non-empty strings")
+    return CrossOntologyRelationComparison(
+        certificate=certificate,
+        external_state=external_state,
+        external_references=tuple(ref.strip() for ref in refs),
+    )
+
+
+def load_certificate_packet(payload: Mapping[str, Any]) -> list[LeanOntologyCertificate]:
+    """Load a deterministic certificate packet exported by a Lean-side adapter."""
+
+    if payload.get("contract") != CONTRACT:
+        raise LeanCertificateError(f"unsupported certificate contract: {payload.get('contract')!r}")
+    raw = payload.get("certificates")
+    if not isinstance(raw, list):
+        raise LeanCertificateError("certificates must be a list")
+    certificates: list[LeanOntologyCertificate] = []
+    for index, row in enumerate(raw):
+        if not isinstance(row, Mapping):
+            raise LeanCertificateError(f"certificates[{index}] must be an object")
+        certificates.append(LeanOntologyCertificate.from_mapping(row))
+    return certificates

--- a/src/ontology/lean_wikidata_source_contract.py
+++ b/src/ontology/lean_wikidata_source_contract.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+ARISTOTLE_REQUEST_ID = "ae06ae06-2580-422a-8fc3-92aeaaca8762"
+
+SOURCE_SHA256 = {
+    "RequestProject.ClassAlgebra": "6ee3b2371498d67c159fe97389c9ca1e06144ad530e17554cb3f87968c9f899a",
+    "RequestProject.Rdf": "11a4d3fc6b152a022016d7c8639b89805d45352c9e08c16ec2a8172a2610f3cf",
+}
+
+
+@dataclass(frozen=True)
+class TheoremBackedChecker:
+    relation_kind: str
+    module_name: str
+    checker_name: str
+    theorem_name: str
+
+
+SOURCE_CHECKER_CONTRACTS = (
+    TheoremBackedChecker(
+        relation_kind="union_of",
+        module_name="RequestProject.ClassAlgebra",
+        checker_name="Wikidata.KB.unionOk",
+        theorem_name="Wikidata.KB.isUnion_of_unionOk",
+    ),
+    TheoremBackedChecker(
+        relation_kind="intersection_of",
+        module_name="RequestProject.ClassAlgebra",
+        checker_name="Wikidata.KB.interOk",
+        theorem_name="Wikidata.KB.isIntersection_of_interOk",
+    ),
+)
+
+SOURCE_THEOREMS_WITHOUT_BOOLEAN_CHECKER = {
+    ("subclass_of", "RequestProject.Rdf", "Wikidata.Rdf.entails_iff_isSubclassOf"),
+    ("rdf_entailment", "RequestProject.Rdf", "Wikidata.Rdf.entails_sound"),
+    ("rdf_entailment", "RequestProject.Rdf", "Wikidata.Rdf.entails_sub_iff"),
+    ("rdf_entailment", "RequestProject.Rdf", "Wikidata.Rdf.entails_inst_iff"),
+}
+
+
+def checker_contract_is_source_backed(
+    *, relation_kind: str, module_name: str, checker_name: str, theorem_name: str
+) -> bool:
+    return any(
+        contract.relation_kind == relation_kind
+        and contract.module_name == module_name
+        and contract.checker_name == checker_name
+        and contract.theorem_name == theorem_name
+        for contract in SOURCE_CHECKER_CONTRACTS
+    )

--- a/src/ontology/ontology_issue_detector.py
+++ b/src/ontology/ontology_issue_detector.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from typing import Any, Mapping, Sequence
 
+from src.ontology.lean_wikidata_certificate import (
+    LeanOntologyCertificate,
+    compare_external_relation,
+)
+
 
 @dataclass(frozen=True)
 class OntologyIssue:
@@ -100,6 +105,62 @@ def _issue_from_probe_row(
     )
 
 
+def _issue_from_formal_relation_comparison(row: Mapping[str, Any]) -> OntologyIssue | None:
+    raw_certificate = row.get("lean_certificate")
+    if not isinstance(raw_certificate, Mapping):
+        raise ValueError("formal relation comparison requires lean_certificate")
+    certificate = LeanOntologyCertificate.from_mapping(raw_certificate)
+    external_state = _stringify(row.get("external_state")).strip()
+    external_references = _string_list(row.get("external_references"))
+    comparison = compare_external_relation(
+        certificate,
+        external_state=external_state,
+        external_references=external_references,
+    )
+
+    # Replication is useful evidence but not an ontology issue.  Unresolved
+    # comparisons also remain non-negative: absence of an external edge or a
+    # failed/unbacked Lean checker does not manufacture contradiction.
+    if comparison.disposition != "conflicting":
+        return None
+
+    evidence_refs = tuple(
+        dict.fromkeys(
+            (
+                f"lean-request:{certificate.request_id}",
+                f"lean-theorem:{certificate.module_name}:{certificate.theorem_name}",
+                *certificate.source_references,
+                *comparison.external_references,
+            )
+        )
+    )
+    return OntologyIssue(
+        issue_id=(
+            "issue:cross-ontology:"
+            f"{certificate.subject_ref}:{certificate.predicate_ref}:{certificate.object_ref}"
+        ),
+        issue_type="cross_ontology_explicit_relation_conflict",
+        scope="wikidata_ontology",
+        subject_ids=(certificate.subject_ref, certificate.object_ref),
+        status="review_required",
+        confidence_band="high",
+        reason_codes=("formal_relation_conflict", "explicit_opposing_evidence"),
+        evidence_refs=evidence_refs,
+        details={
+            "relation_kind": certificate.relation_kind,
+            "predicate_ref": certificate.predicate_ref,
+            "lean_state": certificate.epistemic_state,
+            "external_state": comparison.external_state,
+            "checker_name": certificate.checker_name,
+            "module_name": certificate.module_name,
+            "theorem_name": certificate.theorem_name,
+            "source_snapshot": certificate.source_snapshot,
+            "truth_authority": False,
+            "edit_authority": False,
+        },
+    )
+
+
 def detect_ontology_issues(
     *,
     relation_rows: Sequence[Mapping[str, Any]] | None = None,
@@ -107,10 +168,21 @@ def detect_ontology_issues(
     source_system: str = "wikidata",
     type_probing_surface: Mapping[str, Any] | None = None,
     operator_review_surface: Mapping[str, Any] | None = None,
+    formal_relation_comparisons: Sequence[Mapping[str, Any]] | None = None,
 ) -> list[OntologyIssue]:
     del relation_rows, equivalence_clusters
     if source_system != "wikidata":
         return []
+
+    if formal_relation_comparisons is not None:
+        issues = [
+            issue
+            for row in formal_relation_comparisons
+            if isinstance(row, Mapping)
+            for issue in [_issue_from_formal_relation_comparison(row)]
+            if issue is not None
+        ]
+        return sorted(issues, key=lambda issue: issue.issue_id)
 
     if type_probing_surface is not None:
         probe_rows = type_probing_surface.get("probe_rows")

--- a/tests/fixtures/wikidata/lean_artist_union_certificate_v0_1.json
+++ b/tests/fixtures/wikidata/lean_artist_union_certificate_v0_1.json
@@ -4,15 +4,16 @@
     {
       "request_id": "ae06ae06-2580-422a-8fc3-92aeaaca8762",
       "module_name": "RequestProject.ClassAlgebra",
-      "theorem_name": "unionOk_sound",
-      "checker_name": "unionOk",
-      "source_snapshot": "worked-fragment:artist-painter-sculptor",
-      "subject_ref": "wd:artist",
+      "theorem_name": "Wikidata.KB.isUnion_of_unionOk",
+      "checker_name": "Wikidata.KB.unionOk",
+      "source_snapshot": "sha256:6ee3b2371498d67c159fe97389c9ca1e06144ad530e17554cb3f87968c9f899a#ClassAlgebraExample.artistKB",
+      "subject_ref": "wd:Q483501",
       "predicate_ref": "wdt:P2737",
-      "object_ref": "wd:painter|wd:sculptor",
+      "object_ref": "wd:Q1028181|wd:Q1281618",
       "relation_kind": "union_of",
       "source_references": [
         "aristotle:ae06ae06-2580-422a-8fc3-92aeaaca8762",
+        "lean:Wikidata.ClassAlgebraExample.artistKB_unionOk",
         "reported-by:James-Michael-DuPont:2026-08-16"
       ],
       "checker_accepted": true,

--- a/tests/fixtures/wikidata/lean_artist_union_certificate_v0_1.json
+++ b/tests/fixtures/wikidata/lean_artist_union_certificate_v0_1.json
@@ -1,0 +1,22 @@
+{
+  "contract": "sensiblaw.lean_wikidata_certificate.v0_1",
+  "certificates": [
+    {
+      "request_id": "ae06ae06-2580-422a-8fc3-92aeaaca8762",
+      "module_name": "RequestProject.ClassAlgebra",
+      "theorem_name": "unionOk_sound",
+      "checker_name": "unionOk",
+      "source_snapshot": "worked-fragment:artist-painter-sculptor",
+      "subject_ref": "wd:artist",
+      "predicate_ref": "wdt:P2737",
+      "object_ref": "wd:painter|wd:sculptor",
+      "relation_kind": "union_of",
+      "source_references": [
+        "aristotle:ae06ae06-2580-422a-8fc3-92aeaaca8762",
+        "reported-by:James-Michael-DuPont:2026-08-16"
+      ],
+      "checker_accepted": true,
+      "theorem_backed": true
+    }
+  ]
+}

--- a/tests/test_lean_wikidata_certificate.py
+++ b/tests/test_lean_wikidata_certificate.py
@@ -14,12 +14,12 @@ def _certificate_row(**overrides):
     row = {
         "request_id": "ae06ae06-2580-422a-8fc3-92aeaaca8762",
         "module_name": "RequestProject.ClassAlgebra",
-        "theorem_name": "unionOk_sound",
-        "checker_name": "unionOk",
-        "source_snapshot": "wikidata-fragment:artist-painter-sculptor",
-        "subject_ref": "wd:artist",
+        "theorem_name": "Wikidata.KB.isUnion_of_unionOk",
+        "checker_name": "Wikidata.KB.unionOk",
+        "source_snapshot": "sha256:6ee3b2371498d67c159fe97389c9ca1e06144ad530e17554cb3f87968c9f899a#ClassAlgebraExample.artistKB",
+        "subject_ref": "wd:Q483501",
         "predicate_ref": "wdt:P2737",
-        "object_ref": "wd:painter|wd:sculptor",
+        "object_ref": "wd:Q1028181|wd:Q1281618",
         "relation_kind": "union_of",
         "source_references": ["aristotle:ae06ae06-2580-422a-8fc3-92aeaaca8762"],
         "checker_accepted": True,
@@ -36,7 +36,7 @@ def test_positive_theorem_backed_checker_projects_to_supported_without_authority
     receipt = certificate.to_receipt()
     assert receipt["truth_authority"] is False
     assert receipt["edit_authority"] is False
-    assert receipt["checker_name"] == "unionOk"
+    assert receipt["checker_name"] == "Wikidata.KB.unionOk"
 
 
 def test_failed_checker_is_unresolved_not_contradicted() -> None:
@@ -49,12 +49,36 @@ def test_failed_checker_is_unresolved_not_contradicted() -> None:
     assert comparison.disposition == "unresolved"
 
 
-def test_unbacked_checker_is_unresolved() -> None:
+def test_unbacked_checker_is_unresolved_even_if_names_are_not_source_backed() -> None:
     certificate = LeanOntologyCertificate.from_mapping(
-        _certificate_row(theorem_backed=False)
+        _certificate_row(
+            theorem_backed=False,
+            theorem_name="not-a-source-theorem",
+            checker_name="not-a-source-checker",
+        )
     )
 
     assert certificate.epistemic_state == "unresolved"
+
+
+def test_forged_theorem_backed_pair_fails_closed() -> None:
+    with pytest.raises(LeanCertificateError, match="pinned Lean source"):
+        LeanOntologyCertificate.from_mapping(
+            _certificate_row(theorem_name="unionOk_sound", checker_name="unionOk")
+        )
+
+
+def test_source_backed_intersection_pair_is_admitted() -> None:
+    certificate = LeanOntologyCertificate.from_mapping(
+        _certificate_row(
+            relation_kind="intersection_of",
+            theorem_name="Wikidata.KB.isIntersection_of_interOk",
+            checker_name="Wikidata.KB.interOk",
+            subject_ref="wd:Q-painter-sculptor",
+            predicate_ref="internal:intersection",
+        )
+    )
+    assert certificate.epistemic_state == "supported"
 
 
 def test_supported_pair_replicates_and_explicit_opposition_conflicts() -> None:
@@ -86,7 +110,7 @@ def test_only_explicit_cross_ontology_conflict_becomes_review_issue() -> None:
     assert issue.issue_type == "cross_ontology_explicit_relation_conflict"
     assert issue.status == "review_required"
     assert issue.confidence_band == "high"
-    assert issue.details["checker_name"] == "unionOk"
+    assert issue.details["checker_name"] == "Wikidata.KB.unionOk"
     assert issue.details["truth_authority"] is False
     assert "external-ontology:explicit-incompatibility" in issue.evidence_refs
 
@@ -111,7 +135,7 @@ def test_packet_loader_is_strict_and_deterministic() -> None:
     loaded = load_certificate_packet(packet)
 
     assert len(loaded) == 1
-    assert loaded[0].theorem_name == "unionOk_sound"
+    assert loaded[0].theorem_name == "Wikidata.KB.isUnion_of_unionOk"
 
 
 def test_unknown_relation_kind_fails_closed() -> None:

--- a/tests/test_lean_wikidata_certificate.py
+++ b/tests/test_lean_wikidata_certificate.py
@@ -1,0 +1,119 @@
+import pytest
+
+from src.ontology.lean_wikidata_certificate import (
+    CONTRACT,
+    LeanCertificateError,
+    LeanOntologyCertificate,
+    compare_external_relation,
+    load_certificate_packet,
+)
+from src.ontology.ontology_issue_detector import detect_ontology_issues
+
+
+def _certificate_row(**overrides):
+    row = {
+        "request_id": "ae06ae06-2580-422a-8fc3-92aeaaca8762",
+        "module_name": "RequestProject.ClassAlgebra",
+        "theorem_name": "unionOk_sound",
+        "checker_name": "unionOk",
+        "source_snapshot": "wikidata-fragment:artist-painter-sculptor",
+        "subject_ref": "wd:artist",
+        "predicate_ref": "wdt:P2737",
+        "object_ref": "wd:painter|wd:sculptor",
+        "relation_kind": "union_of",
+        "source_references": ["aristotle:ae06ae06-2580-422a-8fc3-92aeaaca8762"],
+        "checker_accepted": True,
+        "theorem_backed": True,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_positive_theorem_backed_checker_projects_to_supported_without_authority() -> None:
+    certificate = LeanOntologyCertificate.from_mapping(_certificate_row())
+
+    assert certificate.epistemic_state == "supported"
+    receipt = certificate.to_receipt()
+    assert receipt["truth_authority"] is False
+    assert receipt["edit_authority"] is False
+    assert receipt["checker_name"] == "unionOk"
+
+
+def test_failed_checker_is_unresolved_not_contradicted() -> None:
+    certificate = LeanOntologyCertificate.from_mapping(
+        _certificate_row(checker_accepted=False)
+    )
+
+    assert certificate.epistemic_state == "unresolved"
+    comparison = compare_external_relation(certificate, external_state="supported")
+    assert comparison.disposition == "unresolved"
+
+
+def test_unbacked_checker_is_unresolved() -> None:
+    certificate = LeanOntologyCertificate.from_mapping(
+        _certificate_row(theorem_backed=False)
+    )
+
+    assert certificate.epistemic_state == "unresolved"
+
+
+def test_supported_pair_replicates_and_explicit_opposition_conflicts() -> None:
+    certificate = LeanOntologyCertificate.from_mapping(_certificate_row())
+
+    replicated = compare_external_relation(certificate, external_state="supported")
+    conflicting = compare_external_relation(
+        certificate,
+        external_state="contradicted",
+        external_references=["sio:SIO_000593-not-subclass-example"],
+    )
+
+    assert replicated.disposition == "replicated"
+    assert conflicting.disposition == "conflicting"
+
+
+def test_only_explicit_cross_ontology_conflict_becomes_review_issue() -> None:
+    certificate = LeanOntologyCertificate.from_mapping(_certificate_row())
+    conflict = compare_external_relation(
+        certificate,
+        external_state="contradicted",
+        external_references=["external-ontology:explicit-incompatibility"],
+    ).to_receipt()
+
+    issues = detect_ontology_issues(formal_relation_comparisons=[conflict])
+
+    assert len(issues) == 1
+    issue = issues[0]
+    assert issue.issue_type == "cross_ontology_explicit_relation_conflict"
+    assert issue.status == "review_required"
+    assert issue.confidence_band == "high"
+    assert issue.details["checker_name"] == "unionOk"
+    assert issue.details["truth_authority"] is False
+    assert "external-ontology:explicit-incompatibility" in issue.evidence_refs
+
+
+def test_replication_and_unresolved_comparisons_do_not_become_issues() -> None:
+    supported = LeanOntologyCertificate.from_mapping(_certificate_row())
+    failed = LeanOntologyCertificate.from_mapping(
+        _certificate_row(checker_accepted=False)
+    )
+
+    comparisons = [
+        compare_external_relation(supported, external_state="supported").to_receipt(),
+        compare_external_relation(failed, external_state="supported").to_receipt(),
+    ]
+
+    assert detect_ontology_issues(formal_relation_comparisons=comparisons) == []
+
+
+def test_packet_loader_is_strict_and_deterministic() -> None:
+    packet = {"contract": CONTRACT, "certificates": [_certificate_row()]}
+
+    loaded = load_certificate_packet(packet)
+
+    assert len(loaded) == 1
+    assert loaded[0].theorem_name == "unionOk_sound"
+
+
+def test_unknown_relation_kind_fails_closed() -> None:
+    with pytest.raises(LeanCertificateError):
+        LeanOntologyCertificate.from_mapping(_certificate_row(relation_kind="maybe_related"))

--- a/third_party/jmdupont_wikidata_lean/RequestProject/ClassAlgebra.lean
+++ b/third_party/jmdupont_wikidata_lean/RequestProject/ClassAlgebra.lean
@@ -1,0 +1,302 @@
+import RequestProject.DisjointUnion
+
+/-!
+# `union of` (P2737) and class intersections
+
+`RequestProject.DisjointUnion` covers `disjoint union of` (P2738), the strongest of the
+class-decomposition statements.  Wikidata also has the weaker `union of` (P2737), which
+carves a class into subclasses that are allowed to **overlap**, and — although Wikidata
+has no dedicated property for it — classes that are *intersections* of others (a class
+that is a subclass of several classes and contains every item that is an instance of all
+of them) occur constantly in the ontology.
+
+This file adds both:
+
+* `Wikidata.Ontology.IsUnion O c Part`: every part is a subclass of `c` and every
+  instance of `c` is an instance of some part.  Proved: the instances of the union are
+  exactly the instances of the parts; a disjoint union is a union; the union is empty
+  when all parts are; unions compose under refinement; a union with a single part has
+  the same instances as that part; and everything the parts have in common (being a
+  subclass of a further class, in the sense of inherited instances) is inherited by
+  the union.
+* `Wikidata.Ontology.IsIntersection O c Part`: `c` is a subclass of every part and every
+  item instantiating all the parts is an instance of `c`.  Proved: the instances of the
+  intersection are exactly the items lying in all the parts; the intersection of two
+  disjoint classes is empty; the intersection is the largest such class; and an
+  intersection over the parts of a union of which one part exhausts the class collapses
+  to that part.
+* Certified executable checkers `Wikidata.KB.unionOk` and `Wikidata.KB.interOk`.
+* A worked fragment where `artist` is the union of `painter` and `sculptor` — which is
+  *not* a disjoint union, since Michelangelo is both — and where the class of
+  painter-sculptors is checked to be their intersection.
+
+Note on the degenerate case: an intersection over the empty family of parts is the class
+of *all* items, which is what the definition says; the executable checker therefore
+requires a nonempty list of parts.
+-/
+
+namespace Wikidata
+
+namespace Ontology
+
+variable {I : Type*} {O : Ontology I}
+
+/-! ### `union of` (P2737) -/
+
+/-- `IsUnion O c Part`: the class `c` is the union (P2737) of the classes satisfying
+`Part` — each part is a subclass of `c`, and every instance of `c` is an instance of at
+least one part.  Unlike `IsDisjointUnion` the parts may overlap. -/
+structure IsUnion (O : Ontology I) (c : I) (Part : I → Prop) : Prop where
+  /-- Every part is a subclass of the whole. -/
+  subclass : ∀ ⦃p⦄, Part p → O.SubclassOf p c
+  /-- Every instance of the whole is an instance of some part. -/
+  cover : ∀ ⦃a⦄, O.InstanceOf a c → ∃ p, Part p ∧ O.InstanceOf a p
+
+namespace IsUnion
+
+variable {c : I} {Part : I → Prop} (h : IsUnion O c Part)
+include h
+
+/-- An instance of a part is an instance of the whole. -/
+theorem instanceOf_of_part {a p : I} (hp : Part p) (ha : O.InstanceOf a p) :
+    O.InstanceOf a c :=
+  instanceOf_trans_subclassOf ha (h.subclass hp)
+
+/-- The instances of the union are exactly the instances of its parts. -/
+theorem instanceOf_iff {a : I} : O.InstanceOf a c ↔ ∃ p, Part p ∧ O.InstanceOf a p :=
+  ⟨fun ha => h.cover ha, fun ⟨_, hp, ha⟩ => h.instanceOf_of_part hp ha⟩
+
+/-- The union of classes without instances has no instances. -/
+theorem not_hasInstance (hempty : ∀ p, Part p → ¬ O.HasInstance p) : ¬ O.HasInstance c := by
+  rintro ⟨a, ha⟩
+  obtain ⟨p, hp, hap⟩ := h.cover ha
+  exact hempty p hp ⟨a, hap⟩
+
+/-- A property shared by all the parts — every instance of a part being an instance of
+`d` — is inherited by the union. -/
+theorem instanceOf_of_forall_parts {d : I}
+    (hd : ∀ p, Part p → ∀ a, O.InstanceOf a p → O.InstanceOf a d) {a : I}
+    (ha : O.InstanceOf a c) : O.InstanceOf a d := by
+  obtain ⟨p, hp, hap⟩ := h.cover ha
+  exact hd p hp a hap
+
+/-- A union with a single part has exactly the instances of that part. -/
+theorem instanceOf_iff_of_singleton {p : I} (hpart : ∀ q, Part q ↔ q = p) {a : I} :
+    O.InstanceOf a c ↔ O.InstanceOf a p := by
+  refine ⟨fun ha => ?_, fun ha => h.instanceOf_of_part ((hpart p).2 rfl) ha⟩
+  obtain ⟨q, hq, haq⟩ := h.cover ha
+  rw [hpart q] at hq
+  exact hq ▸ haq
+
+/-- Unions compose: refining every part of a union again yields a union. -/
+theorem comp {Sub : I → I → Prop} (hsub : ∀ p, Part p → IsUnion O p (Sub p)) :
+    IsUnion O c (fun q => ∃ p, Part p ∧ Sub p q) where
+  subclass := by
+    rintro q ⟨p, hp, hq⟩
+    exact subclassOf_trans ((hsub p hp).subclass hq) (h.subclass hp)
+  cover := by
+    intro a ha
+    obtain ⟨p, hp, hap⟩ := h.cover ha
+    obtain ⟨q, hq, haq⟩ := (hsub p hp).cover hap
+    exact ⟨q, ⟨p, hp, hq⟩, haq⟩
+
+end IsUnion
+
+/-- A disjoint union (P2738) is in particular a union (P2737). -/
+theorem IsDisjointUnion.isUnion {c : I} {Part : I → Prop}
+    (h : IsDisjointUnion O c Part) : IsUnion O c Part where
+  subclass := h.subclass
+  cover := h.cover
+
+/-! ### Intersections -/
+
+/-- `IsIntersection O c Part`: the class `c` is the intersection of the classes
+satisfying `Part` — it is a subclass of each of them, and every item that instantiates
+all of them is an instance of `c`. -/
+structure IsIntersection (O : Ontology I) (c : I) (Part : I → Prop) : Prop where
+  /-- The intersection is a subclass of each part. -/
+  subclass : ∀ ⦃p⦄, Part p → O.SubclassOf c p
+  /-- An item instantiating every part is an instance of the intersection. -/
+  complete : ∀ ⦃a⦄, (∀ p, Part p → O.InstanceOf a p) → O.InstanceOf a c
+
+namespace IsIntersection
+
+variable {c : I} {Part : I → Prop} (h : IsIntersection O c Part)
+include h
+
+/-- An instance of the intersection is an instance of each part. -/
+theorem instanceOf_part {a p : I} (hp : Part p) (ha : O.InstanceOf a c) : O.InstanceOf a p :=
+  instanceOf_trans_subclassOf ha (h.subclass hp)
+
+/-- The instances of the intersection are exactly the items lying in every part. -/
+theorem instanceOf_iff {a : I} : O.InstanceOf a c ↔ ∀ p, Part p → O.InstanceOf a p :=
+  ⟨fun ha _ hp => h.instanceOf_part hp ha, fun ha => h.complete ha⟩
+
+/-- The intersection is the largest such class: if every instance of a class `d` lies
+in all the parts, then every instance of `d` is an instance of the intersection. -/
+theorem instanceOf_of_subclass_all {d a : I}
+    (hd : ∀ p, Part p → ∀ x, O.InstanceOf x d → O.InstanceOf x p) (hda : O.InstanceOf a d) :
+    O.InstanceOf a c :=
+  h.complete fun p hp => hd p hp a hda
+
+omit h in
+/-- The intersection of two classes declared disjoint has no instances. -/
+theorem not_hasInstance_of_disjoint {D : WithDisjointness I}
+    (h : IsIntersection D.toOntology c Part) {p q : I} (hp : Part p) (hq : Part q)
+    (hdisj : D.DisjointWith p q) : ¬ D.toOntology.HasInstance c := by
+  rintro ⟨a, ha⟩
+  exact D.disjointWith_spec hdisj (h.instanceOf_part hp ha) (h.instanceOf_part hq ha)
+
+/-- If one of the parts is already contained in all the others, the intersection has
+exactly its instances. -/
+theorem instanceOf_iff_of_smallest {p : I} (hp : Part p)
+    (hmin : ∀ q, Part q → ∀ a, O.InstanceOf a p → O.InstanceOf a q) {a : I} :
+    O.InstanceOf a c ↔ O.InstanceOf a p :=
+  ⟨fun ha => h.instanceOf_part hp ha, fun ha => h.complete fun q hq => hmin q hq a ha⟩
+
+end IsIntersection
+
+end Ontology
+
+/-! ### The executable checkers -/
+
+namespace KB
+
+variable (kb : KB)
+
+/-- The `union of` (P2737) check: every listed class is a subclass of `c`, and every
+instance of `c` is an instance of one of them. -/
+def unionOk (c : Qid) (ps : List Qid) : Bool :=
+  kb.dunSubclassOk c ps && kb.dunCoverOk c ps
+
+/-- The intersection check: `c` is a subclass of every listed class, and every item
+instantiating all of them is an instance of `c`.  The list must be nonempty. -/
+def interOk (c : Qid) (ps : List Qid) : Bool :=
+  !ps.isEmpty && ps.all (fun p => kb.isSubclassOf c p) &&
+    kb.items.all (fun a => !ps.all (fun p => kb.isInstanceOf a p) || kb.isInstanceOf a c)
+
+variable {kb}
+
+/-- **Soundness of the union checker.** -/
+theorem isUnion_of_unionOk (hv : kb.valid = true) {c : Qid} {ps : List Qid}
+    (h : kb.unionOk c ps = true) :
+    Ontology.IsUnion (kb.toOntology hv) c (fun p => p ∈ ps) := by
+  simp only [unionOk, Bool.and_eq_true] at h
+  obtain ⟨hsub, hcov⟩ := h
+  refine ⟨?_, ?_⟩
+  · intro p hp
+    exact (isSubclassOf_iff_subclassOf hv p c).1 (List.all_eq_true.1 hsub p hp)
+  · intro a ha
+    have hmem : a ∈ kb.instancesOf c :=
+      mem_instancesOf.2 ⟨mem_items_of_instanceOf hv ha,
+        (isInstanceOf_iff_instanceOf hv a c).2 ha⟩
+    obtain ⟨p, hp, hap⟩ := List.any_eq_true.1 (List.all_eq_true.1 hcov a hmem)
+    exact ⟨p, hp, (isInstanceOf_iff_instanceOf hv a p).1 hap⟩
+
+/-- **Soundness of the intersection checker.** -/
+theorem isIntersection_of_interOk (hv : kb.valid = true) {c : Qid} {ps : List Qid}
+    (h : kb.interOk c ps = true) :
+    Ontology.IsIntersection (kb.toOntology hv) c (fun p => p ∈ ps) := by
+  simp only [interOk, Bool.and_eq_true] at h
+  obtain ⟨⟨hne, hsub⟩, hcomp⟩ := h
+  refine ⟨?_, ?_⟩
+  · intro p hp
+    exact (isSubclassOf_iff_subclassOf hv c p).1 (List.all_eq_true.1 hsub p hp)
+  · intro a ha
+    obtain ⟨p, hp⟩ := List.exists_mem_of_ne_nil ps (by
+      simpa [List.isEmpty_iff] using hne)
+    have hamem : a ∈ kb.items := mem_items_of_instanceOf hv (ha p hp)
+    have hall : ps.all (fun q => kb.isInstanceOf a q) = true :=
+      List.all_eq_true.2 fun q hq => (isInstanceOf_iff_instanceOf hv a q).2 (ha q hq)
+    have := List.all_eq_true.1 hcomp a hamem
+    rw [hall] at this
+    simp only [Bool.not_true, Bool.false_or] at this
+    exact (isInstanceOf_iff_instanceOf hv a c).1 this
+
+end KB
+
+/-! ### A worked fragment -/
+
+namespace ClassAlgebraExample
+
+open KB
+
+/-- Abbreviation for a Wikidata item. -/
+def Q (s : String) : Qid := .wd s
+
+/-- English labels for the identifiers used below. -/
+def labels : List (Qid × String) :=
+  [(Q "Q483501", "artist"), (Q "Q1028181", "painter"), (Q "Q1281618", "sculptor"),
+   (Q "Q5592", "Michelangelo"), (Q "Q762", "Leonardo da Vinci"),
+   (Q "Q-painter-sculptor", "painter-sculptor")]
+
+/-- The label of an identifier, or its raw form if none is recorded. -/
+def labelOf (q : Qid) : String := (labels.lookup q).getD (toString (repr q))
+
+/-- `painter` and `sculptor` are subclasses of `artist`; Michelangelo is both, Leonardo
+is (here) only a painter; `painter-sculptor` is the class of those who are both. -/
+def artistKB : KB where
+  name := "wd-class-algebra"
+  items := [Q "Q483501", Q "Q1028181", Q "Q1281618", Q "Q-painter-sculptor",
+            Q "Q5592", Q "Q762"]
+  levels := [(Q "Q483501", 1), (Q "Q1028181", 1), (Q "Q1281618", 1),
+             (Q "Q-painter-sculptor", 1), (Q "Q5592", 0), (Q "Q762", 0)]
+  sub := [(Q "Q1028181", Q "Q483501"), (Q "Q1281618", Q "Q483501"),
+          (Q "Q-painter-sculptor", Q "Q1028181"), (Q "Q-painter-sculptor", Q "Q1281618")]
+  inst := [(Q "Q5592", Q "Q-painter-sculptor"), (Q "Q762", Q "Q1028181")]
+
+set_option maxRecDepth 40000 in
+theorem artistKB_valid : artistKB.valid = true := by decide
+
+set_option maxRecDepth 40000 in
+/-- `artist` is the union (P2737) of `painter` and `sculptor`. -/
+theorem artistKB_unionOk :
+    artistKB.unionOk (Q "Q483501") [Q "Q1028181", Q "Q1281618"] = true := by decide
+
+set_option maxRecDepth 40000 in
+/-- It is *not* a disjoint union: Michelangelo is both a painter and a sculptor. -/
+theorem artistKB_not_dunOk :
+    artistKB.dunOk (Q "Q483501") [Q "Q1028181", Q "Q1281618"] = false := by decide
+
+/-- Hence, abstractly, `artist` is the union of the two classes. -/
+theorem artistKB_isUnion :
+    Ontology.IsUnion (artistKB.toOntology artistKB_valid) (Q "Q483501")
+      (fun p => p ∈ [Q "Q1028181", Q "Q1281618"]) :=
+  KB.isUnion_of_unionOk artistKB_valid artistKB_unionOk
+
+/-- Every artist of the fragment is a painter or a sculptor. -/
+theorem artist_painter_or_sculptor {a : Qid}
+    (ha : (artistKB.toOntology artistKB_valid).InstanceOf a (Q "Q483501")) :
+    (artistKB.toOntology artistKB_valid).InstanceOf a (Q "Q1028181") ∨
+      (artistKB.toOntology artistKB_valid).InstanceOf a (Q "Q1281618") := by
+  obtain ⟨p, hp, hap⟩ := artistKB_isUnion.cover ha
+  rcases List.mem_cons.1 hp with rfl | hp
+  · exact Or.inl hap
+  · have : p = Q "Q1281618" := by simpa using hp
+    exact Or.inr (this ▸ hap)
+
+set_option maxRecDepth 40000 in
+/-- `painter-sculptor` is the intersection of `painter` and `sculptor`. -/
+theorem artistKB_interOk :
+    artistKB.interOk (Q "Q-painter-sculptor") [Q "Q1028181", Q "Q1281618"] = true := by decide
+
+/-- Hence, abstractly, it really is their intersection. -/
+theorem artistKB_isIntersection :
+    Ontology.IsIntersection (artistKB.toOntology artistKB_valid) (Q "Q-painter-sculptor")
+      (fun p => p ∈ [Q "Q1028181", Q "Q1281618"]) :=
+  KB.isIntersection_of_interOk artistKB_valid artistKB_interOk
+
+/-- Michelangelo, being both, is an instance of the intersection. -/
+theorem michelangelo_mem_intersection :
+    (artistKB.toOntology artistKB_valid).InstanceOf (Q "Q5592") (Q "Q-painter-sculptor") :=
+  (KB.isInstanceOf_iff_instanceOf artistKB_valid _ _).1 (by decide)
+
+set_option maxRecDepth 40000 in
+/-- Leonardo is not a sculptor in this fragment, so the intersection check rejects the
+claim that `painter` alone is the intersection of `painter` and `sculptor`. -/
+theorem artistKB_interOk_wrong :
+    artistKB.interOk (Q "Q1028181") [Q "Q1028181", Q "Q1281618"] = false := by decide
+
+end ClassAlgebraExample
+
+end Wikidata

--- a/third_party/jmdupont_wikidata_lean/SOURCE_SNAPSHOT.md
+++ b/third_party/jmdupont_wikidata_lean/SOURCE_SNAPSHOT.md
@@ -1,0 +1,25 @@
+# James Michael DuPont / Aristotle Wikidata Lean source snapshot
+
+Source supplied directly by the user as `ae06ae06-2580-422a-8fc3-92aeaaca8762-aristotle.tar.gz` on 2026-08-16.
+
+Aristotle request: `ae06ae06-2580-422a-8fc3-92aeaaca8762`.
+
+The archive contains a full Lean 4 project under `RequestProject/` (36+ modules in the status report) plus Lake configuration. This directory vendors the theorem surfaces consumed directly by SensibLaw. The first imported source is `RequestProject/ClassAlgebra.lean`.
+
+Exact source SHA-256:
+
+- `RequestProject/ClassAlgebra.lean`: `6ee3b2371498d67c159fe97389c9ca1e06144ad530e17554cb3f87968c9f899a`
+- `RequestProject/Rdf.lean`: `11a4d3fc6b152a022016d7c8639b89805d45352c9e08c16ec2a8172a2610f3cf`
+
+The source project README asks that Aristotle be cited by tagging `@Aristotle-Harmonic` on GitHub PRs/issues or by using:
+
+`Co-authored-by: Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>`
+
+The source archive does not contain a license file. The vendored snapshot is therefore provenance material for this integration, not a claim of relicensing.
+
+The exact checker/theorem pairs used by the current bridge are:
+
+- `Wikidata.KB.unionOk` → `Wikidata.KB.isUnion_of_unionOk`
+- `Wikidata.KB.interOk` → `Wikidata.KB.isIntersection_of_interOk`
+
+The RDF source additionally supplies `Wikidata.Rdf.entails_sound`, `entails_sub_iff`, `entails_inst_iff`, and `entails_iff_isSubclassOf`; its source hash is pinned above even before the complete dependency closure is vendored.


### PR DESCRIPTION
## Purpose

Import and operationalise the James Michael DuPont / Aristotle Wikidata Lean work from the concrete archive supplied for Aristotle request `ae06ae06-2580-422a-8fc3-92aeaaca8762`.

The branch is no longer based only on the earlier status report. The uploaded archive contains the actual `RequestProject/` Lean sources; this PR now pins its exact source identities and theorem/checker names.

## Source import

- Vendors `third_party/jmdupont_wikidata_lean/RequestProject/ClassAlgebra.lean` verbatim from the supplied archive.
- Records SHA-256 provenance in `third_party/jmdupont_wikidata_lean/SOURCE_SNAPSHOT.md`.
- Pins `ClassAlgebra.lean` SHA-256 to `6ee3b2371498d67c159fe97389c9ca1e06144ad530e17554cb3f87968c9f899a`.
- Pins `Rdf.lean` SHA-256 to `11a4d3fc6b152a022016d7c8639b89805d45352c9e08c16ec2a8172a2610f3cf` for the next dependency-complete import.
- Import commits carry the Aristotle co-author attribution requested by the archive README.

The archive contains no license file, so the source snapshot is retained with explicit provenance and no relicensing claim.

## Exact source-backed certificate contract

`src/ontology/lean_wikidata_source_contract.py` records the real theorem/checker pairs from the supplied source:

```text
RequestProject.ClassAlgebra
Wikidata.KB.unionOk
Wikidata.KB.isUnion_of_unionOk

RequestProject.ClassAlgebra
Wikidata.KB.interOk
Wikidata.KB.isIntersection_of_interOk
```

A certificate with `theorem_backed=true` must now match the pinned Aristotle request and an exact source-backed checker/theorem/relation tuple. The earlier placeholder names `unionOk_sound` / `unionOk` are deliberately rejected as forged theorem metadata.

The worked fixture is updated to the actual source identifiers:

```text
artist    Q483501
painter   Q1028181
sculptor  Q1281618
P2737     union of
```

## Open-world / authority boundary

The projection remains fail-closed:

```text
source-backed theorem contract + checker accepted -> supported
failed checker / absent edge / unbacked result     -> unresolved
```

Only explicit opposing external evidence emits `cross_ontology_explicit_relation_conflict`. Missing external relationships never become contradiction.

Every receipt retains `truth_authority=false` and `edit_authority=false`.

## Operational integration

`ontology_issue_detector.py` accepts formal cross-ontology relation comparisons. Replication is retained as evidence; explicit opposition becomes a review issue; unresolved comparisons remain non-negative.

This supplies the operational path for the Ontology Cleaning Task Force proposal to walk mapped ontologies and compare relation preservation.

## Validation boundary

No GitHub Actions/CI or CodeRabbit requested. Focused Python tests were updated to require the exact source theorem/checker pairs, but are not claimed executed in this connector-only pass.